### PR TITLE
change app name to Cloud Breez #390

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.NFC"/>  <!-- Deep links -->
 
     <application
-        android:label="c_breez"
+        android:label="Breez Cloud"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>C Breez</string>
+	<string>Breez Cloud</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This PR references issue #390. 

The app now displays Cloud Breez when installed on device. 
![Cloud Breez](https://user-images.githubusercontent.com/36157890/214239855-794fcb89-1c02-4eea-88e0-421da9259e67.png)


Please let me know if this name change is sufficient or if the scope for the renaming is larger?