### PR TITLE
Revise avatar icon logic

### DIFF
--- a/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
@@ -19,7 +19,9 @@ class PaymentItemAvatar extends StatelessWidget {
         radius: radius,
         backgroundColor: Colors.white,
         child: Icon(
-          paymentItem.paymentType == PaymentType.Received ? Icons.add_rounded : Icons.remove_rounded,
+          paymentItem.paymentType == PaymentType.Received
+              ? Icons.add_rounded
+              : Icons.remove_rounded,
           color: const Color(0xb3303234),
         ),
       );
@@ -29,5 +31,14 @@ class PaymentItemAvatar extends StatelessWidget {
     }
   }
 
-  bool get _shouldShowLeadingIcon => paymentItem.details is LnPaymentDetails &&  (paymentItem.details as LnPaymentDetails).keysend;
+  bool get _shouldShowLeadingIcon {
+    final hasDescription = (paymentItem.description != null &&
+        paymentItem.description!.isNotEmpty);
+    final details = paymentItem.details.data;
+    final isKeySend = (details is LnPaymentDetails) ? details.keysend : false;
+    final isClosedChannelPayment =
+        paymentItem.paymentType == PaymentType.ClosedChannel;
+
+    return hasDescription || isKeySend || isClosedChannelPayment;
+  }
 }


### PR DESCRIPTION
Addresses https://github.com/breez/c-breez/issues/414

Display +/- icons when payment item 
- has description or
- is sent with keysend or
- is a channel close payment