### PR TITLE
fetch_rates now returns a vector of structs

### DIFF
--- a/packages/breez_sdk/rust/src/binding.rs
+++ b/packages/breez_sdk/rust/src/binding.rs
@@ -1,4 +1,4 @@
-use crate::fiat::FiatCurrency;
+use crate::fiat::{FiatCurrency, Rate};
 use crate::lsp::LspInformation;
 use lazy_static::lazy_static;
 use std::future::Future;
@@ -82,7 +82,7 @@ pub fn get_node_state() -> Result<Option<NodeState>> {
     block_on(async { build_services().await?.get_node_state() })
 }
 
-pub fn fetch_rates() -> Result<Vec<(String, f64)>> {
+pub fn fetch_rates() -> Result<Vec<Rate>> {
     block_on(async { build_services().await?.fetch_rates().await })
 }
 

--- a/packages/breez_sdk/rust/src/fiat.rs
+++ b/packages/breez_sdk/rust/src/fiat.rs
@@ -40,6 +40,12 @@ pub struct FiatCurrency {
     pub info: CurrencyInfo,
 }
 
+#[derive(Debug, PartialEq)]
+pub struct Rate {
+    pub coin: String,
+    pub value: f64,
+}
+
 fn convert_to_fiat_currency_with_id(id: String, info: CurrencyInfo) -> FiatCurrency {
     FiatCurrency { id, info }
 }
@@ -58,7 +64,7 @@ impl FiatAPI for BreezServer {
     }
 
     // get the live rates from the server
-    async fn fetch_rates(&self) -> Result<Vec<(String, f64)>> {
+    async fn fetch_rates(&self) -> Result<Vec<Rate>> {
         let mut client = self.get_information_client().await?;
 
         let request = Request::new(RatesRequest {});
@@ -67,7 +73,10 @@ impl FiatAPI for BreezServer {
             .into_inner()
             .rates
             .into_iter()
-            .map(|r| (r.coin, r.value))
+            .map(|r| Rate {
+                coin: r.coin,
+                value: r.value,
+            })
             .collect())
     }
 }

--- a/packages/breez_sdk/rust/src/models.rs
+++ b/packages/breez_sdk/rust/src/models.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 use gl_client::pb::Invoice;
 use serde::{Deserialize, Serialize};
 
-use crate::fiat::FiatCurrency;
+use crate::fiat::{FiatCurrency, Rate};
 use crate::grpc::{self, PaymentInformation, RegisterPaymentReply};
 use crate::lsp::LspInformation;
 use crate::models::Network::Bitcoin;
@@ -34,7 +34,7 @@ pub trait LspAPI {
 #[tonic::async_trait]
 pub trait FiatAPI {
     fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>>;
-    async fn fetch_rates(&self) -> Result<Vec<(String, f64)>>;
+    async fn fetch_rates(&self) -> Result<Vec<Rate>>;
 }
 
 #[derive(Clone)]

--- a/packages/breez_sdk/rust/src/test_utils.rs
+++ b/packages/breez_sdk/rust/src/test_utils.rs
@@ -4,7 +4,7 @@ use gl_client::pb::{Amount, Invoice};
 use rand::distributions::{Alphanumeric, DistString, Standard};
 use rand::Rng;
 
-use crate::fiat::FiatCurrency;
+use crate::fiat::{FiatCurrency, Rate};
 
 use crate::grpc::{self, PaymentInformation, RegisterPaymentReply};
 use crate::lsp::LspInformation;
@@ -74,8 +74,11 @@ impl FiatAPI for MockBreezServer {
         Ok(vec![])
     }
 
-    async fn fetch_rates(&self) -> Result<Vec<(String, f64)>> {
-        Ok(vec![("USD".to_string(), 20_000.00)])
+    async fn fetch_rates(&self) -> Result<Vec<Rate>> {
+        Ok(vec![Rate {
+            coin: "USD".to_string(),
+            value: 20_000.00,
+        }])
     }
 }
 


### PR DESCRIPTION
We have to change the rate result to struct instead of tuple as the dart generation tool doesn't support tuples.