### PR TITLE
Implement `.into()` for network type conversion

### DIFF
--- a/packages/breez_sdk/rust/src/models.rs
+++ b/packages/breez_sdk/rust/src/models.rs
@@ -120,6 +120,17 @@ impl From<bitcoin::network::constants::Network> for Network {
     }
 }
 
+impl From<Network> for bitcoin::network::constants::Network {
+    fn from(network: Network) -> Self {
+        match network {
+            Bitcoin => bitcoin::network::constants::Network::Bitcoin,
+            Testnet => bitcoin::network::constants::Network::Testnet,
+            Signet => bitcoin::network::constants::Network::Signet,
+            Regtest => bitcoin::network::constants::Network::Regtest
+        }
+    }
+}
+
 pub enum PaymentTypeFilter {
     Sent,
     Received,

--- a/packages/breez_sdk/rust/src/node_service.rs
+++ b/packages/breez_sdk/rust/src/node_service.rs
@@ -75,7 +75,7 @@ impl NodeService {
         });
 
         let btc_receive_swapper = Arc::new(BTCReceiveSwap::new(
-            parse_network(&config.clone().network),
+            config.network.clone().into(),
             breez_server.clone(),
             persister.clone(),
             chain_service.clone(),
@@ -453,15 +453,6 @@ async fn get_lsp(persister: Arc<SqliteStorage>, lsp: Arc<dyn LspAPI>) -> Result<
         .ok_or("No LSP found for given LSP ID")
         .map_err(|err| anyhow!(err))
         .cloned()
-}
-
-pub fn parse_network(gn: &Network) -> bitcoin::Network {
-    match gn {
-        Network::Bitcoin => bitcoin::Network::Bitcoin,
-        Network::Testnet => bitcoin::Network::Testnet,
-        Network::Signet => bitcoin::Network::Signet,
-        Network::Regtest => bitcoin::Network::Regtest,
-    }
 }
 
 mod test {


### PR DESCRIPTION
The two network types (`bitcoin::network::constants::Network` and `lightning_toolkit::models::Network`) can now be converted one to the other via `.into()`.

This replaces the previous `parse_network()` method.