### PR TITLE
Add ability to "Export Keys"

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -271,9 +271,8 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     return state.toJson();
   }
 
-  // TODO: Export the user keys to a file
-  Future exportKeyFiles(Directory destDir) async {
-    throw Exception("not implemented");
+  Future<String> exportCredentialsFile() async {
+    return _credentialsManager.exportCredentials();
   }
 
   void recursiveFolderCopySync(String path1, String path2) {

--- a/lib/routes/dev/commands.dart
+++ b/lib/routes/dev/commands.dart
@@ -1,6 +1,3 @@
-import 'dart:io';
-
-import 'package:archive/archive_io.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/logger.dart';
 import 'package:c_breez/routes/ui_test/ui_test_page.dart';
@@ -8,7 +5,6 @@ import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:share_extend/share_extend.dart';
 
 import 'commands_list.dart';
@@ -94,22 +90,8 @@ class DevelopersView extends StatelessWidget {
   }
 
   void _exportKeys(BuildContext context) async {
-    var accBloc = context.read<AccountBloc>();
-    Directory tempDir = await getTemporaryDirectory();
-    var keysDir = tempDir.createTempSync("keys");
-    await accBloc.exportKeyFiles(keysDir);
-
-    var encoder = ZipFileEncoder();
-    var zipFilePath = '${tempDir.path}/keys.zip';
-    encoder.create(zipFilePath);
-    keysDir.listSync().forEach((keyFile) {
-      if (keyFile is File) {
-        encoder.addFile(keyFile);
-      } else {
-        encoder.addDirectory(keyFile as Directory);
-      }
-    });
-    encoder.close();
-    ShareExtend.share(zipFilePath, "file");
+    final accBloc = context.read<AccountBloc>();
+    final credentialsFilePath = await accBloc.exportCredentialsFile();
+    ShareExtend.share(credentialsFilePath, "file");
   }
 }


### PR DESCRIPTION
This PR addresses #303 

Credentials are exported as an encoded JSON file and credentials can be constructed from JSON. This enables us to implement the feature to restore from JSON on startup.

_The file format is subject to change to be compatible with CLI._