### PR TITLE
cleanup, renaming & use persistency for node state and lsp

### DIFF
--- a/packages/breez_sdk/rust/Cargo.lock
+++ b/packages/breez_sdk/rust/Cargo.lock
@@ -2207,6 +2207,7 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
+ "serde_json",
  "smallvec",
 ]
 

--- a/packages/breez_sdk/rust/Cargo.toml
+++ b/packages/breez_sdk/rust/Cargo.toml
@@ -29,7 +29,7 @@ ripemd = "*"
 rand = "*"
 tiny-bip39 = "*"
 tokio = "*"
-rusqlite = { version = "0.28.0", features = ["bundled"] }
+rusqlite = { version = "0.28.0", features = ["serde_json", "bundled"] }
 rusqlite_migration = "*"
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/breez_sdk/rust/src/lib.rs
+++ b/packages/breez_sdk/rust/src/lib.rs
@@ -1,6 +1,6 @@
 mod chain;
 mod crypto;
 mod invoice;
-mod node;
+mod node_service;
 mod persist;
 mod swap;

--- a/packages/breez_sdk/rust/src/persist/cache.rs
+++ b/packages/breez_sdk/rust/src/persist/cache.rs
@@ -2,7 +2,7 @@ use super::db::SqliteStorage;
 use rusqlite::Result;
 
 impl SqliteStorage {
-    pub fn get_cached_item(&mut self, key: String) -> Result<Option<String>> {
+    pub fn get_cached_item(&self, key: String) -> Result<Option<String>> {
         let res = self.conn.query_row(
             "SELECT value FROM cached_items WHERE key = ?1",
             [key],
@@ -11,7 +11,7 @@ impl SqliteStorage {
         Ok(res.ok())
     }
 
-    pub fn update_cached_item(&mut self, key: String, value: String) -> Result<()> {
+    pub fn update_cached_item(&self, key: String, value: String) -> Result<()> {
         self.conn.execute(
             "INSERT OR REPLACE INTO cached_items (key, value) VALUES (?1,?2)",
             (key, value),
@@ -19,7 +19,7 @@ impl SqliteStorage {
         Ok(())
     }
 
-    pub fn delete_cached_item(&mut self, key: String) -> Result<()> {
+    pub fn delete_cached_item(&self, key: String) -> Result<()> {
         self.conn
             .execute("DELETE FROM cached_items WHERE key = ?1", [key])?;
         Ok(())

--- a/packages/breez_sdk/rust/src/persist/transactions.rs
+++ b/packages/breez_sdk/rust/src/persist/transactions.rs
@@ -24,7 +24,7 @@ pub struct LightningTransaction {
 }
 
 impl SqliteStorage {
-    pub fn insert_ln_transactions(&mut self, transactions: &[LightningTransaction]) -> Result<()> {
+    pub fn insert_ln_transactions(&self, transactions: &[LightningTransaction]) -> Result<()> {
         let mut prep_statment = self.conn.prepare(
             "
                INSERT INTO ln_transactions (
@@ -65,7 +65,7 @@ impl SqliteStorage {
     }
 
     pub fn list_ln_transactions(
-        &mut self,
+        &self,
         type_filter: PaymentTypeFilter,
         from_timestamp: Option<i64>,
         to_timestamp: Option<i64>,


### PR DESCRIPTION
First some cleanup and remove non necessary mutable references from persistency.
Then introducing NodeStat, some getter/setters from the persistency layer (lsp, node state) and renaming the current NodeState to NodeService.
Last I removed currently the static usage of NodeService because this solution actually belongs to the binding layer and a user in rust would rather create a NodeService by invoking `start_node` and so I think it is better to get back to it when we implement the binding functions.