### PR TITLE
block on all binding functions

### DIFF
--- a/packages/breez_sdk/rust/src/binding.rs
+++ b/packages/breez_sdk/rust/src/binding.rs
@@ -1,43 +1,45 @@
+use std::future::Future;
 use std::sync::Mutex;
 
 use anyhow::{anyhow, Result};
 use once_cell::sync::Lazy;
 
+use crate::models::{
+    Config, GreenlightCredentials, LightningTransaction, Network, PaymentTypeFilter,
+};
+use crate::node_service::NodeServiceBuilder;
 use crate::{greenlight::Greenlight, node_service::NodeService};
-use crate::models::{Config, GreenlightCredentials, LightningTransaction, Network, NodeAPI, PaymentTypeFilter};
-use crate::node_service::{BreezLSP, NodeServiceBuilder};
-use crate::test_utils::MockNodeAPI;
 
 static STATE: Lazy<Mutex<Option<Greenlight>>> = Lazy::new(|| Mutex::new(None));
 
-pub async fn register_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredentials> {
-    Greenlight::register(network, seed).await
+pub fn register_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredentials> {
+    block_on(Greenlight::register(network, seed))
 }
 
 pub async fn recover_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredentials> {
-    Greenlight::recover(network, seed).await
+    block_on(Greenlight::recover(network, seed))
 }
 
-pub async fn create_node_services(
+pub fn create_node_services(
     network: Network,
     seed: Vec<u8>,
     creds: GreenlightCredentials,
 ) -> Result<NodeService> {
-    let greenlight = Greenlight::new(network, seed, creds).await?;
+    let greenlight = block_on(Greenlight::new(network, seed, creds))?;
     *STATE.lock().unwrap() = Some(greenlight);
-    build_services().await
+    block_on(build_services())
 }
 
 pub async fn start_node() -> Result<()> {
-    build_services().await?.start_node().await
+    block_on(build_services().await?.start_node())
 }
 
 pub async fn run_signer() -> Result<()> {
-    build_services().await?.run_signer().await
+    block_on(build_services().await?.run_signer())
 }
 
 pub async fn sync() -> Result<()> {
-    build_services().await?.sync().await
+    block_on(build_services().await?.sync())
 }
 
 pub async fn list_transactions(
@@ -45,10 +47,11 @@ pub async fn list_transactions(
     from_timestamp: Option<i64>,
     to_timestamp: Option<i64>,
 ) -> Result<Vec<LightningTransaction>> {
-    build_services()
-        .await?
-        .list_transactions(filter, from_timestamp, to_timestamp)
-        .await
+    block_on(
+        build_services()
+            .await?
+            .list_transactions(filter, from_timestamp, to_timestamp),
+    )
 }
 
 async fn build_services() -> Result<NodeService> {
@@ -60,7 +63,16 @@ async fn build_services() -> Result<NodeService> {
     Ok(NodeServiceBuilder::default()
         .config(Config::default())
         .client(Box::new(greenlight))
-        .client_grpc_init_from_config().await
-        .build().await
-    )
+        .client_grpc_init_from_config()
+        .await
+        .build()
+        .await)
+}
+
+fn block_on<F: Future>(future: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(future)
 }


### PR DESCRIPTION
Better to use sync functions in the binding layer, leaving the choice to the user whether to call it in a separate thread and simplify bridging generation.