### PR TITLE
Return generic error message for unexpected errors on lnurlw flow

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -40,12 +40,12 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   Stream<PaymentFilters> get paymentFiltersStream =>
       _paymentFiltersStreamController.stream;
 
-  final BreezBridge _breezLib;  
+  final BreezBridge _breezLib;
   final CredentialsManager _credentialsManager;
 
   AccountBloc(
     this._breezLib,
-    this._credentialsManager,    
+    this._credentialsManager,
   ) : super(AccountState.initial()) {
     // emit on every change
     _watchAccountChanges().listen((acc) => emit(acc));
@@ -117,7 +117,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       required sdk.LnUrlWithdrawRequestData reqData,
       String? description}) async {
     _log.v(
-        "withdrawLnurl amount: $amountSats, description: '$description', reqData: $reqData");
+        "lnurlWithdraw amount: $amountSats, description: '$description', reqData: $reqData");
     try {
       return _breezLib.lnurlWithdraw(
         amountSats: amountSats,
@@ -125,18 +125,17 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
         description: description,
       );
     } catch (e) {
-      _log.e("withdrawLnurl error", ex: e);
+      _log.e("lnurlWithdraw error", ex: e);
       rethrow;
     }
   }
 
-  Future<sdk.LnUrlPayResult> sendLNURLPayment({
+  Future<sdk.LnUrlPayResult> lnurlPay({
     required int amount,
     required sdk.LnUrlPayRequestData reqData,
     String? comment,
   }) async {
-    _log.v(
-        "sendLNURLPayment amount: $amount, comment: '$comment', reqData: $reqData");
+    _log.v("lnurlPay amount: $amount, comment: '$comment', reqData: $reqData");
     try {
       return _breezLib.lnurlPay(
         userAmountSat: amount,
@@ -144,7 +143,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
         comment: comment,
       );
     } catch (e) {
-      _log.e("sendLNURLPayment error", ex: e);
+      _log.e("lnurlPay error", ex: e);
       rethrow;
     }
   }

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -1,9 +1,9 @@
 import 'dart:convert';
 
 import 'package:breez_sdk/bridge_generated.dart' as sdk;
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/models/currency.dart';
 import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
 import 'package:c_breez/utils/fiat_conversion.dart';
@@ -44,9 +44,11 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
     final texts = context.texts();
     final currencyState = context.read<CurrencyBloc>().state;
     final metadataMap = {
-      for (var v in json.decode(widget.requestData.metadataStr)) v[0] as String: v[1],
+      for (var v in json.decode(widget.requestData.metadataStr))
+        v[0] as String: v[1],
     };
-    final description = metadataMap['text/long-desc'] ?? metadataMap['text/plain'];
+    final description =
+        metadataMap['text/long-desc'] ?? metadataMap['text/plain'];
     FiatConversion? fiatConversion;
     if (currencyState.fiatEnabled) {
       fiatConversion = FiatConversion(
@@ -88,8 +90,10 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
               ),
               child: Text(
                 _showFiatCurrency && fiatConversion != null
-                    ? fiatConversion.format(widget.requestData.maxSendable ~/ 1000)
-                    : BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker)
+                    ? fiatConversion
+                        .format(widget.requestData.maxSendable ~/ 1000)
+                    : BitcoinCurrency.fromTickerSymbol(
+                            currencyState.bitcoinTicker)
                         .format(widget.requestData.maxSendable ~/ 1000),
                 style: themeData.primaryTextTheme.headline5,
                 textAlign: TextAlign.center,
@@ -111,7 +115,9 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                       fontSize: 16,
                     ),
                     textAlign:
-                        description.length > 40 && !description.contains("\n") ? TextAlign.start : TextAlign.center,
+                        description.length > 40 && !description.contains("\n")
+                            ? TextAlign.start
+                            : TextAlign.center,
                   ),
                 ),
               ),
@@ -159,7 +165,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
               _log.v("LNURL payment of $amount sats where "
                   "min is ${widget.requestData.minSendable} msats "
                   "and max is ${widget.requestData.maxSendable} mstas.");
-              final resp = await accountBloc.sendLNURLPayment(
+              final resp = await accountBloc.lnurlPay(
                 amount: amount,
                 reqData: widget.requestData,
               );
@@ -175,7 +181,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                   error: resp.data.reason,
                 ));
               } else {
-                _log.w("Unknown response from sendLNURLPayment: $resp");
+                _log.w("Unknown response from lnurlPay: $resp");
                 navigator.pop(LNURLPaymentPageResult(
                   error: texts.lnurl_payment_page_unknown_error,
                 ));

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -193,7 +193,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
               _log.v("LNURL payment of $amount sats where "
                   "min is ${widget.requestData.minSendable} msats "
                   "and max is ${widget.requestData.maxSendable} msats.");
-              final resp = await accountBloc.sendLNURLPayment(
+              final resp = await accountBloc.lnurlPay(
                 amount: amount,
                 comment: comment,
                 reqData: widget.requestData,
@@ -210,7 +210,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                   error: resp.data.reason,
                 ));
               } else {
-                _log.w("Unknown response from sendLNURLPayment: $resp");
+                _log.w("Unknown response from lnurlPay: $resp");
                 navigator.pop(LNURLPaymentPageResult(
                   error: texts.lnurl_payment_page_unknown_error,
                 ));

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -263,11 +263,11 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
               } catch (e) {
                 _log.w("Error withdrawing LNURL payment", ex: e);
                 navigator.removeRoute(loaderRoute);
-                navigator.pop(LNURLWithdrawPageResult(
-                  error: texts.lnurl_withdraw_dialog_error(
-                    extractExceptionMessage(e),
+                navigator.pop(
+                  LNURLWithdrawPageResult(
+                    error: texts.lnurl_withdraw_dialog_error_unknown,
                   ),
-                ));
+                );
               }
             }
           },

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -6,7 +6,6 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/models/currency.dart';
 import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
-import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/utils/fiat_conversion.dart';
 import 'package:c_breez/utils/min_font_size.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
@@ -255,7 +254,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                     error: resp.data.reason,
                   ));
                 } else {
-                  _log.w("Unknown response from sendLNURLPayment: $resp");
+                  _log.w("Unknown response from lnurlWithdraw: $resp");
                   navigator.pop(LNURLWithdrawPageResult(
                     error: texts.lnurl_payment_page_unknown_error,
                   ));


### PR DESCRIPTION
This PR addresses https://github.com/breez/c-breez/issues/374

A generic error message "Failed to receive funds" is shown for unexpected errors thrown during lnurl withdraw flow.