### PR TITLE
Handle unrecognized clipboard data

### DIFF
--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -90,26 +90,33 @@ class SendOptionsBottomSheet extends StatelessWidget {
     GlobalKey firstPaymentItemKey,
   ) async {
     Navigator.of(context).pop();
-    if (clipboardData != null) {
-      final data = clipboardData.data;
-      if (clipboardData.type == ClipboardDataType.paymentRequest) {
-        inputBloc.addIncomingInput(data ?? "");
-      } else if (clipboardData.type == ClipboardDataType.nodeID) {
-        Navigator.of(context).push(FadeInRoute(
-          builder: (_) => SpontaneousPaymentPage(data, firstPaymentItemKey),
-        ));
-      }
-    } else {
-      await showDialog(
-        useRootNavigator: false,
-        context: context,
-        barrierDismissible: false,
-        builder: (_) => EnterPaymentInfoDialog(
-          context,
-          inputBloc,
-          firstPaymentItemKey,
-        ),
-      );
+    switch (clipboardData?.type) {
+      case ClipboardDataType.lnurl:
+      case ClipboardDataType.lightningAddress:
+      case ClipboardDataType.paymentRequest:
+        inputBloc.addIncomingInput(clipboardData!.data ?? "");
+        return;
+      case ClipboardDataType.nodeID:
+        Navigator.of(context).push(
+          FadeInRoute(
+            builder: (_) => SpontaneousPaymentPage(
+                clipboardData!.data, firstPaymentItemKey),
+          ),
+        );
+        return;
+      case ClipboardDataType.unrecognized:
+      default:
+        await showDialog(
+          useRootNavigator: false,
+          context: context,
+          barrierDismissible: false,
+          builder: (_) => EnterPaymentInfoDialog(
+            context,
+            inputBloc,
+            firstPaymentItemKey,
+          ),
+        );
+        return;
     }
   }
 


### PR DESCRIPTION
This PR addresses #96

- Unrecognized and empty clipboard data is now being handled by opening EnterPaymentInfoDialog.
  - The logic is refactored to use a switch statement.  _`default:` handles null case._
- Clipboard data of type lnurl and lightningAddress are now being handled by "Paste Invoice or ID" button