### PR TITLE
Sync after LNURL-pay payment complete

### DIFF
--- a/packages/breez_sdk/rust/src/breez_services.rs
+++ b/packages/breez_sdk/rust/src/breez_services.rs
@@ -176,6 +176,7 @@ impl BreezServices {
             ValidatedCallbackResponse::EndpointError(e) => Ok(LnUrlPayResult::EndpointError(e)),
             ValidatedCallbackResponse::EndpointSuccess(cb) => {
                 self.send_payment(cb.pr).await?;
+                self.sync().await?;
                 Ok(LnUrlPayResult::EndpointSuccess(cb.success_action))
             }
         }


### PR DESCRIPTION
Make sure we call `sync()` after LNURL-pay complete, to pull the latest list of transactions