### PR TITLE
Separate start from init/recover/register

### DIFF
--- a/lib/bloc/account/account_state.dart
+++ b/lib/bloc/account/account_state.dart
@@ -3,7 +3,7 @@ import 'package:c_breez/bloc/account/payment_filters.dart';
 
 const initialInboundCapacity = 4000000;
 
-enum ConnectionStatus { CONNECTING, CONNECTED }
+enum ConnectionStatus { CONNECTING, CONNECTED, DISCONNECTED }
 
 class AccountState {
   final String? id;


### PR DESCRIPTION
The _init_ can only run once (and is promised to succeed). This is not the case with _start_ method, so in case we need to recover from a failed start we need to call start again in a later time. This PR decouple these two functions and also makes sure we call start once internet connection is restored.
depends on https://github.com/breez/breez-sdk/pull/71
fixes #415 
fixes #416 