### PR TITLE
Wait for initial node state before selecting lsp

### DIFF
--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -131,7 +131,7 @@ class AccountPage extends StatelessWidget {
             builder: (context, shrinkedHeight, overlapContent) {
               return BlocBuilder<LSPBloc, LspState?>(builder: (context, lspState) {
                 var isConnecting = account.status == ConnectionStatus.CONNECTING;
-                if (!isConnecting && lspState?.lspInfo == null) {
+                if (!isConnecting && lspState != null && lspState.selectedLspId == null) {
                   return const Padding(
                     padding: EdgeInsets.only(top: 120.0),
                     child: NoLSPWidget(),

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -33,7 +33,7 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
             );
           }
 
-          if (accState.status != ConnectionStatus.CONNECTING && lspState?.selectedLspId == null) {
+          if (accState.status != ConnectionStatus.CONNECTING && lspState != null && lspState.selectedLspId == null) {
             warnings.add(WarningAction(() {
               navigatorState.pushNamed("/select_lsp");
             }));


### PR DESCRIPTION
The lsp state is intialized when the node info is pushed from the sdk. We wait for this info before we emit the lsp state.
Ignoring null state in the UI ensures that we only consider a real state which prevents showing the LSP selection in cases where LSP is already selected.

Fixed #385