### PR TITLE
Add support for LN Address

### DIFF
--- a/packages/breez_sdk/lib/bridge_generated.dart
+++ b/packages/breez_sdk/lib/bridge_generated.dart
@@ -308,6 +308,7 @@ class InputType with _$InputType {
   /// - LUD-03 `withdrawRequest` spec
   /// - LUD-04 `auth` base spec
   /// - LUD-06 `payRequest` spec
+  /// - LUD-16 LN Address
   /// - LUD-17 Support for lnurlp, lnurlw, keyauth prefixes and non bech32-encoded LNURL URLs
   ///
   /// # Not supported (yet)


### PR DESCRIPTION
It comes down to one extra conversion

```
user@domain.com -> https://domain.com/.well-known/lnurlp/user
```

which is a normal LNURL-pay endpoint.

Also includes format validation and tests.