### PR TITLE
Fix send to btc title

### DIFF
--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -3,6 +3,7 @@ import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/routes/home/widgets/app_bar/warning_action.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -24,7 +25,10 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
           if (walletBalance > 0) {
             warnings.add(
               WarningAction(
-                () => navigatorState.pushNamed("/withdraw_funds"),
+                () => navigatorState.pushNamed("/withdraw_funds",
+                    arguments: const WithdrawFundsArguments(
+                      WithdrawKind.unexpected_funds,
+                    )),
               ),
             );
           }

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,14 +1,14 @@
-import 'package:c_breez/bloc/input/input_bloc.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/input/input_bloc.dart';
 import 'package:c_breez/models/clipboard.dart';
+import 'package:c_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
+import 'package:c_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
 import 'package:c_breez/routes/spontaneous_payment/spontaneous_payment_page.dart';
+import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_page.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/widgets/route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
-import 'bottom_action_item_image.dart';
-import 'enter_payment_info_dialog.dart';
 
 class SendOptionsBottomSheet extends StatelessWidget {
   final bool connected;
@@ -53,7 +53,7 @@ class SendOptionsBottomSheet extends StatelessWidget {
               indent: 72.0,
             ),
             ListTile(
-              enabled: connected,
+              enabled: false, // TODO: back to connected when we integrate with the SDK
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
                 enabled: connected,
@@ -62,7 +62,10 @@ class SendOptionsBottomSheet extends StatelessWidget {
                 texts.bottom_action_bar_send_btc_address,
                 style: theme.bottomSheetTextStyle,
               ),
-              onTap: () => _push(context, "/withdraw_funds"),
+              onTap: () => _push(context, "/withdraw_funds",
+                  arguments: const WithdrawFundsArguments(
+                    WithdrawKind.withdraw_funds,
+                  )),
             ),
             const SizedBox(height: 8.0)
           ],
@@ -106,9 +109,9 @@ class SendOptionsBottomSheet extends StatelessWidget {
     }
   }
 
-  void _push(BuildContext context, String route) {
+  void _push(BuildContext context, String route, {Object? arguments}) {
     final navigatorState = Navigator.of(context);
     navigatorState.pop();
-    navigatorState.pushNamed(route);
+    navigatorState.pushNamed(route, arguments: arguments);
   }
 }

--- a/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
@@ -1,6 +1,6 @@
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/routes/withdraw_funds/bitcoin_address_text_form_field.dart';
 import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_next_button.dart';
 import 'package:c_breez/routes/withdraw_funds/withdraw_funds_available_btc.dart';
@@ -9,9 +9,17 @@ import 'package:c_breez/widgets/warning_box.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+class WithdrawFundsArguments {
+  final WithdrawKind withdrawKind;
+
+  const WithdrawFundsArguments(this.withdrawKind);
+}
+
 class WithdrawFundsAddressPage extends StatefulWidget {
+  final WithdrawFundsArguments arguments;
   const WithdrawFundsAddressPage({
     Key? key,
+    required this.arguments,
   }) : super(key: key);
 
   @override
@@ -31,7 +39,11 @@ class _WithdrawFundsAddressPageState extends State<WithdrawFundsAddressPage> {
       appBar: AppBar(
         leading: const back_button.BackButton(),
         actions: const [],
-        title: Text(texts.unexpected_funds_title),
+        title: Text(
+          widget.arguments.withdrawKind == WithdrawKind.withdraw_funds
+              ? texts.reverse_swap_title
+              : texts.unexpected_funds_title,
+        ),
       ),
       body: Column(
         children: [
@@ -70,4 +82,9 @@ class _WithdrawFundsAddressPageState extends State<WithdrawFundsAddressPage> {
       ),
     );
   }
+}
+
+enum WithdrawKind {
+  withdraw_funds,
+  unexpected_funds,
 }

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -194,8 +194,9 @@ class UserApp extends StatelessWidget {
                                   );
                                 case '/withdraw_funds':
                                   return FadeInRoute(
-                                    builder: (_) =>
-                                        const WithdrawFundsAddressPage(),
+                                    builder: (_) => WithdrawFundsAddressPage(
+                                      arguments: settings.arguments as WithdrawFundsArguments,
+                                    ),
                                     settings: settings,
                                   );
                               }


### PR DESCRIPTION
Send to BTC flow has 2 possible titles, one when the user spontaneously send its sats to a BTC address and another when he needs to refund after a channel closed, this PR I add a way to correctly set the title on send to BTC flow