### PR TITLE
Use singleTask activity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
We move to singleTask instead of singleTop. 
Main difference is that singleTask behaves like a single top with one activity instance and singleTop may create several activity instances.
In the app we are not prepared (and do not want) several instances of the main activity which will result in multiple initializations of the rust sdk.

https://developer.android.com/guide/topics/manifest/activity-element#aff