### PR TITLE
Simplify defaults mgmt for Config

### DIFF
--- a/packages/breez_sdk/rust/src/node_service.rs
+++ b/packages/breez_sdk/rust/src/node_service.rs
@@ -96,11 +96,21 @@ impl NodeService {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct Config {
     pub breezserver: String,
     pub mempoolspace_url: String,
     pub working_dir: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            breezserver: "https://bs1-st.breez.technology:443".to_string(),
+            mempoolspace_url: "https://mempool.space".to_string(),
+            working_dir: ".".to_string(),
+        }
+    }
 }
 
 pub struct GreenlightCredentials {
@@ -161,7 +171,7 @@ pub async fn start_node(
     signer.run_forever(recv).await?;
 
     Ok(NodeService::new(
-        create_default_config(),
+        Config::default(),
         Box::new(greenlight::Greenlight::from_client(client)),
     ))
 }
@@ -184,23 +194,15 @@ fn parse_network(gn: &Network) -> lightning_signer::bitcoin::Network {
     }
 }
 
-fn create_default_config() -> Config {
-    Config {
-        breezserver: "https://bs1-st.breez.technology:443".to_string(),
-        mempoolspace_url: "https://mempool.space".to_string(),
-        working_dir: ".".to_string(),
-    }
-}
-
 mod test {
     use crate::models::{LightningTransaction, NodeAPI, NodeState, PaymentTypeFilter};
-    use crate::node_service::{create_default_config, NodeService};
+    use crate::node_service::{Config, NodeService};
     use crate::test_utils::MockNodeAPI;
 
     #[test]
     fn test_config() {
         // Before the state is initialized, the config defaults to using ::default() for its values
-        let config = create_default_config();
+        let config = Config::default();
         assert_eq!(config.breezserver, "https://bs1-st.breez.technology:443");
         assert_eq!(config.mempoolspace_url, "https://mempool.space");
     }
@@ -253,7 +255,7 @@ mod test {
         ];
 
         let node_service = NodeService::new(
-            create_default_config(),
+            Config::default(),
             Box::new(MockNodeAPI {
                 node_state: dummy_node_state.clone(),
                 transactions: dummy_transactions.clone(),


### PR DESCRIPTION
Implement the `Default` trait, which is a more standardized way of handling default values