### PR TITLE
Initial approach to withdraw funds

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/account/account_state_assembler.dart';
@@ -152,8 +153,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     await _lightningNode.getNodeAPI().publishTransaction(tx);
   }
 
-  Future<bool> validateAddress(String address) {
-    throw Exception("not implemented");
+  bool validateAddress(String? address) {
+    if (address == null) return false;
+    // TODO real impl. Random next bool is used to simulate valid/invalid flow
+    return Random().nextBool();
   }
 
   // validatePayment is used to validate that outgoing/incoming payments meet the liquidity

--- a/lib/models/bitcoin_address_info.dart
+++ b/lib/models/bitcoin_address_info.dart
@@ -1,0 +1,31 @@
+import 'package:c_breez/models/currency.dart';
+import 'package:fixnum/fixnum.dart';
+
+class BitcoinAddressInfo {
+  final String? address;
+  final Int64? satAmount;
+
+  const BitcoinAddressInfo(
+    this.address,
+    this.satAmount,
+  );
+
+  factory BitcoinAddressInfo.fromScannedString(String? scannedString) {
+    String? address;
+    Int64? satAmount;
+    if (scannedString != null) {
+      final uri = Uri.tryParse(scannedString);
+      if (uri != null) {
+        address = uri.path;
+        final amount = uri.queryParameters["amount"];
+        if (amount != null) {
+          final btcAmount = double.tryParse(amount);
+          if (btcAmount != null) {
+            satAmount = BitcoinCurrency.BTC.toSats(btcAmount);
+          }
+        }
+      }
+    }
+    return BitcoinAddressInfo(address, satAmount);
+  }
+}

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -2,14 +2,13 @@ import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/bloc/lsp/lsp_state.dart';
+import 'package:c_breez/routes/home/widgets/app_bar/select_provider_error_dialog.dart';
+import 'package:c_breez/routes/home/widgets/app_bar/warning_action.dart';
 import 'package:c_breez/routes/lsp/select_lsp_page.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:fixnum/fixnum.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'select_provider_error_dialog.dart';
-import 'warning_action.dart';
 
 class AccountRequiredActionsIndicator extends StatelessWidget {
   const AccountRequiredActionsIndicator({
@@ -45,7 +44,9 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
 
     if (walletBalance > 0) {
       warnings.add(
-        WarningAction(() => navigatorState.pushNamed("/send_coins")),
+        WarningAction(
+          () => navigatorState.pushNamed("/withdraw_funds_address"),
+        ),
       );
     }
 

--- a/lib/routes/home/widgets/bubble_painter.dart
+++ b/lib/routes/home/widgets/bubble_painter.dart
@@ -20,22 +20,22 @@ class BubblePainter extends CustomPainter {
   void paint(Canvas canvas, Size size) {
     double height = (size.height - kToolbarHeight);
     canvas.drawCircle(
-      Offset(size.width / 2, height * 0.36),
+      Offset(size.width / 2, height * 0.4),
       _kBubbleRadius,
       bubblePaint,
     );
     canvas.drawCircle(
-      Offset(size.width * 0.39, height * 0.59),
+      Offset(size.width * 0.39, height * 0.6),
       _kBubbleRadius * 1.5,
       bubblePaint,
     );
     canvas.drawCircle(
-      Offset(size.width * 0.65, height * 0.71),
+      Offset(size.width * 0.65, height * 0.7),
       _kBubbleRadius * 1.25,
       bubblePaint,
     );
     canvas.drawCircle(
-      Offset(size.width / 2, height * 0.80),
+      Offset(size.width / 2, height * 0.8),
       _kBubbleRadius * 0.75,
       bubblePaint,
     );

--- a/lib/routes/withdraw_funds/bitcoin_address_text_form_field.dart
+++ b/lib/routes/withdraw_funds/bitcoin_address_text_form_field.dart
@@ -1,0 +1,52 @@
+import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/l10n/build_context_localizations.dart';
+import 'package:c_breez/models/bitcoin_address_info.dart';
+import 'package:c_breez/theme/theme_provider.dart' as theme;
+import 'package:c_breez/widgets/flushbar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class BitcoinAddressTextFormField extends TextFormField {
+  BitcoinAddressTextFormField({
+    Key? key,
+    required BuildContext context,
+    required TextEditingController controller,
+  }) : super(
+          key: key,
+          controller: controller,
+          decoration: InputDecoration(
+            labelText: context.texts().withdraw_funds_btc_address,
+            suffixIcon: IconButton(
+              alignment: Alignment.bottomRight,
+              icon: Image(
+                image: const AssetImage("src/icon/qr_scan.png"),
+                color: theme.BreezColors.white[500],
+                fit: BoxFit.contain,
+                width: 24.0,
+                height: 24.0,
+              ),
+              tooltip: context.texts().withdraw_funds_scan_barcode,
+              onPressed: () async {
+                final address = BitcoinAddressInfo.fromScannedString(
+                  await Navigator.pushNamed<String>(context, "/qr_scan"),
+                ).address;
+                if (address != null) {
+                  controller.text = address;
+                } else {
+                  // ignore: use_build_context_synchronously
+                  showFlushbar(context, message: context.texts().withdraw_funds_error_qr_code_not_detected);
+                }
+              },
+            ),
+          ),
+          style: theme.FieldTextStyle.textStyle,
+          validator: (address) {
+            final valid = context.read<AccountBloc>().validateAddress(address);
+            if (valid) {
+              return null;
+            } else {
+              return context.texts().withdraw_funds_error_invalid_address;
+            }
+          },
+        );
+}

--- a/lib/routes/withdraw_funds/withdraw_funds_address_next_button.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_address_next_button.dart
@@ -1,0 +1,34 @@
+import 'package:c_breez/l10n/build_context_localizations.dart';
+import 'package:c_breez/widgets/single_button_bottom_bar.dart';
+import 'package:flutter/material.dart';
+
+class WithdrawFundsAddressNextButton extends StatelessWidget {
+  final TextEditingController addressController;
+  final bool Function() validator;
+
+  const WithdrawFundsAddressNextButton({
+    Key? key,
+    required this.addressController,
+    required this.validator,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
+      child: SubmitButton(
+        texts.withdraw_funds_action_next,
+        () {
+          if (validator()) {
+            Navigator.of(context).pushNamed(
+              "/withdraw_funds_amount",
+              arguments: addressController.text,
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
@@ -1,0 +1,65 @@
+import 'package:c_breez/l10n/build_context_localizations.dart';
+import 'package:c_breez/routes/withdraw_funds/bitcoin_address_text_form_field.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_next_button.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_available_btc.dart';
+import 'package:c_breez/widgets/back_button.dart' as back_button;
+import 'package:c_breez/widgets/warning_box.dart';
+import 'package:flutter/material.dart';
+
+class WithdrawFundsAddressPage extends StatefulWidget {
+  const WithdrawFundsAddressPage();
+
+  @override
+  State<WithdrawFundsAddressPage> createState() =>
+      _WithdrawFundsAddressPageState();
+}
+
+class _WithdrawFundsAddressPageState extends State<WithdrawFundsAddressPage> {
+  final _addressController = TextEditingController();
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: const back_button.BackButton(),
+        actions: const [],
+        title: Text(texts.unexpected_funds_title),
+      ),
+      body: Column(
+        children: [
+          WarningBox(
+            boxPadding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
+            contentPadding: const EdgeInsets.fromLTRB(8, 12, 8, 12),
+            child: Text(
+              texts.unexpected_funds_message,
+              style: themeData.textTheme.headline6,
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: Form(
+              key: _formKey,
+              child: BitcoinAddressTextFormField(
+                context: context,
+                controller: _addressController,
+              ),
+            ),
+          ),
+          const Padding(
+            padding: EdgeInsets.fromLTRB(16, 8, 16, 8),
+            child: WithdrawFundsAvailableBtc(),
+          ),
+          Expanded(child: Container()),
+          WithdrawFundsAddressNextButton(
+            addressController: _addressController,
+            validator: () => _formKey.currentState?.validate() ?? false,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/withdraw_funds/withdraw_funds_amount_page.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_amount_page.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+
+class WithdrawFundsAmountPage extends StatelessWidget {
+  final String address;
+
+  const WithdrawFundsAmountPage(
+    this.address, {
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text("TODO implements amount page"),
+      ),
+      body: Center(
+        child: Text(
+          "TODO implements amount page, received address: $address",
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/withdraw_funds/withdraw_funds_available_btc.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_available_btc.dart
@@ -1,0 +1,45 @@
+import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/bloc/account/account_state.dart';
+import 'package:c_breez/bloc/currency/currency_bloc.dart';
+import 'package:c_breez/bloc/currency/currency_state.dart';
+import 'package:c_breez/l10n/build_context_localizations.dart';
+import 'package:c_breez/theme/theme_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class WithdrawFundsAvailableBtc extends StatelessWidget {
+  const WithdrawFundsAvailableBtc();
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+    final textStyle = themeData.primaryTextTheme.headline3!.copyWith(
+      color: BreezColors.white[500],
+    );
+
+    return Row(
+      children: [
+        Text(
+          texts.withdraw_funds_balance,
+          style: textStyle,
+        ),
+        Padding(
+          padding: const EdgeInsets.only(left: 3.0),
+          child: BlocBuilder<AccountBloc, AccountState>(
+            builder: (context, account) {
+              return BlocBuilder<CurrencyBloc, CurrencyState>(
+                builder: (context, currencyState) {
+                  return Text(
+                    currencyState.bitcoinCurrency.format(account.balance),
+                    style: textStyle,
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -2,28 +2,29 @@ import 'dart:typed_data';
 
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
+import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:c_breez/l10n/locales.dart';
 import 'package:c_breez/models/user_profile.dart';
+import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:c_breez/routes/dev/commands.dart';
 import 'package:c_breez/routes/fiat_currencies/fiat_currency_settings.dart';
 import 'package:c_breez/routes/home/home_page.dart';
+import 'package:c_breez/routes/initial_walkthrough/initial_walkthrough.dart';
 import 'package:c_breez/routes/initial_walkthrough/mnemonics/enter_mnemonic_seed_page.dart';
 import 'package:c_breez/routes/initial_walkthrough/mnemonics/generate_mnemonic_seed_confirmation_page.dart';
+import 'package:c_breez/routes/lsp/select_lsp_page.dart';
 import 'package:c_breez/routes/qr_scan/widgets/qr_scan.dart';
+import 'package:c_breez/routes/splash/splash_page.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_page.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_amount_page.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/locale.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'bloc/lsp/lsp_bloc.dart';
-import 'routes/create_invoice/create_invoice_page.dart';
-import 'routes/initial_walkthrough/initial_walkthrough.dart';
-import 'routes/lsp/select_lsp_page.dart';
-import 'routes/splash/splash_page.dart';
 
 class UserApp extends StatelessWidget {
   final GlobalKey _appKey = GlobalKey();
@@ -126,6 +127,19 @@ class UserApp extends StatelessWidget {
                               return MaterialPageRoute<String>(
                                 fullscreenDialog: true,
                                 builder: (_) => QRScan(),
+                                settings: settings,
+                              );
+                            case '/withdraw_funds_address':
+                              return FadeInRoute(
+                                builder: (_) =>
+                                    const WithdrawFundsAddressPage(),
+                                settings: settings,
+                              );
+                            case '/withdraw_funds_amount':
+                              return FadeInRoute(
+                                builder: (_) => WithdrawFundsAmountPage(
+                                  settings.arguments as String,
+                                ),
                                 settings: settings,
                               );
                           }


### PR DESCRIPTION
I'm changing a little bit the approach to what we have on breezmobile, the main difference are:

- An address widget that checks by itself the validity of the bitcoin address (it is using mock data right now)
- Using the standard navigation instead of a pager (not sure if it is better but looks better for me)
- Not checking the address at the time user clicks the button, instead of that I'm checking automatically and enabling/disabling the button

You can see what it looks like:

https://user-images.githubusercontent.com/1225438/172912962-fe804548-8b8f-4ef7-a937-61b1b01ee1e9.mp4


