### PR TITLE
Stream logs from rust to the platform

### DIFF
--- a/packages/breez_sdk/ios/Classes/bridge_generated.h
+++ b/packages/breez_sdk/ios/Classes/bridge_generated.h
@@ -50,6 +50,8 @@ void wire_init_node(int64_t port_,
 
 void wire_breez_events_stream(int64_t port_);
 
+void wire_breez_log_stream(int64_t port_);
+
 void wire_stop_node(int64_t port_);
 
 void wire_send_payment(int64_t port_, struct wire_uint_8_list *bolt11);
@@ -114,6 +116,7 @@ static int64_t dummy_method_to_enforce_bundling(void) {
     dummy_var ^= ((int64_t) (void*) wire_recover_node);
     dummy_var ^= ((int64_t) (void*) wire_init_node);
     dummy_var ^= ((int64_t) (void*) wire_breez_events_stream);
+    dummy_var ^= ((int64_t) (void*) wire_breez_log_stream);
     dummy_var ^= ((int64_t) (void*) wire_stop_node);
     dummy_var ^= ((int64_t) (void*) wire_send_payment);
     dummy_var ^= ((int64_t) (void*) wire_send_spontaneous_payment);

--- a/packages/breez_sdk/lib/breez_bridge.dart
+++ b/packages/breez_sdk/lib/breez_bridge.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_sdk/native_toolkit.dart';
-import 'package:flutter_rust_bridge/flutter_rust_bridge.dart';
 import 'package:rxdart/rxdart.dart';
 
 class BreezBridge {

--- a/packages/breez_sdk/lib/bridge_generated.dart
+++ b/packages/breez_sdk/lib/bridge_generated.dart
@@ -65,6 +65,10 @@ abstract class LightningToolkit {
 
   FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta;
 
+  Stream<LogEntry> breezLogStream({dynamic hint});
+
+  FlutterRustBridgeTaskConstMeta get kBreezLogStreamConstMeta;
+
   /// Cleanup node resources and stop the signer.
   Future<void> stopNode({dynamic hint});
 
@@ -358,6 +362,16 @@ class LocalizedName {
   LocalizedName({
     required this.locale,
     required this.name,
+  });
+}
+
+class LogEntry {
+  final String line;
+  final String level;
+
+  LogEntry({
+    required this.line,
+    required this.level,
   });
 }
 
@@ -658,6 +672,21 @@ class LightningToolkitImpl implements LightningToolkit {
   FlutterRustBridgeTaskConstMeta get kBreezEventsStreamConstMeta =>
       const FlutterRustBridgeTaskConstMeta(
         debugName: "breez_events_stream",
+        argNames: [],
+      );
+
+  Stream<LogEntry> breezLogStream({dynamic hint}) =>
+      _platform.executeStream(FlutterRustBridgeTask(
+        callFfi: (port_) => _platform.inner.wire_breez_log_stream(port_),
+        parseSuccessData: _wire2api_log_entry,
+        constMeta: kBreezLogStreamConstMeta,
+        argValues: [],
+        hint: hint,
+      ));
+
+  FlutterRustBridgeTaskConstMeta get kBreezLogStreamConstMeta =>
+      const FlutterRustBridgeTaskConstMeta(
+        debugName: "breez_log_stream",
         argNames: [],
       );
 
@@ -1219,6 +1248,16 @@ class LightningToolkitImpl implements LightningToolkit {
     );
   }
 
+  LogEntry _wire2api_log_entry(dynamic raw) {
+    final arr = raw as List<dynamic>;
+    if (arr.length != 2)
+      throw Exception('unexpected arr length: expect 2 but see ${arr.length}');
+    return LogEntry(
+      line: _wire2api_String(arr[0]),
+      level: _wire2api_String(arr[1]),
+    );
+  }
+
   LspInformation _wire2api_lsp_information(dynamic raw) {
     final arr = raw as List<dynamic>;
     if (arr.length != 15)
@@ -1657,6 +1696,20 @@ class LightningToolkitWire implements FlutterRustBridgeWireBase {
           'wire_breez_events_stream');
   late final _wire_breez_events_stream =
       _wire_breez_events_streamPtr.asFunction<void Function(int)>();
+
+  void wire_breez_log_stream(
+    int port_,
+  ) {
+    return _wire_breez_log_stream(
+      port_,
+    );
+  }
+
+  late final _wire_breez_log_streamPtr =
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int64)>>(
+          'wire_breez_log_stream');
+  late final _wire_breez_log_stream =
+      _wire_breez_log_streamPtr.asFunction<void Function(int)>();
 
   void wire_stop_node(
     int port_,

--- a/packages/breez_sdk/rust/src/bridge_generated.io.rs
+++ b/packages/breez_sdk/rust/src/bridge_generated.io.rs
@@ -37,6 +37,11 @@ pub extern "C" fn wire_breez_events_stream(port_: i64) {
 }
 
 #[no_mangle]
+pub extern "C" fn wire_breez_log_stream(port_: i64) {
+    wire_breez_log_stream_impl(port_)
+}
+
+#[no_mangle]
 pub extern "C" fn wire_stop_node(port_: i64) {
     wire_stop_node_impl(port_)
 }

--- a/packages/breez_sdk/rust/src/bridge_generated.rs
+++ b/packages/breez_sdk/rust/src/bridge_generated.rs
@@ -34,6 +34,7 @@ use crate::lsp::LspInformation;
 use crate::models::Config;
 use crate::models::FeeratePreset;
 use crate::models::GreenlightCredentials;
+use crate::models::LogEntry;
 use crate::models::Network;
 use crate::models::NodeState;
 use crate::models::Payment;
@@ -111,6 +112,16 @@ fn wire_breez_events_stream_impl(port_: MessagePort) {
             mode: FfiCallMode::Stream,
         },
         move || move |task_callback| breez_events_stream(task_callback.stream_sink()),
+    )
+}
+fn wire_breez_log_stream_impl(port_: MessagePort) {
+    FLUTTER_RUST_BRIDGE_HANDLER.wrap(
+        WrapInfo {
+            debug_name: "breez_log_stream",
+            port: Some(port_),
+            mode: FfiCallMode::Stream,
+        },
+        move || move |task_callback| breez_log_stream(task_callback.stream_sink()),
     )
 }
 fn wire_stop_node_impl(port_: MessagePort) {
@@ -561,6 +572,13 @@ impl support::IntoDart for LocalizedName {
     }
 }
 impl support::IntoDartExceptPrimitive for LocalizedName {}
+
+impl support::IntoDart for LogEntry {
+    fn into_dart(self) -> support::DartAbi {
+        vec![self.line.into_dart(), self.level.into_dart()].into_dart()
+    }
+}
+impl support::IntoDartExceptPrimitive for LogEntry {}
 
 impl support::IntoDart for LspInformation {
     fn into_dart(self) -> support::DartAbi {

--- a/packages/breez_sdk/rust/src/greenlight.rs
+++ b/packages/breez_sdk/rust/src/greenlight.rs
@@ -116,6 +116,15 @@ impl NodeAPI for Greenlight {
         Ok(stream)
     }
 
+    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>> {
+        let mut client = self.get_client().await?;
+        let stream = client
+            .stream_log(gl_client::pb::StreamLogRequest {})
+            .await?
+            .into_inner();
+        Ok(stream)
+    }
+
     fn sign_invoice(&self, invoice: RawInvoice) -> Result<String> {
         let hrp_bytes = invoice.hrp.to_string().as_bytes().to_vec();
         let data_bytes = invoice.data.to_base32();

--- a/packages/breez_sdk/rust/src/models.rs
+++ b/packages/breez_sdk/rust/src/models.rs
@@ -47,6 +47,7 @@ pub trait NodeAPI: Send + Sync {
     fn sign_invoice(&self, invoice: RawInvoice) -> Result<String>;
     async fn close_peer_channels(&self, node_id: String) -> Result<CloseChannelResponse>;
     async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>>;
+    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>>;
 }
 
 #[tonic::async_trait]
@@ -86,6 +87,12 @@ pub trait SwapperAPI: Send + Sync {
     ) -> Result<Swap>;
 
     async fn complete_swap(&self, bolt11: String) -> Result<()>;
+}
+
+#[derive(Clone, Debug)]
+pub struct LogEntry {
+    pub line: String,
+    pub level: String,
 }
 
 #[derive(Clone)]

--- a/packages/breez_sdk/rust/src/test_utils.rs
+++ b/packages/breez_sdk/rust/src/test_utils.rs
@@ -108,6 +108,10 @@ impl NodeAPI for MockNodeAPI {
     async fn stream_incoming_payments(&self) -> Result<Streaming<gl_client::pb::IncomingPayment>> {
         Err(anyhow!("Not implemented"))
     }
+
+    async fn stream_log_messages(&self) -> Result<Streaming<gl_client::pb::LogEntry>> {
+        Err(anyhow!("Not implemented"))
+    }
 }
 
 impl MockNodeAPI {


### PR DESCRIPTION
In the sdk we are using the standard log crate to log events so a rust user can always configure his own logger and configuration.
When used as a library in other platform (android, ios, web assembly, etc...) we need a way to connect to the platform log.
I went on a simple path to allow streaming the log messages to the platform and from there every platform can redirect these entries to its central logging system.
Once the user uses this streaming API we replace the system logger and no more logs will be printed to the stdout.