### PR TITLE
Store description_hash in LNInvoice

### DIFF
--- a/packages/breez_sdk/lib/bridge_generated.dart
+++ b/packages/breez_sdk/lib/bridge_generated.dart
@@ -338,7 +338,8 @@ class LNInvoice {
   final String bolt11;
   final String payeePubkey;
   final String paymentHash;
-  final String description;
+  final String? description;
+  final String? descriptionHash;
   final int? amountMsat;
   final int timestamp;
   final int expiry;
@@ -349,7 +350,8 @@ class LNInvoice {
     required this.bolt11,
     required this.payeePubkey,
     required this.paymentHash,
-    required this.description,
+    this.description,
+    this.descriptionHash,
     this.amountMsat,
     required this.timestamp,
     required this.expiry,
@@ -1351,18 +1353,19 @@ class LightningToolkitImpl implements LightningToolkit {
 
   LNInvoice _wire2api_ln_invoice(dynamic raw) {
     final arr = raw as List<dynamic>;
-    if (arr.length != 9)
-      throw Exception('unexpected arr length: expect 9 but see ${arr.length}');
+    if (arr.length != 10)
+      throw Exception('unexpected arr length: expect 10 but see ${arr.length}');
     return LNInvoice(
       bolt11: _wire2api_String(arr[0]),
       payeePubkey: _wire2api_String(arr[1]),
       paymentHash: _wire2api_String(arr[2]),
-      description: _wire2api_String(arr[3]),
-      amountMsat: _wire2api_opt_box_autoadd_u64(arr[4]),
-      timestamp: _wire2api_u64(arr[5]),
-      expiry: _wire2api_u64(arr[6]),
-      routingHints: _wire2api_list_route_hint(arr[7]),
-      paymentSecret: _wire2api_uint_8_list(arr[8]),
+      description: _wire2api_opt_String(arr[3]),
+      descriptionHash: _wire2api_opt_String(arr[4]),
+      amountMsat: _wire2api_opt_box_autoadd_u64(arr[5]),
+      timestamp: _wire2api_u64(arr[6]),
+      expiry: _wire2api_u64(arr[7]),
+      routingHints: _wire2api_list_route_hint(arr[8]),
+      paymentSecret: _wire2api_uint_8_list(arr[9]),
     );
   }
 
@@ -1826,7 +1829,7 @@ class LightningToolkitWire implements FlutterRustBridgeWireBase {
       : _lookup = lookup;
 
   void store_dart_post_cobject(
-    DartPostCObjectFnType ptr,
+    int ptr,
   ) {
     return _store_dart_post_cobject(
       ptr,
@@ -1834,10 +1837,10 @@ class LightningToolkitWire implements FlutterRustBridgeWireBase {
   }
 
   late final _store_dart_post_cobjectPtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(DartPostCObjectFnType)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.Int)>>(
           'store_dart_post_cobject');
-  late final _store_dart_post_cobject = _store_dart_post_cobjectPtr
-      .asFunction<void Function(DartPostCObjectFnType)>();
+  late final _store_dart_post_cobject =
+      _store_dart_post_cobjectPtr.asFunction<void Function(int)>();
 
   Object get_dart_object(
     int ptr,
@@ -2405,7 +2408,5 @@ class wire_GreenlightCredentials extends ffi.Struct {
   external ffi.Pointer<wire_uint_8_list> device_cert;
 }
 
-typedef DartPostCObjectFnType = ffi.Pointer<
-    ffi.NativeFunction<ffi.Bool Function(DartPort, ffi.Pointer<ffi.Void>)>>;
-typedef DartPort = ffi.Int64;
+typedef bool = ffi.NativeFunction<ffi.Int Function(ffi.Pointer<ffi.Int>)>;
 typedef uintptr_t = ffi.UnsignedLong;

--- a/packages/breez_sdk/rust/src/bridge_generated.rs
+++ b/packages/breez_sdk/rust/src/bridge_generated.rs
@@ -552,6 +552,7 @@ impl support::IntoDart for LNInvoice {
             self.payee_pubkey.into_dart(),
             self.payment_hash.into_dart(),
             self.description.into_dart(),
+            self.description_hash.into_dart(),
             self.amount_msat.into_dart(),
             self.timestamp.into_dart(),
             self.expiry.into_dart(),

--- a/packages/breez_sdk/rust/src/greenlight.rs
+++ b/packages/breez_sdk/rust/src/greenlight.rs
@@ -428,7 +428,7 @@ fn invoice_to_transaction(
         keysend: false,
         bolt11: invoice.bolt11,
         pending: false,
-        description: Some(ln_invoice.description),
+        description: ln_invoice.description,
     })
 }
 
@@ -436,7 +436,7 @@ fn invoice_to_transaction(
 fn payment_to_transaction(payment: pb::Payment) -> Result<crate::models::Payment> {
     let mut description = None;
     if !payment.bolt11.is_empty() {
-        description = Some(parse_invoice(&payment.bolt11)?.description);
+        description = parse_invoice(&payment.bolt11)?.description;
     }
 
     let payment_amount = amount_to_msat(payment.amount.unwrap_or_default()) as i32;
@@ -454,7 +454,7 @@ fn payment_to_transaction(payment: pb::Payment) -> Result<crate::models::Payment
         keysend: payment.bolt11.is_empty(),
         bolt11: payment.bolt11,
         pending: pb::PayStatus::from_i32(payment.status) == Some(pb::PayStatus::Pending),
-        description: description,
+        description,
     })
 }
 

--- a/packages/breez_sdk/rust/src/invoice.rs
+++ b/packages/breez_sdk/rust/src/invoice.rs
@@ -12,7 +12,8 @@ pub struct LNInvoice {
     pub bolt11: String,
     pub payee_pubkey: String,
     pub payment_hash: String,
-    pub description: String,
+    pub description: Option<String>,
+    pub description_hash: Option<String>,
     pub amount_msat: Option<u64>,
     pub timestamp: u64,
     pub expiry: u64,
@@ -160,8 +161,12 @@ pub fn parse_invoice(bolt11: &str) -> Result<LNInvoice> {
         payment_hash: invoice.payment_hash().encode_hex::<String>(),
         payment_secret: invoice.payment_secret().0.to_vec(),
         description: match invoice.description() {
-            InvoiceDescription::Direct(msg) => msg.to_string(),
-            InvoiceDescription::Hash(_) => String::from(""),
+            InvoiceDescription::Direct(msg) => Some(msg.to_string()),
+            InvoiceDescription::Hash(_) => None,
+        },
+        description_hash: match invoice.description() {
+            InvoiceDescription::Direct(_) => None,
+            InvoiceDescription::Hash(h) => Some(h.0.to_string()),
         },
     };
     Ok(ln_invoice)


### PR DESCRIPTION
Part of the LNURL validation is checking the invoice `description_hash`.

Therefore, this PR reads it from the parsed invoice and stores it in our `LNInvoice` as well.