### PR TITLE
Notify PaymentItem when FlipTransition finishes

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -63,7 +63,7 @@ PODS:
     - Flutter
   - flutter_secure_storage (6.0.0):
     - Flutter
-  - GoogleDataTransport (9.2.0):
+  - GoogleDataTransport (9.2.1):
     - GoogleUtilities/Environment (~> 7.7)
     - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
@@ -142,8 +142,9 @@ PODS:
   - OrderedSet (5.0.0)
   - package_info_plus (0.4.5):
     - Flutter
-  - path_provider_ios (0.0.1):
+  - path_provider_foundation (0.0.1):
     - Flutter
+    - FlutterMacOS
   - PromisesObjC (2.1.1)
   - Protobuf (3.21.12)
   - ReachabilitySwift (5.0.0)
@@ -191,7 +192,7 @@ DEPENDENCIES:
   - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_ios (from `.symlinks/plugins/path_provider_ios/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
@@ -259,8 +260,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/mobile_scanner/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
-  path_provider_ios:
-    :path: ".symlinks/plugins/path_provider_ios/ios"
+  path_provider_foundation:
+    :path: ".symlinks/plugins/path_provider_foundation/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
@@ -291,7 +292,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview: 4fe74e5e65809c3d363febfd9e2b21aa79bb0f1c
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
-  GoogleDataTransport: 1c8145da7117bd68bbbed00cf304edb6a24de00f
+  GoogleDataTransport: ea169759df570f4e37bdee1623ec32a7e64e67c4
   GoogleMLKit: 0017a6a8372e1a182139b9def4d89be5d87ca5a7
   GoogleToolboxForMac: 8bef7c7c5cf7291c687cf5354f39f9db6399ad34
   GoogleUtilities: c2bdc4cf2ce786c4d2e6b3bcfd599a25ca78f06f
@@ -308,7 +309,7 @@ SPEC CHECKSUMS:
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
-  path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
+  path_provider_foundation: 37748e03f12783f9de2cb2c4eadfaa25fe6d4852
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
   Protobuf: 120350fc38646e2dedc26f49ecba778184ea1de2
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825

--- a/lib/routes/home/widgets/payments_list/flip_transition.dart
+++ b/lib/routes/home/widgets/payments_list/flip_transition.dart
@@ -7,12 +7,14 @@ class FlipTransition extends StatefulWidget {
   final Widget firstChild;
   final Widget secondChild;
   final double radius;
+  final Function() onComplete;
 
   const FlipTransition(
     this.firstChild,
     this.secondChild, {
     Key? key,
     required this.radius,
+    required this.onComplete,
   }) : super(key: key);
 
   @override
@@ -41,7 +43,9 @@ class FlipTransitionState extends State<FlipTransition>
         _flipAnimationController!.reverse();
       }
     });
-    _flipAnimationController!.forward();
+    _flipAnimationController!.forward().whenCompleteOrCancel(() {
+      widget.onComplete();
+    });
   }
 
   @override

--- a/lib/routes/home/widgets/payments_list/payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item.dart
@@ -9,7 +9,7 @@ import 'package:c_breez/routes/home/widgets/payments_list/success_avatar.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
 
-class PaymentItem extends StatelessWidget {
+class PaymentItem extends StatefulWidget {
   final Payment _paymentInfo;
   final bool _firstItem;
   final GlobalKey firstPaymentItemKey;
@@ -20,6 +20,19 @@ class PaymentItem extends StatelessWidget {
     this.firstPaymentItemKey, {
     Key? key,
   }) : super(key: key);
+
+  @override
+  State<PaymentItem> createState() => _PaymentItemState();
+}
+
+class _PaymentItemState extends State<PaymentItem> {
+  late bool isPaymentItemNew;
+
+  @override
+  void initState() {
+    super.initState();
+    isPaymentItemNew = _createdWithin(const Duration(seconds: 15));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -35,8 +48,9 @@ class PaymentItem extends StatelessWidget {
               ListTile(
                 leading: Container(
                   height: 72.0,
-                  decoration: _createdWithin(const Duration(seconds: 10))
-                      ? BoxDecoration(
+                  decoration: isPaymentItemNew
+                      ? null
+                      : BoxDecoration(
                           color: Colors.white,
                           shape: BoxShape.circle,
                           boxShadow: [
@@ -46,29 +60,33 @@ class PaymentItem extends StatelessWidget {
                               blurRadius: 5.0,
                             ),
                           ],
-                        )
-                      : null,
-                  child: _createdWithin(const Duration(seconds: 10))
-                      ? PaymentItemAvatar(_paymentInfo, radius: 16)
-                      : FlipTransition(
+                        ),
+                  child: isPaymentItemNew
+                      ? FlipTransition(
                           PaymentItemAvatar(
-                            _paymentInfo,
+                            widget._paymentInfo,
                             radius: 16,
                           ),
                           const SuccessAvatar(radius: 16),
                           radius: 16,
-                        ),
+                          onComplete: () {
+                            setState(() {
+                              isPaymentItemNew = false;
+                            });
+                          },
+                        )
+                      : PaymentItemAvatar(widget._paymentInfo, radius: 16),
                 ),
-                key: _firstItem ? firstPaymentItemKey : null,
+                key: widget._firstItem ? widget.firstPaymentItemKey : null,
                 title: Transform.translate(
                   offset: const Offset(-8, 0),
-                  child: PaymentItemTitle(_paymentInfo),
+                  child: PaymentItemTitle(widget._paymentInfo),
                 ),
                 subtitle: Transform.translate(
                   offset: const Offset(-8, 0),
-                  child: PaymentItemSubtitle(_paymentInfo),
+                  child: PaymentItemSubtitle(widget._paymentInfo),
                 ),
-                trailing: PaymentItemAmount(_paymentInfo),
+                trailing: PaymentItemAmount(widget._paymentInfo),
                 onTap: () => _showDetail(context),
               ),
             ],
@@ -80,16 +98,16 @@ class PaymentItem extends StatelessWidget {
 
   bool _createdWithin(Duration duration) {
     final diff = DateTime.fromMillisecondsSinceEpoch(
-      _paymentInfo.paymentTime * 1000,
+      widget._paymentInfo.paymentTime * 1000,
     ).difference(
       DateTime.fromMillisecondsSinceEpoch(
         DateTime.now().millisecondsSinceEpoch,
       ),
     );
-    return diff < -duration;
+    return diff > -duration;
   }
 
   void _showDetail(BuildContext context) {
-    showPaymentDetailsDialog(context, _paymentInfo);
+    showPaymentDetailsDialog(context, widget._paymentInfo);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -828,7 +828,7 @@ packages:
       name: local_auth_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   logging:
     dependency: transitive
     description:
@@ -947,7 +947,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   path_provider_android:
     dependency: transitive
     description:
@@ -955,13 +955,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.22"
-  path_provider_ios:
+  path_provider_foundation:
     dependency: transitive
     description:
-      name: path_provider_ios
+      name: path_provider_foundation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.1.0"
   path_provider_linux:
     dependency: transitive
     description:
@@ -969,13 +969,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.7"
-  path_provider_macos:
-    dependency: transitive
-    description:
-      name: path_provider_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.7"
   path_provider_platform_interface:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dependencies:
   mobile_scanner: ^2.1.0
   package_info_plus: ^3.0.2
   path: ^1.8.3
-  path_provider: ^2.0.11
+  path_provider: ^2.0.12
   path_provider_platform_interface: ^2.0.5
   plugin_platform_interface: ^2.1.3
   qr_flutter: ^4.0.0


### PR DESCRIPTION
Fixes https://github.com/breez/c-breez/issues/404

- PaymentItem converted to StatefulWidget
- FlipTransition notifies PaymentItem when it's animation has completed to switch states,
- _createdWithin's return value now reflects it's name, previously it checked if it was not created within the duration


#### Known Issues:
- New item added to PaymentsList doesn't force rebuild,
   - The solution introduced in this PR will be obsolete if this is caused by a state management issue.
- There's a small delay after payment completion waiting for sync operations to finish, if this delay exceeds 10 seconds, the animation won't run.