### PR TITLE
Update BreezBridgeMock with Calculate fee changes

### DIFF
--- a/test/mock/breez_bridge_mock.dart
+++ b/test/mock/breez_bridge_mock.dart
@@ -33,6 +33,7 @@ class BreezBridgeMock extends Mock implements BreezBridge {
     blockHeight: 2,
     channelsBalanceMsat: 0,
     onchainBalanceMsat: 0,
+    utxos: [],
     maxPayableMsat: 0,
     maxReceivableMsat: 0,
     maxSinglePaymentAmountMsat: 0,


### PR DESCRIPTION
Updated BreezBridgeMock to be compatible with with Calculate fee changes introduced in #337 & https://github.com/breez/breez-sdk/pull/49

- [Added utxos field to mock NodeState](https://github.com/breez/c-breez/commit/85dfb699486e29e0dbb2d528b23e7a5245c87ca5)