### PR TITLE
Add amount parameter to send_payment for invoices with custom amount

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -173,9 +173,9 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     }
   }
 
-  Future sendPayment(String bolt11, int amountSat) async {
+  Future sendPayment(String bolt11, int? amountSats) async {
     try {
-      await _breezLib.sendPayment(bolt11: bolt11);
+      await _breezLib.sendPayment(bolt11: bolt11, amountSats: amountSats);
     } catch (e) {
       _paymentResultStreamController.add(PaymentResultData(error: e));
       return Future.error(e);

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -66,7 +66,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
       return ProcessingPaymentDialog(
         firstPaymentItemKey: widget.firstPaymentItemKey,
         minHeight: minHeight,
-        paymentFunc: () => context.read<AccountBloc>().sendPayment(widget.invoice.bolt11, _amountToPay!),
+        paymentFunc: () => context.read<AccountBloc>().sendPayment(widget.invoice.bolt11, widget.invoice.amountMsat == 0 ? _amountToPay! : null),
         onStateChange: (state) => _onStateChange(context, state),
       );
     } else if (_state == PaymentRequestState.WAITING_FOR_CONFIRMATION) {


### PR DESCRIPTION
This PR addresses #249 

Invoices without specified amounts could not be paid as custom amount parameter was missing on send_payment binding API. After adding this parameter, we've discovered a missing mapping between custom amount of PayRequest to Pay on Greenlight.

Changes:
- Missing custom amount parameter is now added to binding API send payment function,
- gl-client dependency now targets main branch that includes the fix for this mapping issue,
    - Custom amounts unit was changed to millisatoshi from sats while discovering this issue, can revert this back if requested but it'll need testing to confirm if it's compatible with Greenlight's pay function,
- Custom amount is added to lnurl pay.
