### PR TITLE
Add digit masked widget plus a preview structure

### DIFF
--- a/lib/routes/lock_screen/widget/digit_masked_widget.dart
+++ b/lib/routes/lock_screen/widget/digit_masked_widget.dart
@@ -1,0 +1,134 @@
+import 'dart:math';
+
+import 'package:c_breez/widgets/preview/preview.dart';
+import 'package:flutter/material.dart';
+
+class DigitMaskedWidget extends StatelessWidget {
+  final double size;
+  final bool filled;
+  final Color filledColor;
+  final Color unfilledColor;
+
+  const DigitMaskedWidget({
+    Key? key,
+    this.size = 32,
+    this.filled = false,
+    this.filledColor = Colors.white,
+    this.unfilledColor = Colors.transparent,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.only(top: 24.0),
+          margin: const EdgeInsets.only(bottom: 0),
+          curve: filled ? Curves.decelerate : Curves.easeIn,
+          width: size,
+          height: size,
+          decoration: BoxDecoration(
+            color: unfilledColor,
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: filledColor,
+              width: 2.0,
+            ),
+          ),
+        ),
+        AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          padding: const EdgeInsets.only(top: 24.0),
+          margin: const EdgeInsets.only(bottom: 0),
+          curve: filled ? Curves.decelerate : Curves.easeIn,
+          alignment: Alignment.center,
+          width: filled ? size : 0,
+          height: filled ? size : 0,
+          decoration: BoxDecoration(
+            color: filledColor,
+            shape: BoxShape.circle,
+            border: Border.all(
+              color: filled ? filledColor : unfilledColor,
+              width: 2.0,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// Preview
+
+class DigitMaskedWidgetPreview extends StatefulWidget {
+  const DigitMaskedWidgetPreview({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  State<DigitMaskedWidgetPreview> createState() => _DigitMaskedWidgetPreviewState();
+}
+
+class _DigitMaskedWidgetPreviewState extends State<DigitMaskedWidgetPreview> {
+  int count = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return Preview([
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(
+          6,
+          (index) => Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: DigitMaskedWidget(
+              filled: count > index,
+            ),
+          ),
+        ),
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: List.generate(
+          6,
+          (index) => Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: DigitMaskedWidget(
+              filled: count > index,
+              filledColor: Colors.red,
+              unfilledColor: Colors.blue,
+            ),
+          ),
+        ),
+      ),
+      Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                count = min(count + 1, 6);
+              });
+            },
+            child: const Text("Fill"),
+          ),
+          const SizedBox(width: 8),
+          ElevatedButton(
+            onPressed: () {
+              setState(() {
+                count = max(0, count - 1);
+              });
+            },
+            child: const Text("Clear"),
+          ),
+        ],
+      ),
+    ]);
+  }
+}
+
+void main() {
+  runApp(const DigitMaskedWidgetPreview());
+}

--- a/lib/widgets/preview/fill_view_port_column_scroll_view.dart
+++ b/lib/widgets/preview/fill_view_port_column_scroll_view.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+
+class FillViewPortColumnScrollView extends StatelessWidget {
+  final List<Widget> children;
+
+  const FillViewPortColumnScrollView({
+    Key? key,
+    required this.children,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return SingleChildScrollView(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(
+              minHeight: constraints.maxHeight,
+            ),
+            child: IntrinsicHeight(
+              child: Column(
+                mainAxisSize: MainAxisSize.max,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: children,
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/preview/preview.dart
+++ b/lib/widgets/preview/preview.dart
@@ -1,0 +1,50 @@
+import 'package:c_breez/widgets/preview/fill_view_port_column_scroll_view.dart';
+import 'package:flutter/material.dart';
+
+class Preview extends StatelessWidget {
+  final List<Widget> children;
+
+  const Preview(
+    this.children, {
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: Scaffold(
+        body: SafeArea(
+          child: Stack(
+            children: [
+              LayoutBuilder(
+                builder: (context, constraints) {
+                  final cols = constraints.maxWidth ~/ 8;
+                  final rows = constraints.maxHeight ~/ 8;
+                  return GridView.builder(
+                    itemCount: cols * rows + cols,
+                    gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: cols,
+                      childAspectRatio: 1.0,
+                      crossAxisSpacing: 0.0,
+                      mainAxisSpacing: 0.0,
+                    ),
+                    itemBuilder: (context, index) {
+                      final oddRow = (index ~/ cols).isOdd;
+                      final oddCol = (index % cols).isOdd;
+                      return Container(
+                        color: oddRow == oddCol ? Colors.grey.withAlpha(128) : Colors.blueGrey.withAlpha(128),
+                      );
+                    },
+                  );
+                },
+              ),
+              FillViewPortColumnScrollView(
+                children: children,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Add the digit masked widget to be used here https://github.com/breez/c-breez/issues/81 plus a proposal of preview, let me explain what this proposal is.

I'm adding a `Preview` widget that allows us to experiment with our widgets directly, which makes it much easier to create and maintain such widgets.

to use the preview you need to add the following code at the end of the widget file and run it, that is all, take a look at the screenshot of what it looks like and the `DigitMaskedWidget` code for a real code example.

```
void main() {
  runApp(const Preview([
   …
   the widget variations you want to experiment
   …
  ]));
}
```

How does it look like

![Screenshot_20220801_120019](https://user-images.githubusercontent.com/1225438/182181012-6434d025-4514-46eb-a8df-40ae43ab67ed.png)

Let me know if you see value in this preview, I'll be using it as it makes it much faster for me, but I can keep that thing locally on my machine, in that case, tell me that I remove it from this PR.