### PR TITLE
Use one globally NodeServices wrapped in Arc

### DIFF
--- a/packages/breez_sdk/cli/src/main.rs
+++ b/packages/breez_sdk/cli/src/main.rs
@@ -36,7 +36,6 @@ fn get_seed() -> Vec<u8> {
 fn main() -> Result<()> {
     env_logger::Builder::from_env(Env::default().default_filter_or("debug,rustyline=warn")).init();
     let seed = get_seed();
-    let mut greenlight_credentials: Option<GreenlightCredentials> = None;
 
     let mut rl = Editor::<()>::new()?;
     if rl.load_history("history.txt").is_err() {
@@ -52,7 +51,7 @@ fn main() -> Result<()> {
                 match command.next() {
                     Some("register_node") => {
                         let r = binding::register_node(models::Network::Bitcoin, seed.to_vec());
-                        greenlight_credentials = Some(r.unwrap());
+                        let greenlight_credentials = Some(r.unwrap());
                         info!(
                             "device_cert: {}; device_key: {}",
                             hex::encode(greenlight_credentials.clone().unwrap().device_cert),
@@ -106,26 +105,12 @@ fn main() -> Result<()> {
                     }
                     Some("recover_node") => {
                         let r = binding::recover_node(models::Network::Bitcoin, seed.to_vec());
-                        greenlight_credentials = Some(r.unwrap());
+                        let greenlight_credentials = Some(r.unwrap());
                         info!(
                             "device_cert: {}; device_key: {}",
                             hex::encode(greenlight_credentials.clone().unwrap().device_cert),
                             hex::encode_upper(greenlight_credentials.clone().unwrap().device_key)
                         );
-                    }
-                    Some("create_node_services") => {
-                        if greenlight_credentials.clone().is_none() {
-                            print!("Credentials are not set. Are you missing a call to recover_node or register_node?");
-                            continue;
-                        }
-                        match binding::create_node_services(
-                            crate::models::Config::default(),
-                            seed.to_vec(),
-                            greenlight_credentials.clone().unwrap(),
-                        ) {
-                            Ok(_) => info!("Node services has been created!"),
-                            Err(err) => info!("Error creating node services {}", err),
-                        }
                     }
                     Some("start_node") => show_results(binding::start_node()),
                     Some("sync") => show_results(binding::sync()),

--- a/packages/breez_sdk/ios/Classes/bridge_generated.h
+++ b/packages/breez_sdk/ios/Classes/bridge_generated.h
@@ -11,19 +11,6 @@ typedef struct wire_uint_8_list {
   int32_t len;
 } wire_uint_8_list;
 
-typedef struct wire_Config {
-  struct wire_uint_8_list *breezserver;
-  struct wire_uint_8_list *mempoolspace_url;
-  struct wire_uint_8_list *working_dir;
-  int32_t network;
-  uint32_t payment_timeout_sec;
-} wire_Config;
-
-typedef struct wire_GreenlightCredentials {
-  struct wire_uint_8_list *device_key;
-  struct wire_uint_8_list *device_cert;
-} wire_GreenlightCredentials;
-
 typedef struct WireSyncReturnStruct {
   uint8_t *ptr;
   int32_t len;
@@ -35,11 +22,6 @@ void store_dart_post_cobject(DartPostCObjectFnType ptr);
 void wire_register_node(int64_t port_, int32_t network, struct wire_uint_8_list *seed);
 
 void wire_recover_node(int64_t port_, int32_t network, struct wire_uint_8_list *seed);
-
-void wire_create_node_services(int64_t port_,
-                               struct wire_Config *breez_config,
-                               struct wire_uint_8_list *seed,
-                               struct wire_GreenlightCredentials *creds);
 
 void wire_start_node(int64_t port_);
 
@@ -80,10 +62,6 @@ void wire_parse_invoice(int64_t port_, struct wire_uint_8_list *invoice);
 
 void wire_mnemonic_to_seed(int64_t port_, struct wire_uint_8_list *phrase);
 
-struct wire_Config *new_box_autoadd_config_0(void);
-
-struct wire_GreenlightCredentials *new_box_autoadd_greenlight_credentials_0(void);
-
 int64_t *new_box_autoadd_i64_0(int64_t value);
 
 struct wire_uint_8_list *new_uint_8_list_0(int32_t len);
@@ -94,7 +72,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     int64_t dummy_var = 0;
     dummy_var ^= ((int64_t) (void*) wire_register_node);
     dummy_var ^= ((int64_t) (void*) wire_recover_node);
-    dummy_var ^= ((int64_t) (void*) wire_create_node_services);
     dummy_var ^= ((int64_t) (void*) wire_start_node);
     dummy_var ^= ((int64_t) (void*) wire_run_signer);
     dummy_var ^= ((int64_t) (void*) wire_stop_signer);
@@ -112,8 +89,6 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_withdraw);
     dummy_var ^= ((int64_t) (void*) wire_parse_invoice);
     dummy_var ^= ((int64_t) (void*) wire_mnemonic_to_seed);
-    dummy_var ^= ((int64_t) (void*) new_box_autoadd_config_0);
-    dummy_var ^= ((int64_t) (void*) new_box_autoadd_greenlight_credentials_0);
     dummy_var ^= ((int64_t) (void*) new_box_autoadd_i64_0);
     dummy_var ^= ((int64_t) (void*) new_uint_8_list_0);
     dummy_var ^= ((int64_t) (void*) free_WireSyncReturnStruct);

--- a/packages/breez_sdk/lib/bridge_generated.dart
+++ b/packages/breez_sdk/lib/bridge_generated.dart
@@ -11,60 +11,78 @@ import 'package:meta/meta.dart';
 import 'dart:ffi' as ffi;
 
 abstract class LightningToolkit {
+  /// Register a new node in the cloud and return credentials to interact with it
+  ///
+  /// # Arguments
+  ///
+  /// * `network` - The network type which is one of (Bitcoin, Testnet, Signet, Regtest)
   Future<GreenlightCredentials> registerNode(
       {required Network network, required Uint8List seed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRegisterNodeConstMeta;
 
+  /// Recover an existing node from the cloud and return credentials to interact with it
+  ///
+  /// # Arguments
+  ///
+  /// * `network` - The network type which is one of (Bitcoin, Testnet, Signet, Regtest)
   Future<GreenlightCredentials> recoverNode(
       {required Network network, required Uint8List seed, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRecoverNodeConstMeta;
 
-  Future<void> createNodeServices(
-      {required Config breezConfig,
-      required Uint8List seed,
-      required GreenlightCredentials creds,
-      dynamic hint});
-
-  FlutterRustBridgeTaskConstMeta get kCreateNodeServicesConstMeta;
-
+  /// "Wake up" a node and schedule it to run immediately in the cloud
   Future<void> startNode({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kStartNodeConstMeta;
 
+  /// Run the signer in a separate thread.
+  /// This intended for internal use of the SDK and not recommended to use unless
+  /// you know what you are doing.
   Future<void> runSigner({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRunSignerConstMeta;
 
+  /// Stop the signer thread.
+  /// This intended for internal use of the SDK and not recommended to use unless
+  /// you know what you are doing.
   Future<void> stopSigner({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kStopSignerConstMeta;
 
+  /// Synchronize changes from the cloud to the persistent storage.
+  /// Changes includes the node state (inbound liquidity, max payable, max receivable, etc...)
+  /// and new transactions.
   Future<void> sync({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSyncConstMeta;
 
+  /// List available lsps that can be selected by the user
   Future<List<LspInformation>> listLsps({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kListLspsConstMeta;
 
+  /// Select the lsp to be used and provide inbound liquidity
   Future<void> setLspId({required String lspId, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kSetLspIdConstMeta;
 
+  /// get the node state from the persistent storage
   Future<NodeState?> getNodeState({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kGetNodeStateConstMeta;
 
+  /// Fetch live rates of fiat currencies
   Future<List<Rate>> fetchRates({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kFetchRatesConstMeta;
 
+  /// List all available fiat currencies
   Future<List<FiatCurrency>> listFiatCurrencies({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kListFiatCurrenciesConstMeta;
 
+  /// list transactions (incoming/outgoing payments) from the persistent storage
   Future<List<LightningTransaction>> listTransactions(
       {required PaymentTypeFilter filter,
       int? fromTimestamp,
@@ -73,24 +91,46 @@ abstract class LightningToolkit {
 
   FlutterRustBridgeTaskConstMeta get kListTransactionsConstMeta;
 
+  /// pay a bolt11 invoice
+  ///
+  /// # Arguments
+  ///
+  /// * `bolt11` - The bolt11 invoice
   Future<void> pay({required String bolt11, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kPayConstMeta;
 
+  /// pay directly to a node id using keysend
+  ///
+  /// # Arguments
+  ///
+  /// * `node_id` - The destination node_id
+  /// * `amount_sats` - The amount to pay in satoshis
   Future<void> keysend(
       {required String nodeId, required int amountSats, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kKeysendConstMeta;
 
+  /// Request an bolt11 payment request
+  /// This also works when the node doesn't have any channels and need inbound liquidity.
+  /// In such case when the invoice is paid a new zero-conf channel will be open by the LSP,
+  /// providing inbound liquidity and the payment will be routed via this new channel.
+  ///
+  /// # Arguments
+  ///
+  /// * `description` - The bolt11 payment request description
+  /// * `amount_sats` - The amount to receive in satoshis
   Future<LNInvoice> requestPayment(
       {required int amountSats, required String description, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kRequestPaymentConstMeta;
 
+  /// close all channels with the current lsp
   Future<void> closeLspChannels({dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kCloseLspChannelsConstMeta;
 
+  /// Withdraw on-chain funds in the wallet to an external btc address
   Future<void> withdraw(
       {required String toAddress,
       required FeeratePreset feeratePreset,
@@ -108,22 +148,6 @@ abstract class LightningToolkit {
   Future<Uint8List> mnemonicToSeed({required String phrase, dynamic hint});
 
   FlutterRustBridgeTaskConstMeta get kMnemonicToSeedConstMeta;
-}
-
-class Config {
-  final String breezserver;
-  final String mempoolspaceUrl;
-  final String workingDir;
-  final Network network;
-  final int paymentTimeoutSec;
-
-  Config({
-    required this.breezserver,
-    required this.mempoolspaceUrl,
-    required this.workingDir,
-    required this.network,
-    required this.paymentTimeoutSec,
-  });
 }
 
 class CurrencyInfo {
@@ -428,29 +452,6 @@ class LightningToolkitImpl implements LightningToolkit {
       const FlutterRustBridgeTaskConstMeta(
         debugName: "recover_node",
         argNames: ["network", "seed"],
-      );
-
-  Future<void> createNodeServices(
-          {required Config breezConfig,
-          required Uint8List seed,
-          required GreenlightCredentials creds,
-          dynamic hint}) =>
-      _platform.executeNormal(FlutterRustBridgeTask(
-        callFfi: (port_) => _platform.inner.wire_create_node_services(
-            port_,
-            _platform.api2wire_box_autoadd_config(breezConfig),
-            _platform.api2wire_uint_8_list(seed),
-            _platform.api2wire_box_autoadd_greenlight_credentials(creds)),
-        parseSuccessData: _wire2api_unit,
-        constMeta: kCreateNodeServicesConstMeta,
-        argValues: [breezConfig, seed, creds],
-        hint: hint,
-      ));
-
-  FlutterRustBridgeTaskConstMeta get kCreateNodeServicesConstMeta =>
-      const FlutterRustBridgeTaskConstMeta(
-        debugName: "create_node_services",
-        argNames: ["breezConfig", "seed", "creds"],
       );
 
   Future<void> startNode({dynamic hint}) =>
@@ -1070,11 +1071,6 @@ int api2wire_payment_type_filter(PaymentTypeFilter raw) {
 }
 
 @protected
-int api2wire_u32(int raw) {
-  return raw;
-}
-
-@protected
 int api2wire_u8(int raw) {
   return raw;
 }
@@ -1088,21 +1084,6 @@ class LightningToolkitPlatform
   @protected
   ffi.Pointer<wire_uint_8_list> api2wire_String(String raw) {
     return api2wire_uint_8_list(utf8.encoder.convert(raw));
-  }
-
-  @protected
-  ffi.Pointer<wire_Config> api2wire_box_autoadd_config(Config raw) {
-    final ptr = inner.new_box_autoadd_config_0();
-    _api_fill_to_wire_config(raw, ptr.ref);
-    return ptr;
-  }
-
-  @protected
-  ffi.Pointer<wire_GreenlightCredentials>
-      api2wire_box_autoadd_greenlight_credentials(GreenlightCredentials raw) {
-    final ptr = inner.new_box_autoadd_greenlight_credentials_0();
-    _api_fill_to_wire_greenlight_credentials(raw, ptr.ref);
-    return ptr;
   }
 
   @protected
@@ -1133,30 +1114,6 @@ class LightningToolkitPlatform
   }
 // Section: api_fill_to_wire
 
-  void _api_fill_to_wire_box_autoadd_config(
-      Config apiObj, ffi.Pointer<wire_Config> wireObj) {
-    _api_fill_to_wire_config(apiObj, wireObj.ref);
-  }
-
-  void _api_fill_to_wire_box_autoadd_greenlight_credentials(
-      GreenlightCredentials apiObj,
-      ffi.Pointer<wire_GreenlightCredentials> wireObj) {
-    _api_fill_to_wire_greenlight_credentials(apiObj, wireObj.ref);
-  }
-
-  void _api_fill_to_wire_config(Config apiObj, wire_Config wireObj) {
-    wireObj.breezserver = api2wire_String(apiObj.breezserver);
-    wireObj.mempoolspace_url = api2wire_String(apiObj.mempoolspaceUrl);
-    wireObj.working_dir = api2wire_String(apiObj.workingDir);
-    wireObj.network = api2wire_network(apiObj.network);
-    wireObj.payment_timeout_sec = api2wire_u32(apiObj.paymentTimeoutSec);
-  }
-
-  void _api_fill_to_wire_greenlight_credentials(
-      GreenlightCredentials apiObj, wire_GreenlightCredentials wireObj) {
-    wireObj.device_key = api2wire_uint_8_list(apiObj.deviceKey);
-    wireObj.device_cert = api2wire_uint_8_list(apiObj.deviceCert);
-  }
 }
 
 // ignore_for_file: camel_case_types, non_constant_identifier_names, avoid_positional_boolean_parameters, annotate_overrides, constant_identifier_names
@@ -1232,36 +1189,6 @@ class LightningToolkitWire implements FlutterRustBridgeWireBase {
               ffi.Pointer<wire_uint_8_list>)>>('wire_recover_node');
   late final _wire_recover_node = _wire_recover_nodePtr
       .asFunction<void Function(int, int, ffi.Pointer<wire_uint_8_list>)>();
-
-  void wire_create_node_services(
-    int port_,
-    ffi.Pointer<wire_Config> breez_config,
-    ffi.Pointer<wire_uint_8_list> seed,
-    ffi.Pointer<wire_GreenlightCredentials> creds,
-  ) {
-    return _wire_create_node_services(
-      port_,
-      breez_config,
-      seed,
-      creds,
-    );
-  }
-
-  late final _wire_create_node_servicesPtr = _lookup<
-          ffi.NativeFunction<
-              ffi.Void Function(
-                  ffi.Int64,
-                  ffi.Pointer<wire_Config>,
-                  ffi.Pointer<wire_uint_8_list>,
-                  ffi.Pointer<wire_GreenlightCredentials>)>>(
-      'wire_create_node_services');
-  late final _wire_create_node_services =
-      _wire_create_node_servicesPtr.asFunction<
-          void Function(
-              int,
-              ffi.Pointer<wire_Config>,
-              ffi.Pointer<wire_uint_8_list>,
-              ffi.Pointer<wire_GreenlightCredentials>)>();
 
   void wire_start_node(
     int port_,
@@ -1534,29 +1461,6 @@ class LightningToolkitWire implements FlutterRustBridgeWireBase {
   late final _wire_mnemonic_to_seed = _wire_mnemonic_to_seedPtr
       .asFunction<void Function(int, ffi.Pointer<wire_uint_8_list>)>();
 
-  ffi.Pointer<wire_Config> new_box_autoadd_config_0() {
-    return _new_box_autoadd_config_0();
-  }
-
-  late final _new_box_autoadd_config_0Ptr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<wire_Config> Function()>>(
-          'new_box_autoadd_config_0');
-  late final _new_box_autoadd_config_0 = _new_box_autoadd_config_0Ptr
-      .asFunction<ffi.Pointer<wire_Config> Function()>();
-
-  ffi.Pointer<wire_GreenlightCredentials>
-      new_box_autoadd_greenlight_credentials_0() {
-    return _new_box_autoadd_greenlight_credentials_0();
-  }
-
-  late final _new_box_autoadd_greenlight_credentials_0Ptr = _lookup<
-      ffi.NativeFunction<
-          ffi.Pointer<wire_GreenlightCredentials>
-              Function()>>('new_box_autoadd_greenlight_credentials_0');
-  late final _new_box_autoadd_greenlight_credentials_0 =
-      _new_box_autoadd_greenlight_credentials_0Ptr
-          .asFunction<ffi.Pointer<wire_GreenlightCredentials> Function()>();
-
   ffi.Pointer<ffi.Int64> new_box_autoadd_i64_0(
     int value,
   ) {
@@ -1606,26 +1510,6 @@ class wire_uint_8_list extends ffi.Struct {
 
   @ffi.Int32()
   external int len;
-}
-
-class wire_Config extends ffi.Struct {
-  external ffi.Pointer<wire_uint_8_list> breezserver;
-
-  external ffi.Pointer<wire_uint_8_list> mempoolspace_url;
-
-  external ffi.Pointer<wire_uint_8_list> working_dir;
-
-  @ffi.Int32()
-  external int network;
-
-  @ffi.Uint32()
-  external int payment_timeout_sec;
-}
-
-class wire_GreenlightCredentials extends ffi.Struct {
-  external ffi.Pointer<wire_uint_8_list> device_key;
-
-  external ffi.Pointer<wire_uint_8_list> device_cert;
 }
 
 typedef DartPostCObjectFnType = ffi.Pointer<

--- a/packages/breez_sdk/rust/src/binding.rs
+++ b/packages/breez_sdk/rust/src/binding.rs
@@ -1,8 +1,9 @@
+use crate::chain::MempoolSpace;
 use crate::fiat::{FiatCurrency, Rate};
 use crate::lsp::LspInformation;
 use lazy_static::lazy_static;
 use std::future::Future;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use tokio::sync::mpsc;
 
 use anyhow::{anyhow, Result};
@@ -12,23 +13,33 @@ use crate::models::{
     Config, FeeratePreset, GreenlightCredentials, LightningTransaction, Network, NodeState,
     PaymentTypeFilter,
 };
-use crate::node_service::NodeServiceBuilder;
+use crate::node_service::BreezServer;
 use crate::{greenlight::Greenlight, node_service::NodeService};
 
-use bip39::{Mnemonic, Language, Seed};
 use crate::invoice::{self};
+use bip39::{Language, Mnemonic, Seed};
 
 lazy_static! {
-    static ref STATE: Mutex<Option<Greenlight>> = Mutex::new(None);
+    static ref NODE_SERVICE_STATE: Mutex<Option<Arc<NodeService>>> = Mutex::new(None);
     static ref SIGNER_SHUTDOWN: Mutex<Option<mpsc::Sender::<()>>> = Mutex::new(None);
 }
 
+/// Register a new node in the cloud and return credentials to interact with it
+///
+/// # Arguments
+///
+/// * `network` - The network type which is one of (Bitcoin, Testnet, Signet, Regtest)
 pub fn register_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredentials> {
     let creds = block_on(Greenlight::register(network, seed.clone()))?;
     create_node_services(crate::models::Config::default(), seed, creds.clone())?;
     Ok(creds)
 }
 
+/// Recover an existing node from the cloud and return credentials to interact with it
+///
+/// # Arguments
+///
+/// * `network` - The network type which is one of (Bitcoin, Testnet, Signet, Regtest)
 pub fn recover_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredentials> {
     let creds = block_on(Greenlight::recover(network, seed.clone()))?;
     create_node_services(crate::models::Config::default(), seed, creds.clone())?;
@@ -36,25 +47,14 @@ pub fn recover_node(network: Network, seed: Vec<u8>) -> Result<GreenlightCredent
     Ok(creds)
 }
 
-pub fn create_node_services(
-    breez_config: Config,
-    seed: Vec<u8>,
-    creds: GreenlightCredentials,
-) -> Result<()> {
-    let greenlight = block_on(Greenlight::new(breez_config, seed, creds))?;
-    *STATE.lock().unwrap() = Some(greenlight);
-    block_on(build_services())
-        .map(|_| ())
-        .map_err(|e| anyhow!(e))?;
-    run_signer()?;
-    start_node()?;
-    sync()
-}
-
+/// "Wake up" a node and schedule it to run immediately in the cloud
 pub fn start_node() -> Result<()> {
-    block_on(async { build_services().await?.start_node().await })
+    block_on(async { get_node_service()?.start_node().await })
 }
 
+/// Run the signer in a separate thread.
+/// This intended for internal use of the SDK and not recommended to use unless
+/// you know what you are doing.
 pub fn run_signer() -> Result<()> {
     let shutdown = SIGNER_SHUTDOWN.lock().unwrap().clone();
     match shutdown {
@@ -63,7 +63,7 @@ pub fn run_signer() -> Result<()> {
             let (tx, rec) = mpsc::channel::<()>(1);
             *SIGNER_SHUTDOWN.lock().unwrap() = Some(tx);
             std::thread::spawn(move || {
-                block_on(async move { build_services().await?.run_signer(rec).await })
+                block_on(async move { get_node_service()?.run_signer(rec).await })
             });
 
             Ok(())
@@ -71,6 +71,9 @@ pub fn run_signer() -> Result<()> {
     }
 }
 
+/// Stop the signer thread.
+/// This intended for internal use of the SDK and not recommended to use unless
+/// you know what you are doing.
 pub fn stop_signer() -> Result<()> {
     let shutdown = SIGNER_SHUTDOWN.lock().unwrap().clone();
     match shutdown {
@@ -83,87 +86,126 @@ pub fn stop_signer() -> Result<()> {
     }
 }
 
+/// Synchronize changes from the cloud to the persistent storage.
+/// Changes includes the node state (inbound liquidity, max payable, max receivable, etc...)
+/// and new transactions.
 pub fn sync() -> Result<()> {
-    block_on(async { build_services().await?.sync().await })
+    block_on(async { get_node_service()?.sync().await })
 }
 
+/// List available lsps that can be selected by the user
 pub fn list_lsps() -> Result<Vec<LspInformation>> {
-    block_on(async { build_services().await?.list_lsps().await })
+    block_on(async { get_node_service()?.list_lsps().await })
 }
 
+/// Select the lsp to be used and provide inbound liquidity
 pub fn set_lsp_id(lsp_id: String) -> Result<()> {
-    block_on(async { build_services().await?.set_lsp_id(lsp_id).await })?;
+    block_on(async { get_node_service()?.set_lsp_id(lsp_id).await })?;
     sync()
 }
 
+/// get the node state from the persistent storage
 pub fn get_node_state() -> Result<Option<NodeState>> {
-    block_on(async { build_services().await?.get_node_state() })
+    block_on(async { get_node_service()?.get_node_state() })
 }
 
+/// Fetch live rates of fiat currencies
 pub fn fetch_rates() -> Result<Vec<Rate>> {
-    block_on(async { build_services().await?.fetch_rates().await })
+    block_on(async { get_node_service()?.fetch_rates().await })
 }
 
+/// List all available fiat currencies
 pub fn list_fiat_currencies() -> Result<Vec<FiatCurrency>> {
-    block_on(async { build_services().await?.list_fiat_currencies() })
+    block_on(async { get_node_service()?.list_fiat_currencies() })
 }
 
+/// list transactions (incoming/outgoing payments) from the persistent storage
 pub fn list_transactions(
     filter: PaymentTypeFilter,
     from_timestamp: Option<i64>,
     to_timestamp: Option<i64>,
 ) -> Result<Vec<LightningTransaction>> {
     block_on(async {
-        build_services()
-            .await?
+        get_node_service()?
             .list_transactions(filter, from_timestamp, to_timestamp)
             .await
     })
 }
 
+/// pay a bolt11 invoice
+///
+/// # Arguments
+///
+/// * `bolt11` - The bolt11 invoice
 pub fn pay(bolt11: String) -> Result<()> {
-    block_on(async { build_services().await?.pay(bolt11).await })
+    block_on(async { get_node_service()?.pay(bolt11).await })
 }
 
+/// pay directly to a node id using keysend
+///
+/// # Arguments
+///
+/// * `node_id` - The destination node_id
+/// * `amount_sats` - The amount to pay in satoshis
 pub fn keysend(node_id: String, amount_sats: u64) -> Result<()> {
-    block_on(async { build_services().await?.keysend(node_id, amount_sats).await })
+    block_on(async { get_node_service()?.keysend(node_id, amount_sats).await })
 }
 
+/// Request an bolt11 payment request
+/// This also works when the node doesn't have any channels and need inbound liquidity.
+/// In such case when the invoice is paid a new zero-conf channel will be open by the LSP,
+/// providing inbound liquidity and the payment will be routed via this new channel.
+///
+/// # Arguments
+///
+/// * `description` - The bolt11 payment request description
+/// * `amount_sats` - The amount to receive in satoshis
 pub fn request_payment(amount_sats: u64, description: String) -> Result<LNInvoice> {
     block_on(async {
-        build_services()
-            .await?
+        get_node_service()?
             .request_payment(amount_sats, description.to_string())
             .await
     })
 }
 
+/// close all channels with the current lsp
 pub fn close_lsp_channels() -> Result<()> {
-    block_on(async { build_services().await?.close_lsp_channels().await })
+    block_on(async { get_node_service()?.close_lsp_channels().await })
 }
 
+/// Withdraw on-chain funds in the wallet to an external btc address
 pub fn withdraw(to_address: String, feerate_preset: FeeratePreset) -> Result<()> {
     block_on(async {
-        build_services()
-            .await?
+        get_node_service()?
             .withdraw(to_address, feerate_preset)
             .await
     })
 }
 
-async fn build_services() -> Result<NodeService> {
-    let g = STATE.lock().unwrap().clone();
-    let greenlight = g
-        .ok_or("greenlight is not initialized")
-        .map_err(|e| anyhow!(e))?;
+fn create_node_services(
+    breez_config: Config,
+    seed: Vec<u8>,
+    creds: GreenlightCredentials,
+) -> Result<()> {
+    let config = Config::default();
 
-    Ok(NodeServiceBuilder::default()
-        .config(Config::default())
-        .client(Box::new(greenlight))
-        .client_grpc_init_from_config()
-        .await
-        .build()
-        .await)
+    // greenlight is the implementation of NodeAPI
+    let node_api = block_on(Greenlight::new(breez_config, seed, creds))?;
+    let node_services = NodeService::from_config(config, Box::new(node_api))?;
+    *NODE_SERVICE_STATE.lock().unwrap() = Some(Arc::new(node_services));
+
+    // run the signer, schedule the node in the cloud and sync state
+    run_signer()?;
+    start_node()?;
+    sync()
+}
+
+fn get_node_service() -> Result<Arc<NodeService>> {
+    let n = (*NODE_SERVICE_STATE.lock().unwrap()).clone();
+    match n {
+        Some(a) => Ok(a),
+        None => Err(anyhow!("Node service was not initialized")),
+    }
 }
 
 fn block_on<F: Future>(future: F) -> F::Output {
@@ -177,14 +219,14 @@ fn block_on<F: Future>(future: F) -> F::Output {
 // These functions are exposed temporarily for integration purposes
 
 pub fn parse_invoice(invoice: String) -> Result<LNInvoice> {
- return invoice::parse_invoice(&invoice);
+    return invoice::parse_invoice(&invoice);
 }
 
 /// Attempts to convert the phrase to a mnemonic, then to a seed.
 ///
 /// If the phrase is not a valid mnemonic, an error is returned.
 pub fn mnemonic_to_seed(phrase: String) -> Result<Vec<u8>> {
- let mnemonic = Mnemonic::from_phrase(&phrase, Language::English)?;
- let seed = Seed::new(&mnemonic, "");
- Ok(seed.as_bytes().to_vec())
+    let mnemonic = Mnemonic::from_phrase(&phrase, Language::English)?;
+    let seed = Seed::new(&mnemonic, "");
+    Ok(seed.as_bytes().to_vec())
 }

--- a/packages/breez_sdk/rust/src/bridge_generated.io.rs
+++ b/packages/breez_sdk/rust/src/bridge_generated.io.rs
@@ -12,16 +12,6 @@ pub extern "C" fn wire_recover_node(port_: i64, network: i32, seed: *mut wire_ui
 }
 
 #[no_mangle]
-pub extern "C" fn wire_create_node_services(
-    port_: i64,
-    breez_config: *mut wire_Config,
-    seed: *mut wire_uint_8_list,
-    creds: *mut wire_GreenlightCredentials,
-) {
-    wire_create_node_services_impl(port_, breez_config, seed, creds)
-}
-
-#[no_mangle]
 pub extern "C" fn wire_start_node(port_: i64) {
     wire_start_node_impl(port_)
 }
@@ -122,16 +112,6 @@ pub extern "C" fn wire_mnemonic_to_seed(port_: i64, phrase: *mut wire_uint_8_lis
 // Section: allocate functions
 
 #[no_mangle]
-pub extern "C" fn new_box_autoadd_config_0() -> *mut wire_Config {
-    support::new_leak_box_ptr(wire_Config::new_with_null_ptr())
-}
-
-#[no_mangle]
-pub extern "C" fn new_box_autoadd_greenlight_credentials_0() -> *mut wire_GreenlightCredentials {
-    support::new_leak_box_ptr(wire_GreenlightCredentials::new_with_null_ptr())
-}
-
-#[no_mangle]
 pub extern "C" fn new_box_autoadd_i64_0(value: i64) -> *mut i64 {
     support::new_leak_box_ptr(value)
 }
@@ -153,39 +133,6 @@ impl Wire2Api<String> for *mut wire_uint_8_list {
         String::from_utf8_lossy(&vec).into_owned()
     }
 }
-impl Wire2Api<Config> for *mut wire_Config {
-    fn wire2api(self) -> Config {
-        let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<Config>::wire2api(*wrap).into()
-    }
-}
-impl Wire2Api<GreenlightCredentials> for *mut wire_GreenlightCredentials {
-    fn wire2api(self) -> GreenlightCredentials {
-        let wrap = unsafe { support::box_from_leak_ptr(self) };
-        Wire2Api::<GreenlightCredentials>::wire2api(*wrap).into()
-    }
-}
-
-impl Wire2Api<Config> for wire_Config {
-    fn wire2api(self) -> Config {
-        Config {
-            breezserver: self.breezserver.wire2api(),
-            mempoolspace_url: self.mempoolspace_url.wire2api(),
-            working_dir: self.working_dir.wire2api(),
-            network: self.network.wire2api(),
-            payment_timeout_sec: self.payment_timeout_sec.wire2api(),
-        }
-    }
-}
-
-impl Wire2Api<GreenlightCredentials> for wire_GreenlightCredentials {
-    fn wire2api(self) -> GreenlightCredentials {
-        GreenlightCredentials {
-            device_key: self.device_key.wire2api(),
-            device_cert: self.device_cert.wire2api(),
-        }
-    }
-}
 
 impl Wire2Api<Vec<u8>> for *mut wire_uint_8_list {
     fn wire2api(self) -> Vec<u8> {
@@ -196,23 +143,6 @@ impl Wire2Api<Vec<u8>> for *mut wire_uint_8_list {
     }
 }
 // Section: wire structs
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_Config {
-    breezserver: *mut wire_uint_8_list,
-    mempoolspace_url: *mut wire_uint_8_list,
-    working_dir: *mut wire_uint_8_list,
-    network: i32,
-    payment_timeout_sec: u32,
-}
-
-#[repr(C)]
-#[derive(Clone)]
-pub struct wire_GreenlightCredentials {
-    device_key: *mut wire_uint_8_list,
-    device_cert: *mut wire_uint_8_list,
-}
 
 #[repr(C)]
 #[derive(Clone)]
@@ -230,27 +160,6 @@ pub trait NewWithNullPtr {
 impl<T> NewWithNullPtr for *mut T {
     fn new_with_null_ptr() -> Self {
         std::ptr::null_mut()
-    }
-}
-
-impl NewWithNullPtr for wire_Config {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            breezserver: core::ptr::null_mut(),
-            mempoolspace_url: core::ptr::null_mut(),
-            working_dir: core::ptr::null_mut(),
-            network: Default::default(),
-            payment_timeout_sec: Default::default(),
-        }
-    }
-}
-
-impl NewWithNullPtr for wire_GreenlightCredentials {
-    fn new_with_null_ptr() -> Self {
-        Self {
-            device_key: core::ptr::null_mut(),
-            device_cert: core::ptr::null_mut(),
-        }
     }
 }
 

--- a/packages/breez_sdk/rust/src/bridge_generated.rs
+++ b/packages/breez_sdk/rust/src/bridge_generated.rs
@@ -27,7 +27,6 @@ use crate::invoice::LNInvoice;
 use crate::invoice::RouteHint;
 use crate::invoice::RouteHintHop;
 use crate::lsp::LspInformation;
-use crate::models::Config;
 use crate::models::FeeratePreset;
 use crate::models::GreenlightCredentials;
 use crate::models::LightningTransaction;
@@ -70,26 +69,6 @@ fn wire_recover_node_impl(
             let api_network = network.wire2api();
             let api_seed = seed.wire2api();
             move |task_callback| recover_node(api_network, api_seed)
-        },
-    )
-}
-fn wire_create_node_services_impl(
-    port_: MessagePort,
-    breez_config: impl Wire2Api<Config> + UnwindSafe,
-    seed: impl Wire2Api<Vec<u8>> + UnwindSafe,
-    creds: impl Wire2Api<GreenlightCredentials> + UnwindSafe,
-) {
-    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
-        WrapInfo {
-            debug_name: "create_node_services",
-            port: Some(port_),
-            mode: FfiCallMode::Normal,
-        },
-        move || {
-            let api_breez_config = breez_config.wire2api();
-            let api_seed = seed.wire2api();
-            let api_creds = creds.wire2api();
-            move |task_callback| create_node_services(api_breez_config, api_seed, api_creds)
         },
     )
 }
@@ -335,7 +314,6 @@ impl Wire2Api<i64> for *mut i64 {
         unsafe { *support::box_from_leak_ptr(self) }
     }
 }
-
 impl Wire2Api<FeeratePreset> for i32 {
     fn wire2api(self) -> FeeratePreset {
         match self {
@@ -346,7 +324,6 @@ impl Wire2Api<FeeratePreset> for i32 {
         }
     }
 }
-
 impl Wire2Api<i32> for i32 {
     fn wire2api(self) -> i32 {
         self
@@ -377,11 +354,6 @@ impl Wire2Api<PaymentTypeFilter> for i32 {
             2 => PaymentTypeFilter::All,
             _ => unreachable!("Invalid variant for PaymentTypeFilter: {}", self),
         }
-    }
-}
-impl Wire2Api<u32> for u32 {
-    fn wire2api(self) -> u32 {
-        self
     }
 }
 impl Wire2Api<u64> for u64 {

--- a/packages/breez_sdk/rust/src/lsp.rs
+++ b/packages/breez_sdk/rust/src/lsp.rs
@@ -62,7 +62,7 @@ impl LspAPI for BreezServer {
     }
 
     async fn register_payment(
-        &mut self,
+        &self,
         lsp_id: String,
         lsp_pubkey: Vec<u8>,
         payment_info: PaymentInformation,

--- a/packages/breez_sdk/rust/src/models.rs
+++ b/packages/breez_sdk/rust/src/models.rs
@@ -15,7 +15,7 @@ pub const PAYMENT_TYPE_SENT: &str = "sent";
 pub const PAYMENT_TYPE_RECEIVED: &str = "received";
 
 #[tonic::async_trait]
-pub trait NodeAPI {
+pub trait NodeAPI: Send + Sync {
     async fn create_invoice(&self, amount_sats: u64, description: String) -> Result<Invoice>;
     async fn pull_changed(&self, since_timestamp: i64) -> Result<SyncResponse>;
     /// As per the `pb::PayRequest` docs, `amount_sats` is only needed when the invoice doesn't specify an amount
@@ -35,10 +35,10 @@ pub trait NodeAPI {
 }
 
 #[tonic::async_trait]
-pub trait LspAPI {
+pub trait LspAPI: Send + Sync {
     async fn list_lsps(&self, node_pubkey: String) -> Result<Vec<LspInformation>>;
     async fn register_payment(
-        &mut self,
+        &self,
         lsp_id: String,
         lsp_pubkey: Vec<u8>,
         payment_info: PaymentInformation,
@@ -46,7 +46,7 @@ pub trait LspAPI {
 }
 
 #[tonic::async_trait]
-pub trait FiatAPI {
+pub trait FiatAPI: Send + Sync {
     fn list_fiat_currencies(&self) -> Result<Vec<FiatCurrency>>;
     async fn fetch_rates(&self) -> Result<Vec<Rate>>;
 }

--- a/packages/breez_sdk/rust/src/test_utils.rs
+++ b/packages/breez_sdk/rust/src/test_utils.rs
@@ -129,7 +129,7 @@ impl LspAPI for MockBreezServer {
     }
 
     async fn register_payment(
-        &mut self,
+        &self,
         _lsp_id: String,
         _lsp_pubkey: Vec<u8>,
         _payment_info: PaymentInformation,


### PR DESCRIPTION
Apologies about these big changes. The goal was to use one instance of NodeServices rather than build it on every request.
In order to do so I used Arc which required some changes in the services themselves that will ensure they implement Sync + Send so they can pass between threads.
In general the following was done:

Implement Sync + Send on the services traits
Make NodeServices immutable by changing all mut &self occurences to &self. We didn't really need for it to be mutable.
Use Arc to hold one instance of NodeServices and manage reference counter instead of building from scratch.