### PR TITLE
Flutter 3.7 changes

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -209,6 +209,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -240,6 +241,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -96,5 +96,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/handlers/connectivity_handler.dart
+++ b/lib/handlers/connectivity_handler.dart
@@ -41,7 +41,7 @@ class ConnectivityHandler {
       icon: Icon(
         Icons.warning_amber_outlined,
         size: 28.0,
-        color: Theme.of(context).errorColor,
+        color: Theme.of(context).colorScheme.error,
       ),
       messageText: Text(
         texts.no_connection_flushbar_title,
@@ -59,7 +59,7 @@ class ConnectivityHandler {
                     height: 24.0,
                     width: 24.0,
                     child: CircularProgressIndicator(
-                      color: Theme.of(context).errorColor,
+                      color: Theme.of(context).colorScheme.error,
                     ),
                   ),
                 );
@@ -82,7 +82,7 @@ class ConnectivityHandler {
                 child: Text(
                   texts.no_connection_flushbar_action_retry,
                   style: theme.snackBarStyle.copyWith(
-                    color: Theme.of(context).errorColor,
+                    color: Theme.of(context).colorScheme.error,
                   ),
                 ),
               );

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -40,11 +40,12 @@ class PaymentResultHandler {
     SuccessActionData successActionData,
   ) async {
     // Artificial delay for UX purposes
-    await Future.delayed(const Duration(seconds: 1));
-    return await showDialog(
-      useRootNavigator: false,
-      context: context,
-      builder: (_) => SuccessActionDialog(successActionData),
+    return Future.delayed(const Duration(seconds: 1)).then(
+      (_) => showDialog(
+        useRootNavigator: false,
+        context: context,
+        builder: (_) => SuccessActionDialog(successActionData),
+      ),
     );
   }
 }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -185,7 +185,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
       padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 8),
       child: Text(
         displayErrorMessage,
-        style: themeData.primaryTextTheme.headline3!.copyWith(fontSize: 16),
+        style: themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
       ),
     );
   }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -177,7 +177,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                   valueColor: AlwaysStoppedAnimation<Color>(
                     themeData.primaryTextTheme.button!.color!,
                   ),
-                  backgroundColor: themeData.backgroundColor,
+                  backgroundColor: themeData.colorScheme.background,
                 ),
               )));
     }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -218,7 +218,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
       child: Text(
         texts.qr_code_dialog_warning_message,
         textAlign: TextAlign.center,
-        style: Theme.of(context).primaryTextTheme.caption,
+        style: Theme.of(context).primaryTextTheme.bodySmall,
       ),
     );
   }

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -96,7 +96,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                         highlightColor: Colors.transparent,
                         padding: const EdgeInsets.only(top: 8.0, bottom: 8.0, right: 2.0, left: 14.0),
                         icon: const Icon(IconData(0xe917, fontFamily: 'icomoon')),
-                        color: Theme.of(context).primaryTextTheme.button!.color!,
+                        color: Theme.of(context).primaryTextTheme.labelLarge!.color!,
                         onPressed: () {
                           Share.share("lightning:${widget._invoice!.bolt11}");
                         },
@@ -109,7 +109,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                         highlightColor: Colors.transparent,
                         padding: const EdgeInsets.only(top: 8.0, bottom: 8.0, right: 14.0, left: 2.0),
                         icon: const Icon(IconData(0xe90b, fontFamily: 'icomoon')),
-                        color: Theme.of(context).primaryTextTheme.button!.color!,
+                        color: Theme.of(context).primaryTextTheme.labelLarge!.color!,
                         onPressed: () {
                           ServiceInjector().device.setClipboardText(widget._invoice!.bolt11);
                           showFlushbar(
@@ -175,7 +175,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
                 width: 80.0,
                 child: CircularProgressIndicator(
                   valueColor: AlwaysStoppedAnimation<Color>(
-                    themeData.primaryTextTheme.button!.color!,
+                    themeData.primaryTextTheme.labelLarge!.color!,
                   ),
                   backgroundColor: themeData.colorScheme.background,
                 ),
@@ -231,7 +231,7 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
       }),
       child: Text(
         texts.qr_code_dialog_action_close,
-        style: Theme.of(context).primaryTextTheme.button,
+        style: Theme.of(context).primaryTextTheme.labelLarge,
       ),
     );
   }

--- a/lib/routes/create_invoice/widgets/successful_payment.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment.dart
@@ -101,7 +101,7 @@ class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute>
         Text(
           texts.successful_payment_received,
           textAlign: TextAlign.center,
-          style: themeData.primaryTextTheme.headline4!.copyWith(fontSize: 16),
+          style: themeData.primaryTextTheme.headlineMedium!.copyWith(fontSize: 16),
         ),
         Padding(
           padding: const EdgeInsets.only(top: 20, bottom: 40),

--- a/lib/routes/dev/commands.dart
+++ b/lib/routes/dev/commands.dart
@@ -51,7 +51,7 @@ class DevelopersView extends StatelessWidget {
                   value: choice,
                   child: Text(
                     choice.title,
-                    style: themeData.textTheme.button,
+                    style: themeData.textTheme.labelLarge,
                   ),
                 );
               }).toList();

--- a/lib/routes/dev/commands.dart
+++ b/lib/routes/dev/commands.dart
@@ -40,7 +40,7 @@ class DevelopersView extends StatelessWidget {
         actions: [
           PopupMenuButton<Choice>(
             onSelected: (c) => c.function(context),
-            color: themeData.backgroundColor,
+            color: themeData.colorScheme.background,
             icon: Icon(
               Icons.more_vert,
               color: themeData.iconTheme.color,

--- a/lib/routes/dev/commands_list.dart
+++ b/lib/routes/dev/commands_list.dart
@@ -262,7 +262,7 @@ class Category extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(name, style: Theme.of(context).textTheme.headline6);
+    return Text(name, style: Theme.of(context).textTheme.titleLarge);
   }
 }
 

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -58,11 +58,12 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
           ),
         ),
         hintColor: themeData.dialogTheme.contentTextStyle!.color!,
+        primaryColor: themeData.textTheme.labelLarge!.color,
         colorScheme: ColorScheme.dark(
           primary: themeData.textTheme.labelLarge!.color!,
+          error:
+              themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
         ),
-        primaryColor: themeData.textTheme.labelLarge!.color,
-        errorColor: themeData.isLightTheme ? Colors.red : themeData.errorColor,
       ),
       child: SizedBox(
         width: MediaQuery.of(context).size.width,

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -94,7 +94,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
                   focusNode: _paymentInfoFocusNode,
                   controller: _paymentInfoController,
                   style: TextStyle(
-                    color: themeData.primaryTextTheme.headline4!.color,
+                    color: themeData.primaryTextTheme.headlineMedium!.color,
                   ),
                   validator: (v) {
                     var value = v!;

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -59,9 +59,9 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
         ),
         hintColor: themeData.dialogTheme.contentTextStyle!.color!,
         colorScheme: ColorScheme.dark(
-          primary: themeData.textTheme.button!.color!,
+          primary: themeData.textTheme.labelLarge!.color!,
         ),
-        primaryColor: themeData.textTheme.button!.color,
+        primaryColor: themeData.textTheme.labelLarge!.color,
         errorColor: themeData.isLightTheme ? Colors.red : themeData.errorColor,
       ),
       child: SizedBox(
@@ -143,7 +143,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
         onPressed: () => Navigator.pop(context),
         child: Text(
           texts.payment_info_dialog_action_cancel,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
       )
     ];
@@ -160,7 +160,7 @@ class EnterPaymentInfoDialogState extends State<EnterPaymentInfoDialog> {
           }),
           child: Text(
             texts.payment_info_dialog_action_approve,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
       );

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -73,7 +73,7 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
                           removeTrailingZeros: true,
                         ),
                       ),
-                      maxFontSize: themeData.textTheme.subtitle1!.fontSize!,
+                      maxFontSize: themeData.textTheme.titleMedium!.fontSize!,
                       style: themeData.textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -74,7 +74,7 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
                         ),
                       ),
                       maxFontSize: themeData.textTheme.subtitle1!.fontSize!,
-                      style: themeData.textTheme.headline6,
+                      style: themeData.textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   ),

--- a/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
+++ b/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
@@ -313,7 +313,7 @@ class AvatarSpinner extends StatelessWidget {
           valueColor: AlwaysStoppedAnimation<Color>(
             themeData.primaryTextTheme.button!.color!,
           ),
-          backgroundColor: themeData.backgroundColor,
+          backgroundColor: themeData.colorScheme.background,
         ),
       ),
     );

--- a/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
+++ b/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
@@ -74,12 +74,12 @@ class BreezAvatarDialogState extends State<BreezAvatarDialog> {
             content: SingleChildScrollView(
               child: Theme(
                 data: ThemeData(
-                  primaryColor: themeData.primaryTextTheme.bodyText2!.color,
-                  hintColor: themeData.primaryTextTheme.bodyText2!.color,
+                  primaryColor: themeData.primaryTextTheme.bodyMedium!.color,
+                  hintColor: themeData.primaryTextTheme.bodyMedium!.color,
                 ),
                 child: TextField(
                   enabled: !isUploading,
-                  style: themeData.primaryTextTheme.bodyText2,
+                  style: themeData.primaryTextTheme.bodyMedium,
                   controller: nameInputController,
                   decoration: InputDecoration(
                     hintText: texts.breez_avatar_dialog_your_name,

--- a/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
+++ b/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
@@ -93,7 +93,7 @@ class BreezAvatarDialogState extends State<BreezAvatarDialog> {
                 onPressed: isUploading ? null : () => navigator.pop(),
                 child: Text(
                   texts.breez_avatar_dialog_action_cancel,
-                  style: themeData.primaryTextTheme.button,
+                  style: themeData.primaryTextTheme.labelLarge,
                 ),
               ),
               TextButton(
@@ -104,7 +104,7 @@ class BreezAvatarDialogState extends State<BreezAvatarDialog> {
                       },
                 child: Text(
                   texts.breez_avatar_dialog_action_save,
-                  style: themeData.primaryTextTheme.button,
+                  style: themeData.primaryTextTheme.labelLarge,
                 ),
               ),
             ],
@@ -311,7 +311,7 @@ class AvatarSpinner extends StatelessWidget {
         aspectRatio: 1,
         child: CircularProgressIndicator(
           valueColor: AlwaysStoppedAnimation<Color>(
-            themeData.primaryTextTheme.button!.color!,
+            themeData.primaryTextTheme.labelLarge!.color!,
           ),
           backgroundColor: themeData.colorScheme.background,
         ),

--- a/lib/routes/home/widgets/drawer/breez_drawer_header.dart
+++ b/lib/routes/home/widgets/drawer/breez_drawer_header.dart
@@ -28,7 +28,7 @@ class BreezDrawerHeader extends DrawerHeader {
         duration: duration,
         curve: curve,
         child: DefaultTextStyle(
-          style: theme.textTheme.headline4!,
+          style: theme.textTheme.headlineMedium!,
           child: MediaQuery.removePadding(
             context: context,
             removeTop: true,

--- a/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
+++ b/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
@@ -49,12 +49,12 @@ class DrawerItemConfigGroup {
   });
 }
 
-class NavigationDrawer extends StatelessWidget {
+class BreezNavigationDrawer extends StatelessWidget {
   final List<DrawerItemConfigGroup> _drawerGroupedItems;
   final void Function(String screenName) _onItemSelected;
   final _scrollController = ScrollController();
 
-  NavigationDrawer(
+  BreezNavigationDrawer(
     this._drawerGroupedItems,
     this._onItemSelected, {
     Key? key,

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -11,7 +11,7 @@ import 'package:c_breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'navigation_drawer.dart';
+import 'breez_navigation_drawer.dart';
 
 const _kActiveAccountRoutes = [
   "/connect_to_pay",
@@ -67,7 +67,7 @@ class HomeDrawerState extends State<HomeDrawer> {
   ) {
     final texts = context.texts();
 
-    return NavigationDrawer(
+    return BreezNavigationDrawer(
       [
         if (refundables != null && refundables.isNotEmpty) ...[
           DrawerItemConfigGroup(

--- a/lib/routes/home/widgets/no_lsp_widget.dart
+++ b/lib/routes/home/widgets/no_lsp_widget.dart
@@ -37,7 +37,7 @@ class NoLSPWidget extends StatelessWidget {
                     borderRadius: BorderRadius.circular(6.0),
                   ),
                   side: BorderSide(
-                    color: themeData.textTheme.button!.color!,
+                    color: themeData.textTheme.labelLarge!.color!,
                     style: BorderStyle.solid,
                   ),
                 ),
@@ -45,7 +45,7 @@ class NoLSPWidget extends StatelessWidget {
                   texts.no_lsp_widget_action_select,
                   style: TextStyle(
                     fontSize: 12.3,
-                    color: themeData.textTheme.button!.color!,
+                    color: themeData.textTheme.labelLarge!.color!,
                   ),
                 ),
                 onPressed: () => Navigator.of(context).pushNamed("/select_lsp"),

--- a/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
+++ b/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
@@ -71,7 +71,7 @@ class CalendarDialogState extends State<CalendarDialog> {
         TextButton(
           child: Text(
             texts.pos_transactions_range_dialog_apply,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
           onPressed: () => _applyFilter(context),
         ),

--- a/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
+++ b/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
@@ -63,8 +63,9 @@ class CalendarDialogState extends State<CalendarDialog> {
           child: Text(
             texts.pos_transactions_range_dialog_clear,
             style: theme.cancelButtonStyle.copyWith(
-              color:
-                  themeData.isLightTheme ? Colors.red : themeData.errorColor,
+              color: themeData.isLightTheme
+                  ? Colors.red
+                  : themeData.colorScheme.error,
             ),
           ),
         ),

--- a/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
+++ b/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
@@ -110,7 +110,7 @@ class CalendarDialogState extends State<CalendarDialog> {
         data: themeData.isLightTheme
             ? themeData
             : themeData.copyWith(
-                disabledColor: themeData.backgroundColor,
+                disabledColor: themeData.colorScheme.background,
               ),
         child: TextField(
           decoration: InputDecoration(

--- a/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
@@ -30,7 +30,7 @@ class PaymentsFilterDropdown extends StatelessWidget {
           child: DropdownButton(
             value: filter,
             iconEnabledColor: foregroundColor,
-            style: themeData.textTheme.subtitle2?.copyWith(
+            style: themeData.textTheme.titleSmall?.copyWith(
               color: foregroundColor,
             ),
             items: [
@@ -43,7 +43,7 @@ class PaymentsFilterDropdown extends StatelessWidget {
                 child: Material(
                   child: Text(
                     value,
-                    style: themeData.textTheme.subtitle2?.copyWith(
+                    style: themeData.textTheme.titleSmall?.copyWith(
                       color: foregroundColor,
                     ),
                   ),

--- a/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
@@ -53,7 +53,7 @@ class _PaymentsFilterSliverState extends State<PaymentsFilterSliver> {
         builder: (context, height, overlapContent) {
           return Container(
             color: themeData.isLightTheme
-                ? themeData.backgroundColor
+                ? themeData.colorScheme.background
                 : themeData.canvasColor,
             child: Padding(
               padding: const EdgeInsets.fromLTRB(8, 0, 8, 8),

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
@@ -52,7 +52,7 @@ class PaymentDetailsAmount extends StatelessWidget {
                   paymentInfo.paymentType == PaymentType.Received
                       ? texts.payment_details_dialog_amount_positive(amountSats)
                       : texts.payment_details_dialog_amount_negative(amountSats),
-                  style: themeData.primaryTextTheme.headline3,
+                  style: themeData.primaryTextTheme.displaySmall,
                   textAlign: TextAlign.right,
                   maxLines: 1,
                   group: valueAutoSizeGroup,

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_amount.dart
@@ -34,7 +34,7 @@ class PaymentDetailsAmount extends StatelessWidget {
             padding: const EdgeInsets.only(right: 8.0),
             child: AutoSizeText(
               texts.payment_details_dialog_amount_title,
-              style: themeData.primaryTextTheme.headline4,
+              style: themeData.primaryTextTheme.headlineMedium,
               textAlign: TextAlign.left,
               maxLines: 1,
               group: labelAutoSizeGroup,

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
@@ -48,7 +48,7 @@ class PaymentDetailsDialogDate extends StatelessWidget {
                     paymentInfo.paymentTime * 1000,
                   ),
                 ),
-                style: themeData.primaryTextTheme.headline3,
+                style: themeData.primaryTextTheme.displaySmall,
                 textAlign: TextAlign.right,
                 maxLines: 1,
                 group: valueAutoSizeGroup,

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_date.dart
@@ -31,7 +31,7 @@ class PaymentDetailsDialogDate extends StatelessWidget {
             padding: const EdgeInsets.only(right: 8.0),
             child: AutoSizeText(
               texts.payment_details_dialog_date_and_time,
-              style: themeData.primaryTextTheme.headline4,
+              style: themeData.primaryTextTheme.headlineMedium,
               textAlign: TextAlign.left,
               maxLines: 1,
               group: labelAutoSizeGroup,

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
@@ -30,7 +30,7 @@ class PaymentDetailsDialogDescription extends StatelessWidget {
           child: SingleChildScrollView(
             child: AutoSizeText(
               description,
-              style: themeData.primaryTextTheme.headline4,
+              style: themeData.primaryTextTheme.headlineMedium,
               textAlign: description.length > 40 && !description.contains("\n") ? TextAlign.start : TextAlign.center,
             ),
           ),

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
@@ -32,7 +32,7 @@ class PaymentDetailsDialogExpiration extends StatelessWidget {
             padding: const EdgeInsets.only(right: 8.0),
             child: AutoSizeText(
               texts.payment_details_dialog_expiration,
-              style: themeData.primaryTextTheme.headline4,
+              style: themeData.primaryTextTheme.headlineMedium,
               textAlign: TextAlign.left,
               maxLines: 1,
               group: labelAutoSizeGroup,

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -23,7 +23,7 @@ class ShareablePaymentRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);
-    final color = themeData.primaryTextTheme.button!.color!;
+    final color = themeData.primaryTextTheme.labelLarge!.color!;
 
     return Theme(
       data: themeData.copyWith(

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -27,7 +27,7 @@ class ShareablePaymentRow extends StatelessWidget {
 
     return Theme(
       data: themeData.copyWith(
-        dividerColor: themeData.backgroundColor,
+        dividerColor: themeData.colorScheme.background,
       ),
       child: ExpansionTile(
         iconColor: color,

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -51,7 +51,7 @@ class ShareablePaymentRow extends StatelessWidget {
                     textAlign: TextAlign.left,
                     overflow: TextOverflow.clip,
                     maxLines: 4,
-                    style: themeData.primaryTextTheme.headline3!.copyWith(fontSize: 10),
+                    style: themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 10),
                   ),
                 ),
               ),

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -34,7 +34,7 @@ class ShareablePaymentRow extends StatelessWidget {
         collapsedIconColor: color,
         title: AutoSizeText(
           title,
-          style: themeData.primaryTextTheme.headline4,
+          style: themeData.primaryTextTheme.headlineMedium,
           maxLines: 1,
           group: labelAutoSizeGroup,
         ),

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -24,7 +24,7 @@ class StatusText extends StatelessWidget {
 
       return AutoSizeText(
         texts.status_text_ready,
-        style: themeData.textTheme.bodyText2?.copyWith(
+        style: themeData.textTheme.bodyMedium?.copyWith(
           color: themeData.colorScheme.onSecondary,
         ),
         textAlign: TextAlign.center,

--- a/lib/routes/initial_walkthrough/beta_warning_dialog.dart
+++ b/lib/routes/initial_walkthrough/beta_warning_dialog.dart
@@ -40,7 +40,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
             onPressed: () => exit(0),
             child: Text(
               texts.alpha_warning_action_exit,
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
           ),
           TextButton(
@@ -55,7 +55,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
             }),
             child: Text(
               texts.alpha_warning_action_continue,
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
           ),
         ],
@@ -83,7 +83,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
           children: [
             Theme(
               data: themeData.copyWith(
-                unselectedWidgetColor: themeData.textTheme.button!.color,
+                unselectedWidgetColor: themeData.textTheme.labelLarge!.color,
               ),
               child: Checkbox(
                 activeColor: themeData.canvasColor,

--- a/lib/routes/initial_walkthrough/beta_warning_dialog.dart
+++ b/lib/routes/initial_walkthrough/beta_warning_dialog.dart
@@ -72,7 +72,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
         padding: const EdgeInsets.only(left: 15.0, right: 12.0),
         child: Text(
           texts.alpha_warning_message,
-          style: themeData.primaryTextTheme.headline3!.copyWith(
+          style: themeData.primaryTextTheme.displaySmall!.copyWith(
             fontSize: 16,
           ),
         ),
@@ -97,7 +97,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
             ),
             Text(
               texts.alpha_warning_understand,
-              style: themeData.primaryTextTheme.headline3!.copyWith(
+              style: themeData.primaryTextTheme.displaySmall!.copyWith(
                 fontSize: 16,
               ),
             ),
@@ -110,7 +110,7 @@ class AlphaWarningDialogState extends State<AlphaWarningDialog> {
           padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 0.0),
           child: Text(
             texts.alpha_warning_understand_confirmation,
-            style: themeData.primaryTextTheme.headline3!
+            style: themeData.primaryTextTheme.displaySmall!
                 .copyWith(
                   fontSize: 16,
                 )

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -111,7 +111,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
                     ),
                     child: Text(
                       texts.initial_walk_through_lets_breeze,
-                      style: themeData.textTheme.button,
+                      style: themeData.textTheme.labelLarge,
                     ),
                     onPressed: () => _letsBreez(context),
                   ),

--- a/lib/routes/initial_walkthrough/mnemonics/verify_mnemonic_seed_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/verify_mnemonic_seed_page.dart
@@ -84,7 +84,7 @@ class VerifyMnemonicSeedPageState extends State<VerifyMnemonicSeedPage> {
                 errorText: _hasError
                     ? Text(
                         texts.backup_phrase_generation_verification_failed,
-                        style: themeData.textTheme.headline4?.copyWith(
+                        style: themeData.textTheme.headlineMedium?.copyWith(
                           fontSize: 12,
                         ),
                       )
@@ -92,7 +92,7 @@ class VerifyMnemonicSeedPageState extends State<VerifyMnemonicSeedPage> {
                 registrationFailedText: _registrationFailed
                     ? Text(
                         _registrationErrorMessage,
-                        style: themeData.textTheme.headline4?.copyWith(
+                        style: themeData.textTheme.headlineMedium?.copyWith(
                           fontSize: 12,
                         ),
                       )

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form_page.dart
@@ -57,7 +57,7 @@ class RestoreFormPageState extends State<RestoreFormPage> {
             padding: const EdgeInsets.only(left: 16, right: 16),
             child: Text(
               texts.enter_backup_phrase_error,
-              style: themeData.textTheme.headline4?.copyWith(
+              style: themeData.textTheme.headlineMedium?.copyWith(
                 fontSize: 12,
               ),
             ),

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -60,7 +60,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
     return AlertDialog(
       title: Text(
         widget.domain,
-        style: themeData.primaryTextTheme.headline4!.copyWith(fontSize: 16),
+        style: themeData.primaryTextTheme.headlineMedium!.copyWith(fontSize: 16),
         textAlign: TextAlign.center,
       ),
       content: Column(

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -133,7 +133,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                 return Colors.transparent;
               }
               // Defer to the widget's default.
-              return themeData.textTheme.button!.color!;
+              return themeData.textTheme.labelLarge!.color!;
             }),
           ),
           onPressed: () {
@@ -141,7 +141,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
           },
           child: Text(
             texts.payment_request_dialog_action_cancel,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
         TextButton(
@@ -151,7 +151,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                 return Colors.transparent;
               }
               // Defer to the widget's default.
-              return themeData.textTheme.button!.color!;
+              return themeData.textTheme.labelLarge!.color!;
             }),
           ),
           onPressed: () async {
@@ -194,7 +194,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
           },
           child: Text(
             texts.spontaneous_payment_action_pay,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
       ],

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -95,7 +95,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                     : BitcoinCurrency.fromTickerSymbol(
                             currencyState.bitcoinTicker)
                         .format(widget.requestData.maxSendable ~/ 1000),
-                style: themeData.primaryTextTheme.headline5,
+                style: themeData.primaryTextTheme.headlineSmall,
                 textAlign: TextAlign.center,
               ),
             ),

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -69,7 +69,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
         children: [
           Text(
             texts.payment_request_dialog_requesting,
-            style: themeData.primaryTextTheme.headline3!.copyWith(fontSize: 16),
+            style: themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
             textAlign: TextAlign.center,
           ),
           GestureDetector(
@@ -111,7 +111,7 @@ class LNURLPaymentDialogState extends State<LNURLPaymentDialog> {
                 child: SingleChildScrollView(
                   child: Text(
                     description,
-                    style: themeData.primaryTextTheme.headline3!.copyWith(
+                    style: themeData.primaryTextTheme.displaySmall!.copyWith(
                       fontSize: 16,
                     ),
                     textAlign:

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -99,7 +99,7 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
                               widget.requestData.maxSendable,
                             )
                           : widget.domain,
-                      style: themeData.textTheme.headline6,
+                      style: themeData.textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   )

--- a/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
@@ -113,7 +113,7 @@ class Message extends StatelessWidget {
             child: AutoSizeText(
               message,
               style:
-                  themeData.primaryTextTheme.headline3!.copyWith(fontSize: 16),
+                  themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
               textAlign: message.length > 40 && !message.contains("\n")
                   ? TextAlign.start
                   : TextAlign.center,

--- a/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
@@ -45,7 +45,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
                 return Colors.transparent;
               }
               // Defer to the widget's default.
-              return themeData.textTheme.button!.color!;
+              return themeData.textTheme.labelLarge!.color!;
             }),
           ),
           onPressed: () {
@@ -53,7 +53,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
           },
           child: Text(
             texts.lnurl_withdraw_dialog_action_close,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
         if (widget.successActionData.url != null) ...[
@@ -65,13 +65,13 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
                     return Colors.transparent;
                   }
                   // Defer to the widget's default.
-                  return themeData.textTheme.button!.color!;
+                  return themeData.textTheme.labelLarge!.color!;
                 },
               ),
             ),
             child: Text(
               "OPEN LINK",
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
             onPressed: () async {
               final navigator = Navigator.of(context);

--- a/lib/routes/lnurl/widgets/lnurl_metadata.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata.dart
@@ -17,7 +17,7 @@ class LNURLMetadata extends StatelessWidget {
       children: [
         Text(
           metadataMap['text/long-desc'] ?? metadataMap['text/plain'],
-          style: Theme.of(context).textTheme.caption,
+          style: Theme.of(context).textTheme.bodySmall,
         ),
         _LNURLMetadataImage(
           base64String: base64String,

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -109,7 +109,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                                     currencyState.bitcoinTicker)
                                 .format(
                                     widget.requestData.maxWithdrawable ~/ 1000),
-                        style: themeData.primaryTextTheme.headline5,
+                        style: themeData.primaryTextTheme.headlineSmall,
                         textAlign: TextAlign.center,
                       ),
                     ),

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -124,13 +124,13 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                         ),
                       ),
                       hintColor: themeData.dialogTheme.contentTextStyle!.color,
+                      primaryColor: themeData.textTheme.labelLarge!.color!,
                       colorScheme: ColorScheme.dark(
                         primary: themeData.textTheme.labelLarge!.color!,
+                        error: themeData.isLightTheme
+                            ? Colors.red
+                            : themeData.colorScheme.error,
                       ),
-                      primaryColor: themeData.textTheme.labelLarge!.color!,
-                      errorColor: themeData.isLightTheme
-                          ? Colors.red
-                          : themeData.errorColor,
                     ),
                     child: Column(
                         mainAxisSize: MainAxisSize.max,

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -67,7 +67,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
     return AlertDialog(
       title: Text(
         widget.domain,
-        style: themeData.primaryTextTheme.headline4!.copyWith(fontSize: 16),
+        style: themeData.primaryTextTheme.headlineMedium!.copyWith(fontSize: 16),
         textAlign: TextAlign.center,
       ),
       content: SizedBox(

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -125,9 +125,9 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                       ),
                       hintColor: themeData.dialogTheme.contentTextStyle!.color,
                       colorScheme: ColorScheme.dark(
-                        primary: themeData.textTheme.button!.color!,
+                        primary: themeData.textTheme.labelLarge!.color!,
                       ),
-                      primaryColor: themeData.textTheme.button!.color!,
+                      primaryColor: themeData.textTheme.labelLarge!.color!,
                       errorColor: themeData.isLightTheme
                           ? Colors.red
                           : themeData.errorColor,
@@ -201,7 +201,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                 return Colors.transparent;
               }
               // Defer to the widget's default.
-              return themeData.textTheme.button!.color!;
+              return themeData.textTheme.labelLarge!.color!;
             }),
           ),
           onPressed: () {
@@ -209,7 +209,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
           },
           child: Text(
             texts.lnurl_withdraw_dialog_action_close,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
         TextButton(
@@ -219,7 +219,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                 return Colors.transparent;
               }
               // Defer to the widget's default.
-              return themeData.textTheme.button!.color!;
+              return themeData.textTheme.labelLarge!.color!;
             }),
           ),
           onPressed: () async {
@@ -272,7 +272,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
           },
           child: Text(
             texts.bottom_action_bar_receive,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
       ],

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -80,7 +80,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
               children: [
                 Text(
                   texts.sweep_all_coins_label_receive,
-                  style: themeData.primaryTextTheme.headline3!
+                  style: themeData.primaryTextTheme.displaySmall!
                       .copyWith(fontSize: 16),
                   textAlign: TextAlign.center,
                 ),
@@ -175,7 +175,7 @@ class LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> {
                       child: SingleChildScrollView(
                         child: Text(
                           widget.requestData.defaultDescription,
-                          style: themeData.primaryTextTheme.headline3!
+                          style: themeData.primaryTextTheme.displaySmall!
                               .copyWith(fontSize: 16),
                           textAlign:
                               widget.requestData.defaultDescription.length >

--- a/lib/routes/qr_scan/widgets/qr_scan.dart
+++ b/lib/routes/qr_scan/widgets/qr_scan.dart
@@ -100,6 +100,7 @@ class ImagePickerButton extends StatelessWidget {
       ),
       onPressed: () async {
         final picker = ImagePicker();
+        // ignore: body_might_complete_normally_catch_error
         final pickedFile = await picker.pickImage(source: ImageSource.gallery).catchError((err) {
           _log.w("Failed to pick image", ex: err);
         });

--- a/lib/routes/security/widget/pin_code_widget.dart
+++ b/lib/routes/security/widget/pin_code_widget.dart
@@ -83,7 +83,7 @@ class _PinCodeWidgetState extends State<PinCodeWidget> with SingleTickerProvider
                 Text(
                   errorMessage,
                   textAlign: TextAlign.center,
-                  style: theme.textTheme.headline4?.copyWith(
+                  style: theme.textTheme.headlineMedium?.copyWith(
                     fontSize: 12,
                   ),
                 ),

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -179,7 +179,7 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
     var bitcoinCurrency = currencyBloc.state.bitcoinCurrency;
     var amount = bitcoinCurrency.parse(_amountController.text);
     _amountFocusNode.unfocus();
-    var ok = await promptAreYouSure(
+    await promptAreYouSure(
       context,
       texts.spontaneous_payment_send_payment_title,
       Text(
@@ -190,36 +190,39 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
       ),
       okText: texts.spontaneous_payment_action_pay,
       cancelText: texts.spontaneous_payment_action_pay,
-    );
-    if (ok == true) {
-      Future sendFuture = Future.value(null);
-      showDialog(
-        useRootNavigator: false,
-        context: context,
-        barrierDismissible: false,
-        builder: (_) => ProcessingPaymentDialog(
-          firstPaymentItemKey: widget.firstPaymentItemKey,
-          popOnCompletion: true,
-          paymentFunc: () {
-            var sendPayment = Future.delayed(
-              const Duration(seconds: 1),
-              () {
-                sendFuture = accBloc.sendSpontaneousPayment(
-                  widget.nodeID!,
-                  tipMessage,
-                  amount,
+    ).then(
+      (ok) async {
+        if (ok == true) {
+          Future sendFuture = Future.value(null);
+          showDialog(
+            useRootNavigator: false,
+            context: context,
+            barrierDismissible: false,
+            builder: (_) => ProcessingPaymentDialog(
+              firstPaymentItemKey: widget.firstPaymentItemKey,
+              popOnCompletion: true,
+              paymentFunc: () {
+                var sendPayment = Future.delayed(
+                  const Duration(seconds: 1),
+                  () {
+                    sendFuture = accBloc.sendSpontaneousPayment(
+                      widget.nodeID!,
+                      tipMessage,
+                      amount,
+                    );
+                    return sendFuture;
+                  },
                 );
-                return sendFuture;
-              },
-            );
 
-            return sendPayment;
-          },
-        ),
-      );
-      if (!mounted) return;
-      Navigator.of(context).removeRoute(_currentRoute!);
-      await sendFuture;
-    }
+                return sendPayment;
+              },
+            ),
+          );
+          if (!mounted) return;
+          Navigator.of(context).removeRoute(_currentRoute!);
+          await sendFuture;
+        }
+      },
+    );
   }
 }

--- a/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
+++ b/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
@@ -36,7 +36,7 @@ class CollapsibleListItem extends StatelessWidget {
           collapsedIconColor: userStyle.color,
           title: AutoSizeText(
             title,
-            style: textTheme.headline4!.merge(userStyle),
+            style: textTheme.headlineMedium!.merge(userStyle),
             maxLines: 1,
             group: labelGroup,
           ),

--- a/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
+++ b/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
@@ -72,7 +72,7 @@ class CollapsibleListItem extends StatelessWidget {
                           padding: const EdgeInsets.only(right: 8.0),
                           tooltip: texts.collapsible_list_action_copy(title),
                           iconSize: 16.0,
-                          color: userStyle.color ?? textTheme.button!.color!,
+                          color: userStyle.color ?? textTheme.labelLarge!.color!,
                           icon: const Icon(
                             IconData(0xe90b, fontFamily: 'icomoon'),
                           ),
@@ -91,7 +91,7 @@ class CollapsibleListItem extends StatelessWidget {
                         IconButton(
                           padding: const EdgeInsets.only(right: 8.0),
                           iconSize: 16.0,
-                          color: userStyle.color ?? textTheme.button!.color!,
+                          color: userStyle.color ?? textTheme.labelLarge!.color!,
                           icon: const Icon(Icons.share),
                           onPressed: () {
                             if (sharedValue != null) {

--- a/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
+++ b/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
@@ -53,7 +53,7 @@ class CollapsibleListItem extends StatelessWidget {
                       textAlign: TextAlign.left,
                       overflow: TextOverflow.clip,
                       maxLines: 4,
-                      style: textTheme.headline3!
+                      style: textTheme.displaySmall!
                           .copyWith(fontSize: 10)
                           .merge(userStyle),
                     ),

--- a/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
+++ b/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
@@ -209,7 +209,7 @@ class _TransactionDetails extends StatelessWidget {
           flex: 1,
           child: Text(
             texts.waiting_broadcast_dialog_transaction_id,
-            style: themeData.primaryTextTheme.headline4,
+            style: themeData.primaryTextTheme.headlineMedium,
           ),
         ),
         _ShareAndCopyTxID(txId: txId),

--- a/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
+++ b/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
@@ -294,7 +294,7 @@ class _TransactionID extends StatelessWidget {
               textAlign: TextAlign.left,
               overflow: TextOverflow.clip,
               maxLines: 4,
-              style: themeData.primaryTextTheme.headline3!.copyWith(
+              style: themeData.primaryTextTheme.displaySmall!.copyWith(
                 fontSize: 10,
               ),
             ),

--- a/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
+++ b/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
@@ -77,7 +77,7 @@ class WaitBroadcastDialog extends StatelessWidget {
               onPressed: () => Navigator.of(context).pop(txId),
               child: Text(
                 texts.waiting_broadcast_dialog_action_close,
-                style: themeData.primaryTextTheme.button,
+                style: themeData.primaryTextTheme.labelLarge,
               ),
             ),
           ];
@@ -242,7 +242,7 @@ class _ShareAndCopyTxID extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(0.0, 4.0, 0.0, 0.0),
               tooltip: texts.waiting_broadcast_dialog_action_copy,
               iconSize: 16.0,
-              color: themeData.primaryTextTheme.button!.color!,
+              color: themeData.primaryTextTheme.labelLarge!.color!,
               icon: const Icon(
                 IconData(
                   0xe90b,
@@ -259,7 +259,7 @@ class _ShareAndCopyTxID extends StatelessWidget {
               padding: const EdgeInsets.fromLTRB(0.0, 4.0, 0.0, 0.0),
               tooltip: texts.waiting_broadcast_dialog_action_share,
               iconSize: 16.0,
-              color: themeData.primaryTextTheme.button!.color!,
+              color: themeData.primaryTextTheme.labelLarge!.color!,
               icon: const Icon(Icons.share),
               onPressed: () => Share.share(txId),
             ),

--- a/lib/routes/subswap/swap/widgets/address_qr_widget.dart
+++ b/lib/routes/subswap/swap/widgets/address_qr_widget.dart
@@ -50,7 +50,7 @@ class AddressQRWidget extends StatelessWidget {
             },
             child: Text(
               address,
-              style: themeData.primaryTextTheme.subtitle2,
+              style: themeData.primaryTextTheme.titleSmall,
             ),
           ),
         ),

--- a/lib/routes/subswap/swap/widgets/deposit_widget.dart
+++ b/lib/routes/subswap/swap/widgets/deposit_widget.dart
@@ -60,7 +60,7 @@ class _DepositWidgetState extends State<DepositWidget> {
                   children: [
                     Text(
                       _sendMessage(context, lspInfo),
-                      style: Theme.of(context).textTheme.headline6,
+                      style: Theme.of(context).textTheme.titleLarge,
                       textAlign: TextAlign.center,
                     ),
                   ],

--- a/lib/routes/subswap/swap/widgets/subswap_dialog.dart
+++ b/lib/routes/subswap/swap/widgets/subswap_dialog.dart
@@ -51,7 +51,7 @@ class SwapDialog extends StatelessWidget {
           },
           child: Text(
             texts.invoice_btc_address_on_chain_action_ok,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
       ],

--- a/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/fee_chooser_header.dart
+++ b/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/fee_chooser_header.dart
@@ -79,7 +79,7 @@ class _FeeChooserHeaderState extends State<FeeChooserHeader> {
                     borderRadius: const BorderRadius.all(
                       Radius.circular(10),
                     ),
-                    color: themeData.backgroundColor,
+                    color: themeData.colorScheme.background,
                   ),
                 ),
               );

--- a/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/fee_option_button.dart
+++ b/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/fee_option_button.dart
@@ -27,7 +27,7 @@ class FeeOptionButton extends StatelessWidget {
           text,
           maxLines: 1,
           textAlign: TextAlign.center,
-          style: themeData.textTheme.button!.copyWith(
+          style: themeData.textTheme.labelLarge!.copyWith(
             color: !isAffordable
                 ? themeData.primaryColor.withOpacity(0.4)
                 : themeData.isLightTheme

--- a/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/processing_speed_wait_time.dart
+++ b/lib/routes/withdraw_funds/confirmation_page/widgets/fee_chooser/widgets/processing_speed_wait_time.dart
@@ -38,7 +38,7 @@ class ProcessingSpeedWaitTime extends Text {
 
   static _style(BuildContext context) {
     final themeData = Theme.of(context);
-    return themeData.textTheme.button!.copyWith(
+    return themeData.textTheme.labelLarge!.copyWith(
       color: themeData.colorScheme.onSurface.withOpacity(0.4),
     );
   }

--- a/lib/routes/withdraw_funds/widgets/withdraw_funds_available_btc.dart
+++ b/lib/routes/withdraw_funds/widgets/withdraw_funds_available_btc.dart
@@ -14,7 +14,7 @@ class WithdrawFundsAvailableBtc extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);
-    final textStyle = themeData.primaryTextTheme.headline3!.copyWith(
+    final textStyle = themeData.primaryTextTheme.displaySmall!.copyWith(
       color: BreezColors.white[500],
     );
 

--- a/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
+++ b/lib/routes/withdraw_funds/withdraw_funds_address_page.dart
@@ -45,7 +45,7 @@ class _WithdrawFundsAddressPageState extends State<WithdrawFundsAddressPage> {
             contentPadding: const EdgeInsets.fromLTRB(8, 12, 8, 12),
             child: Text(
               texts.unexpected_funds_message,
-              style: themeData.textTheme.headline6,
+              style: themeData.textTheme.titleLarge,
             ),
           ),
           Padding(

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -11,6 +11,7 @@ final ThemeData breezDarkTheme = ThemeData(
     secondary: Colors.white,
     onSecondary: Colors.white,
     error: const Color(0xFFeddc97),
+    background: const Color(0xFF152a3d),
   ),
   primaryColor: const Color(0xFF0085fb),
   primaryColorDark: const Color(0xFF00081C),
@@ -20,7 +21,6 @@ final ThemeData breezDarkTheme = ThemeData(
     sizeConstraints: BoxConstraints(minHeight: 64, minWidth: 64),
   ),
   canvasColor: const Color(0xFF0c2031),
-  backgroundColor: const Color(0xFF152a3d),
   bottomAppBarTheme:
       const BottomAppBarTheme(elevation: 0, color: Color(0xFF0085fb)),
   appBarTheme: AppBarTheme(

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -90,7 +90,7 @@ final ThemeData breezDarkTheme = ThemeData(
         color: Color(0xFF0085fb), fontSize: 14.3, letterSpacing: 1.25),
     subtitle2: TextStyle(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),
-    caption: TextStyle(color: BreezColors.white[400], fontSize: 12.0),
+    bodySmall: TextStyle(color: BreezColors.white[400], fontSize: 12.0),
   ),
   textSelectionTheme: const TextSelectionThemeData(
     selectionColor: Color.fromRGBO(255, 255, 255, 0.5),

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -47,11 +47,11 @@ final ThemeData breezDarkTheme = ThemeData(
   cardColor: const Color(0xFF121212), // will be replaced with CardTheme.color
   cardTheme: const CardTheme(color: Color(0xFF121212)),
   highlightColor: const Color(0xFF0085fb),
-  textTheme: const TextTheme(
+  textTheme: TextTheme(
       subtitle2:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
       headline5: TextStyle(color: Colors.white, fontSize: 26.0),
-      button:
+      labelLarge:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 1.25),
       headline4: TextStyle(
         color: Color(0xffffe685),
@@ -86,7 +86,7 @@ final ThemeData breezDarkTheme = ThemeData(
         letterSpacing: 0.15,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    button: const TextStyle(
+    labelLarge: const TextStyle(
         color: Color(0xFF0085fb), fontSize: 14.3, letterSpacing: 1.25),
     subtitle2: TextStyle(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -48,7 +48,7 @@ final ThemeData breezDarkTheme = ThemeData(
   cardTheme: const CardTheme(color: Color(0xFF121212)),
   highlightColor: const Color(0xFF0085fb),
   textTheme: TextTheme(
-      subtitle2:
+      titleSmall:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
       headlineSmall: TextStyle(color: Colors.white, fontSize: 26.0),
       labelLarge:
@@ -88,7 +88,7 @@ final ThemeData breezDarkTheme = ThemeData(
         fontFamily: 'IBMPlexSans'),
     labelLarge: const TextStyle(
         color: Color(0xFF0085fb), fontSize: 14.3, letterSpacing: 1.25),
-    subtitle2: TextStyle(
+    titleSmall: TextStyle(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),
     bodySmall: TextStyle(color: BreezColors.white[400], fontSize: 12.0),
   ),

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -107,7 +107,6 @@ final ThemeData breezDarkTheme = ThemeData(
     }),
   ),
   chipTheme: const ChipThemeData(backgroundColor: Color(0xFF0085fb)),
-  errorColor: const Color(0xFFeddc97),
 );
 
 final ThemeData calendarDarkTheme = ThemeData.dark().copyWith(

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -71,7 +71,7 @@ final ThemeData breezDarkTheme = ThemeData(
         height: 1.28,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    headline3: const TextStyle(
+    displaySmall: const TextStyle(
         color: Colors.white, fontSize: 14.0, letterSpacing: 0.0, height: 1.28),
     headline5: const TextStyle(
         color: Colors.white,

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -57,7 +57,7 @@ final ThemeData breezDarkTheme = ThemeData(
         color: Color(0xffffe685),
         fontSize: 18.0,
       ),
-      headline6: TextStyle(
+      titleLarge: TextStyle(
           color: Colors.white,
           fontSize: 12.3,
           fontWeight: FontWeight.w400,

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -53,7 +53,7 @@ final ThemeData breezDarkTheme = ThemeData(
       headline5: TextStyle(color: Colors.white, fontSize: 26.0),
       labelLarge:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 1.25),
-      headline4: TextStyle(
+      headlineMedium: TextStyle(
         color: Color(0xffffe685),
         fontSize: 18.0,
       ),
@@ -64,7 +64,7 @@ final ThemeData breezDarkTheme = ThemeData(
           letterSpacing: 0.25,
           height: 1.22)),
   primaryTextTheme: TextTheme(
-    headline4: const TextStyle(
+    headlineMedium: const TextStyle(
         color: Colors.white,
         fontSize: 14.0,
         letterSpacing: 0.0,

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -47,7 +47,7 @@ final ThemeData breezDarkTheme = ThemeData(
   cardColor: const Color(0xFF121212), // will be replaced with CardTheme.color
   cardTheme: const CardTheme(color: Color(0xFF121212)),
   highlightColor: const Color(0xFF0085fb),
-  textTheme: TextTheme(
+  textTheme:  const TextTheme(
       titleSmall:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
       headlineSmall: TextStyle(color: Colors.white, fontSize: 26.0),

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -50,7 +50,7 @@ final ThemeData breezDarkTheme = ThemeData(
   textTheme: TextTheme(
       subtitle2:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 0.2),
-      headline5: TextStyle(color: Colors.white, fontSize: 26.0),
+      headlineSmall: TextStyle(color: Colors.white, fontSize: 26.0),
       labelLarge:
           TextStyle(color: Colors.white, fontSize: 14.3, letterSpacing: 1.25),
       headlineMedium: TextStyle(
@@ -73,7 +73,7 @@ final ThemeData breezDarkTheme = ThemeData(
         fontFamily: 'IBMPlexSans'),
     displaySmall: const TextStyle(
         color: Colors.white, fontSize: 14.0, letterSpacing: 0.0, height: 1.28),
-    headline5: const TextStyle(
+    headlineSmall: const TextStyle(
         color: Colors.white,
         fontSize: 24.0,
         letterSpacing: 0.0,

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -80,7 +80,7 @@ final ThemeData breezDarkTheme = ThemeData(
         height: 1.28,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    bodyText2: const TextStyle(
+    bodyMedium: const TextStyle(
         color: Colors.white,
         fontSize: 16.4,
         letterSpacing: 0.15,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -57,7 +57,7 @@ final ThemeData breezLightTheme = ThemeData(
         color: Color(0xffffe685),
         fontSize: 18.0,
       ),
-      headline6: const TextStyle(
+      titleLarge: const TextStyle(
           color: Colors.white,
           fontSize: 12.3,
           fontWeight: FontWeight.w400,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -50,7 +50,7 @@ final ThemeData breezLightTheme = ThemeData(
   textTheme: TextTheme(
       subtitle2: TextStyle(
           color: BreezColors.grey[600], fontSize: 14.3, letterSpacing: 0.2),
-      headline5: TextStyle(color: BreezColors.grey[600], fontSize: 26.0),
+      headlineSmall: TextStyle(color: BreezColors.grey[600], fontSize: 26.0),
       labelLarge: TextStyle(
           color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),
       headlineMedium: const TextStyle(
@@ -76,7 +76,7 @@ final ThemeData breezLightTheme = ThemeData(
         fontSize: 14.0,
         letterSpacing: 0.0,
         height: 1.28),
-    headline5: TextStyle(
+    headlineSmall: TextStyle(
         color: BreezColors.grey[500],
         fontSize: 24.0,
         letterSpacing: 0.0,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -10,6 +10,7 @@ final ThemeData breezLightTheme = ThemeData(
     secondary: Colors.white,
     onSecondary: const Color.fromRGBO(0, 133, 251, 1.0),
     error: const Color(0xffffe685),
+    background: Colors.white,
   ),
   primaryColor: const Color.fromRGBO(255, 255, 255, 1.0),
   primaryColorDark: BreezColors.blue[900],
@@ -19,7 +20,6 @@ final ThemeData breezLightTheme = ThemeData(
     sizeConstraints: BoxConstraints(minHeight: 64, minWidth: 64),
   ),
   canvasColor: BreezColors.blue[500],
-  backgroundColor: Colors.white,
   bottomAppBarTheme:
       const BottomAppBarTheme(elevation: 0, color: Color(0xFF0085fb)),
   appBarTheme: AppBarTheme(

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -116,7 +116,6 @@ final ThemeData breezLightTheme = ThemeData(
     ),
   ),
   chipTheme: const ChipThemeData(backgroundColor: Color(0xFF0085fb)),
-  errorColor: const Color(0xffffe685),
 );
 
 final ThemeData calendarLightTheme = ThemeData.light().copyWith(

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -83,7 +83,7 @@ final ThemeData breezLightTheme = ThemeData(
         height: 1.28,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    bodyText2: TextStyle(
+    bodyMedium: TextStyle(
         color: BreezColors.blue[900],
         fontSize: 16.4,
         letterSpacing: 0.15,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -71,7 +71,7 @@ final ThemeData breezLightTheme = ThemeData(
         height: 1.28,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    headline3: TextStyle(
+    displaySmall: TextStyle(
         color: BreezColors.grey[500],
         fontSize: 14.0,
         letterSpacing: 0.0,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -93,7 +93,7 @@ final ThemeData breezLightTheme = ThemeData(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),
     button: TextStyle(
         color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),
-    caption: TextStyle(color: BreezColors.grey[500], fontSize: 12.0),
+    bodySmall: TextStyle(color: BreezColors.grey[500], fontSize: 12.0),
   ),
   textSelectionTheme: const TextSelectionThemeData(
     selectionColor: Color.fromRGBO(0, 133, 251, 0.25),

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -51,7 +51,7 @@ final ThemeData breezLightTheme = ThemeData(
       subtitle2: TextStyle(
           color: BreezColors.grey[600], fontSize: 14.3, letterSpacing: 0.2),
       headline5: TextStyle(color: BreezColors.grey[600], fontSize: 26.0),
-      button: TextStyle(
+      labelLarge: TextStyle(
           color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),
       headline4: const TextStyle(
         color: Color(0xffffe685),
@@ -91,7 +91,7 @@ final ThemeData breezLightTheme = ThemeData(
         fontFamily: 'IBMPlexSans'),
     subtitle2: TextStyle(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),
-    button: TextStyle(
+    labelLarge: TextStyle(
         color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),
     bodySmall: TextStyle(color: BreezColors.grey[500], fontSize: 12.0),
   ),

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -48,7 +48,7 @@ final ThemeData breezLightTheme = ThemeData(
   cardTheme: CardTheme(color: BreezColors.blue[500]),
   highlightColor: BreezColors.blue[200],
   textTheme: TextTheme(
-      subtitle2: TextStyle(
+      titleSmall: TextStyle(
           color: BreezColors.grey[600], fontSize: 14.3, letterSpacing: 0.2),
       headlineSmall: TextStyle(color: BreezColors.grey[600], fontSize: 26.0),
       labelLarge: TextStyle(
@@ -89,7 +89,7 @@ final ThemeData breezLightTheme = ThemeData(
         letterSpacing: 0.15,
         fontWeight: FontWeight.w500,
         fontFamily: 'IBMPlexSans'),
-    subtitle2: TextStyle(
+    titleSmall: TextStyle(
         color: BreezColors.white[500], fontSize: 10.0, letterSpacing: 0.09),
     labelLarge: TextStyle(
         color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -53,7 +53,7 @@ final ThemeData breezLightTheme = ThemeData(
       headline5: TextStyle(color: BreezColors.grey[600], fontSize: 26.0),
       labelLarge: TextStyle(
           color: BreezColors.blue[500], fontSize: 14.3, letterSpacing: 1.25),
-      headline4: const TextStyle(
+      headlineMedium: const TextStyle(
         color: Color(0xffffe685),
         fontSize: 18.0,
       ),
@@ -64,7 +64,7 @@ final ThemeData breezLightTheme = ThemeData(
           letterSpacing: 0.25,
           height: 1.22)),
   primaryTextTheme: TextTheme(
-    headline4: TextStyle(
+    headlineMedium: TextStyle(
         color: BreezColors.grey[500],
         fontSize: 14.0,
         letterSpacing: 0.0,

--- a/lib/theme/theme_extensions.dart
+++ b/lib/theme/theme_extensions.dart
@@ -29,7 +29,7 @@ const balanceFiatConversionTextStyle = TextStyle(
 final toolbarTextStyle = const TextTheme(
   headline6:
       TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
-).bodyText2;
+).bodyMedium;
 final titleTextStyle = const TextTheme(
   headline6:
       TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),

--- a/lib/theme/theme_extensions.dart
+++ b/lib/theme/theme_extensions.dart
@@ -27,13 +27,13 @@ const balanceFiatConversionTextStyle = TextStyle(
     height: 1.24,
     fontFamily: 'IBMPlexSans');
 final toolbarTextStyle = const TextTheme(
-  headline6:
+  titleLarge:
       TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
 ).bodyMedium;
 final titleTextStyle = const TextTheme(
-  headline6:
+  titleLarge:
       TextStyle(color: Colors.white, fontSize: 18.0, letterSpacing: 0.22),
-).headline6;
+).titleLarge;
 const TextStyle drawerItemTextStyle =
     TextStyle(height: 1.2, letterSpacing: 0.25, fontSize: 14.3);
 const TextStyle bottomAppBarBtnStyle = TextStyle(

--- a/lib/utils/external_browser.dart
+++ b/lib/utils/external_browser.dart
@@ -12,12 +12,12 @@ Future<void> launchLinkOnExternalBrowser(
   required String linkAddress,
 }) async {
   final texts = context.texts();
+  final themeData = Theme.of(context);
   final navigator = Navigator.of(context);
   var loaderRoute = createLoaderRoute(context);
   navigator.push(loaderRoute);
   try {
     if (await canLaunchUrlString(linkAddress)) {
-      final themeData = Theme.of(context);
       await ChromeSafariBrowser().open(
         url: WebUri(linkAddress),
         settings: ChromeSafariBrowserSettings(

--- a/lib/widgets/amount_form_field/breez_dropdown.dart
+++ b/lib/widgets/amount_form_field/breez_dropdown.dart
@@ -83,8 +83,11 @@ class _DropdownScrollBehavior extends ScrollBehavior {
       Theme.of(context).platform;
 
   @override
-  Widget buildViewportChrome(
-          BuildContext context, Widget child, AxisDirection axisDirection) =>
+  Widget buildOverscrollIndicator(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) =>
       child;
 
   @override

--- a/lib/widgets/amount_form_field/breez_dropdown.dart
+++ b/lib/widgets/amount_form_field/breez_dropdown.dart
@@ -655,7 +655,7 @@ class BreezDropdownButton<T> extends StatefulWidget {
   /// The text style to use for text in the dropdown button and the dropdown
   /// menu that appears when you tap the button.
   ///
-  /// Defaults to the [TextTheme.subtitle1] value of the current
+  /// Defaults to the [TextTheme.titleMedium] value of the current
   /// [ThemeData.textTheme] of the current [Theme].
   final TextStyle? style;
 
@@ -768,7 +768,7 @@ class BreezDropdownButtonState<T> extends State<BreezDropdownButton<T>>
   }
 
   TextStyle get _textStyle =>
-      widget.style ?? Theme.of(context).textTheme.subtitle1!;
+      widget.style ?? Theme.of(context).textTheme.titleMedium!;
 
   void _handleTap() {
     FocusScope.of(context).requestFocus(FocusNode());
@@ -810,7 +810,7 @@ class BreezDropdownButtonState<T> extends State<BreezDropdownButton<T>>
   // would be clipped.
   double get _denseButtonHeight {
     final double fontSize =
-        _textStyle.fontSize ?? Theme.of(context).textTheme.subtitle1!.fontSize!;
+        _textStyle.fontSize ?? Theme.of(context).textTheme.titleMedium!.fontSize!;
     return math.max(fontSize, math.max(widget.iconSize, _kDenseButtonHeight));
   }
 

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -260,7 +260,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
         onPressed: () => Navigator.pop(context),
         child: Text(
           texts.currency_converter_dialog_action_cancel,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
       ),
     ];
@@ -284,7 +284,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
           },
           child: Text(
             texts.currency_converter_dialog_action_done,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
       );

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -239,7 +239,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
             children: [
               Text(
                 _contentMessage(context, currencyState),
-                style: themeData.textTheme.headline5!.copyWith(
+                style: themeData.textTheme.headlineSmall!.copyWith(
                   fontSize: 16.0,
                 ),
               ),

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -1,4 +1,5 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
@@ -69,6 +70,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
           );
         });
       }
+      return {} as Map<String, Rate>;
     });
   }
 

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -335,7 +335,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
     return _exchangeRate == null
         ? Text(
             "",
-            style: themeData.primaryTextTheme.subtitle2,
+            style: themeData.primaryTextTheme.titleSmall,
           )
         : Text(
             texts.currency_converter_dialog_rate(
@@ -345,7 +345,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
               ),
               fiatConversion.currencyData.id,
             ),
-            style: themeData.primaryTextTheme.subtitle2!,
+            style: themeData.primaryTextTheme.titleSmall!,
           );
   }
 

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -179,7 +179,8 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
 
     final fiatConversion = FiatConversion(fiatCurrency, fiatExchangeRate);
     final int fractionSize = fiatCurrency.info.fractionSize;
-    final borderColor = themeData.isLightTheme ? Colors.red : themeData.errorColor;
+    final borderColor =
+        themeData.isLightTheme ? Colors.red : themeData.colorScheme.error;
 
     return Column(
       mainAxisSize: MainAxisSize.min,

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -148,7 +148,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
           ),
           Theme(
             data: themeData.copyWith(
-              canvasColor: themeData.backgroundColor,
+              canvasColor: themeData.colorScheme.background,
             ),
             child: DropdownButtonHideUnderline(
               child: ButtonTheme(

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -205,7 +205,7 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
                 ),
               ),
               errorMaxLines: 2,
-              errorStyle: themeData.primaryTextTheme.caption!.copyWith(
+              errorStyle: themeData.primaryTextTheme.bodySmall!.copyWith(
                 color: borderColor,
               ),
               prefix: Text(

--- a/lib/widgets/error_dialog.dart
+++ b/lib/widgets/error_dialog.dart
@@ -54,7 +54,7 @@ Future<void> promptError(
             TextButton(
               child: Text(
                 okText ?? texts.error_dialog_default_action_ok,
-                style: themeData.primaryTextTheme.button,
+                style: themeData.primaryTextTheme.labelLarge,
               ),
               onPressed: () {
                 canPop = true;
@@ -103,7 +103,7 @@ Future<bool?> promptAreYouSure(
           TextButton(
             child: Text(
               cancelText ?? texts.error_dialog_default_action_no,
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
             onPressed: () {
               Navigator.of(context).pop(false);
@@ -112,7 +112,7 @@ Future<bool?> promptAreYouSure(
           TextButton(
             child: Text(
               okText ?? texts.error_dialog_default_action_yes,
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
             onPressed: () => Navigator.of(context).pop(true),
           ),
@@ -160,7 +160,7 @@ Future<bool?> promptMessage(
           TextButton(
             child: Text(
               closeText ?? texts.error_dialog_default_action_close,
-              style: themeData.primaryTextTheme.button,
+              style: themeData.primaryTextTheme.labelLarge,
             ),
             onPressed: () => Navigator.of(context).pop(false),
           ),

--- a/lib/widgets/flushbar.dart
+++ b/lib/widgets/flushbar.dart
@@ -49,7 +49,7 @@ Flushbar showFlushbar(
             child: Text(
               buttonText ?? texts.flushbar_default_action,
               style: theme.snackBarStyle.copyWith(
-                color: themeData.errorColor,
+                color: themeData.colorScheme.error,
               ),
             ),
           ),

--- a/lib/widgets/keyboard_done_action.dart
+++ b/lib/widgets/keyboard_done_action.dart
@@ -34,7 +34,7 @@ class KeyboardDoneAction {
   }
 
   void _showOverlay() {
-    OverlayState os = Overlay.of(focusNodes[0].context!)!;
+    OverlayState os = Overlay.of(focusNodes[0].context!);
     _overlayEntry = OverlayEntry(builder: (context) {
       final texts = context.texts();
       final queryData = MediaQuery.of(context);

--- a/lib/widgets/loading_animated_text.dart
+++ b/lib/widgets/loading_animated_text.dart
@@ -43,7 +43,7 @@ class LoadingAnimatedTextState extends State<LoadingAnimatedText> {
     return RichText(
         text: TextSpan(
             style: widget.textStyle ??
-                Theme.of(context).textTheme.bodyText2?.copyWith(
+                Theme.of(context).textTheme.bodyMedium?.copyWith(
                       color: Theme.of(context).colorScheme.onSecondary,
                     ),
             text: widget._loadingMessage,

--- a/lib/widgets/open_link_dialog.dart
+++ b/lib/widgets/open_link_dialog.dart
@@ -73,13 +73,13 @@ class OpenLinkDialogState extends State<OpenLinkDialog> {
                   return Colors.transparent;
                 }
                 // Defer to the widget's default.
-                return themeData.textTheme.button!.color!;
+                return themeData.textTheme.labelLarge!.color!;
               },
             ),
           ),
           child: Text(
             texts.qr_action_button_open_link_confirmation_no,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
           onPressed: () => navigator.pop(),
         ),
@@ -91,13 +91,13 @@ class OpenLinkDialogState extends State<OpenLinkDialog> {
                   return Colors.transparent;
                 }
                 // Defer to the widget's default.
-                return themeData.textTheme.button!.color!;
+                return themeData.textTheme.labelLarge!.color!;
               },
             ),
           ),
           child: Text(
             texts.qr_action_button_open_link_confirmation_yes,
-            style: themeData.primaryTextTheme.button,
+            style: themeData.primaryTextTheme.labelLarge,
           ),
           onPressed: () async {
             await launchLinkOnExternalBrowser(

--- a/lib/widgets/payment_dialogs/payment_confirmation_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_confirmation_dialog.dart
@@ -113,12 +113,12 @@ class PaymentConfirmationDialog extends StatelessWidget {
               return Colors.transparent;
             }
             // Defer to the widget's default.
-            return Theme.of(context).textTheme.button!.color!;
+            return Theme.of(context).textTheme.labelLarge!.color!;
           }),
         ),
         child: Text(
           texts.payment_confirmation_dialog_action_no,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
         onPressed: () => _onCancel(),
       ),
@@ -129,12 +129,12 @@ class PaymentConfirmationDialog extends StatelessWidget {
               return Colors.transparent;
             }
             // Defer to the widget's default.
-            return themeData.textTheme.button!.color!;
+            return themeData.textTheme.labelLarge!.color!;
           }),
         ),
         child: Text(
           texts.payment_confirmation_dialog_action_yes,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
         onPressed: () {
           _onPaymentApproved(

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -173,10 +173,11 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
           hintColor: themeData.dialogTheme.contentTextStyle!.color,
           colorScheme: ColorScheme.dark(
             primary: themeData.textTheme.labelLarge!.color!,
+            error: themeData.isLightTheme
+                ? Colors.red
+                : themeData.colorScheme.error,
           ),
           primaryColor: themeData.textTheme.labelLarge!.color!,
-          errorColor:
-              themeData.isLightTheme ? Colors.red : themeData.errorColor,
         ),
         child: Form(
           autovalidateMode: AutovalidateMode.always,
@@ -293,7 +294,8 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         textAlign: TextAlign.center,
         style: themeData.primaryTextTheme.headline3!.copyWith(
           fontSize: 16,
-          color: themeData.isLightTheme ? Colors.red : themeData.errorColor,
+          color:
+              themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,
         ),
       ),
     );

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -172,9 +172,9 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
           ),
           hintColor: themeData.dialogTheme.contentTextStyle!.color,
           colorScheme: ColorScheme.dark(
-            primary: themeData.textTheme.button!.color!,
+            primary: themeData.textTheme.labelLarge!.color!,
           ),
-          primaryColor: themeData.textTheme.button!.color!,
+          primaryColor: themeData.textTheme.labelLarge!.color!,
           errorColor:
               themeData.isLightTheme ? Colors.red : themeData.errorColor,
         ),
@@ -309,7 +309,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         onPressed: () => widget._onCancel(),
         child: Text(
           texts.payment_request_dialog_action_cancel,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
       )
     ];
@@ -336,7 +336,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         }),
         child: Text(
           texts.payment_request_dialog_action_approve,
-          style: themeData.primaryTextTheme.button,
+          style: themeData.primaryTextTheme.labelLarge,
         ),
       ));
     }

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -137,7 +137,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
             widget.invoice.payeeName,
             style: Theme.of(context)
                 .primaryTextTheme
-                .headline4!
+                .headlineMedium!
                 .copyWith(fontSize: 16),
             textAlign: TextAlign.center,
           );

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -234,7 +234,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
               ? fiatConversion.format(widget.invoice.amountMsat ~/ 1000)
               : BitcoinCurrency.fromTickerSymbol(currencyState.bitcoinTicker)
                   .format(widget.invoice.amountMsat ~/ 1000),
-          style: themeData.primaryTextTheme.headline5,
+          style: themeData.primaryTextTheme.headlineSmall,
           textAlign: TextAlign.center,
         ),
       ),

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -152,7 +152,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
       payeeName.isEmpty
           ? texts.payment_request_dialog_requested
           : texts.payment_request_dialog_requesting,
-      style: themeData.primaryTextTheme.headline3!.copyWith(fontSize: 16),
+      style: themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
       textAlign: TextAlign.center,
     );
   }
@@ -258,7 +258,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
                 child: SingleChildScrollView(
                   child: AutoSizeText(
                     description,
-                    style: themeData.primaryTextTheme.headline3!
+                    style: themeData.primaryTextTheme.displaySmall!
                         .copyWith(fontSize: 16),
                     textAlign:
                         description.length > 40 && !description.contains("\n")
@@ -292,7 +292,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         validationError,
         maxLines: 3,
         textAlign: TextAlign.center,
-        style: themeData.primaryTextTheme.headline3!.copyWith(
+        style: themeData.primaryTextTheme.displaySmall!.copyWith(
           fontSize: 16,
           color:
               themeData.isLightTheme ? Colors.red : themeData.colorScheme.error,

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
@@ -41,7 +41,7 @@ class ProcessingPaymentAnimatedContent extends StatelessWidget {
                   color: themeData.isLightTheme
                       ? color
                       : moment >= 0.25
-                          ? themeData.backgroundColor
+                          ? themeData.colorScheme.background
                           : color,
                   shape: RoundedRectangleBorder(
                     borderRadius: BorderRadius.circular(

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -67,7 +67,7 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog> with S
     _currentRoute ??= ModalRoute.of(context);
     colorAnimation = ColorTween(
       begin: Theme.of(context).canvasColor,
-      end: Theme.of(context).backgroundColor,
+      end: Theme.of(context).colorScheme.background,
     ).animate(controller!)
       ..addListener(() {
         setState(() {});

--- a/lib/widgets/receivable_btc_box.dart
+++ b/lib/widgets/receivable_btc_box.dart
@@ -78,7 +78,7 @@ class FeeMessage extends StatelessWidget {
                 children: [
                   Text(
                     formatFeeMessage(context, lspInfo),
-                    style: themeData.textTheme.headline6,
+                    style: themeData.textTheme.titleLarge,
                     textAlign: TextAlign.center,
                   ),
                 ],

--- a/lib/widgets/single_button_bottom_bar.dart
+++ b/lib/widgets/single_button_bottom_bar.dart
@@ -65,7 +65,7 @@ class SubmitButton extends StatelessWidget {
         child: AutoSizeText(
           text,
           maxLines: 1,
-          style: Theme.of(context).textTheme.button,
+          style: Theme.of(context).textTheme.labelLarge,
         ),
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,93 +5,106 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
-    version: "50.0.0"
+    version: "52.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      url: "https://pub.dartlang.org"
+      sha256: "3ff770dfff04a67b0863dff205a0936784de1b87a5e99b11c693fc10e66a9ce3"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.12"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
-    version: "5.2.0"
+    version: "5.4.0"
   another_flushbar:
     dependency: "direct main"
     description:
       name: another_flushbar
-      url: "https://pub.dartlang.org"
+      sha256: fa09f8a4ca582c417669b7b1d0e85ce65bd074d80bb0dcbb1302ad1b22bdc3ef
+      url: "https://pub.dev"
     source: hosted
     version: "1.12.29"
   archive:
     dependency: "direct main"
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   asn1lib:
     dependency: transitive
     description:
       name: asn1lib
-      url: "https://pub.dartlang.org"
+      sha256: ab96a1cb3beeccf8145c52e449233fe68364c9641623acd3adad66f8184f1039
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   auto_size_text:
     dependency: "direct main"
     description:
       name: auto_size_text
-      url: "https://pub.dartlang.org"
+      sha256: "3f5261cd3fb5f2a9ab4e2fc3fba84fd9fcaac8821f20a1d4e71f557521b22599"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   bech32:
     dependency: transitive
     description:
       name: bech32
-      url: "https://pub.dartlang.org"
+      sha256: c36ff22d905b5864cafa7a3cf5e65dd2ca26cff30db1d6a9bd1bbfa2a231e58f
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.1"
   bip39:
     dependency: "direct main"
     description:
       name: bip39
-      url: "https://pub.dartlang.org"
+      sha256: de1ee27ebe7d96b84bb3a04a4132a0a3007dcdd5ad27dd14aa87a29d97c45edc
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      url: "https://pub.dartlang.org"
+      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   breez_sdk:
     dependency: "direct main"
     description:
@@ -112,77 +125,88 @@ packages:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_cli_annotations:
     dependency: transitive
     description:
       name: build_cli_annotations
-      url: "https://pub.dartlang.org"
+      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.3"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   clipboard_watcher:
@@ -198,70 +222,80 @@ packages:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   colorize:
     dependency: transitive
     description:
       name: colorize
-      url: "https://pub.dartlang.org"
+      sha256: "584746cd6ba1cba0633b6720f494fe6f9601c4170f0666c1579d2aa2a61071ba"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   connectivity_plus:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      url: "https://pub.dartlang.org"
+      sha256: "745ebcccb1ef73768386154428a55250bc8d44059c19fd27aecda2a6dc013a22"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: b8795b9238bf83b64375f63492034cb3d8e222af4d9ce59dda085edf038fa06f
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
+      url: "https://pub.dev"
     source: hosted
     version: "1.6.2"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      url: "https://pub.dartlang.org"
+      sha256: f71079978789bc2fe78d79227f1f8cfe195b31bbd8db2399b0d15a4b96fb843b
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.3+2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_lnurl:
@@ -277,154 +311,176 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   dbus:
     dependency: transitive
     description:
       name: dbus
-      url: "https://pub.dartlang.org"
+      sha256: "6f07cba3f7b3448d42d015bfd3d53fe12e5b36da2423f23838efc1d5fb31a263"
+      url: "https://pub.dev"
     source: hosted
     version: "0.7.8"
   drag_and_drop_lists:
     dependency: "direct main"
     description:
       name: drag_and_drop_lists
-      url: "https://pub.dartlang.org"
+      sha256: "9a14595f9880be7953f23578aef88c15cc9b367eeb39dbc1f1bd6af52f70872b"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.3"
   duration:
     dependency: "direct main"
     description:
       name: duration
-      url: "https://pub.dartlang.org"
+      sha256: d0b29d0a345429e3986ac56d60e4aef65b37d11e653022b2b9a4b361332b777f
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.12"
   email_validator:
     dependency: "direct main"
     description:
       name: email_validator
-      url: "https://pub.dartlang.org"
+      sha256: e9a90f27ab2b915a27d7f9c2a7ddda5dd752d6942616ee83529b686fc086221b
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.17"
   encrypt:
     dependency: transitive
     description:
       name: encrypt
-      url: "https://pub.dartlang.org"
+      sha256: "4fd4e4fdc21b9d7d4141823e1e6515cd94e7b8d84749504c232999fba25d9bbb"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.1"
   extended_image:
     dependency: "direct main"
     description:
       name: extended_image
-      url: "https://pub.dartlang.org"
+      sha256: d7e32f19a5c5ee3bfbcb3ff68492d3857bae00acd56e38048a8d53218871998b
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.4"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
-      url: "https://pub.dartlang.org"
+      sha256: b1de389378589e4dffb3564d782373238f19064037458092c49b3043b2791b2b
+      url: "https://pub.dev"
     source: hosted
     version: "3.4.1"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: "direct main"
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   fimber:
     dependency: "direct main"
     description:
       name: fimber
-      url: "https://pub.dartlang.org"
+      sha256: "1415768ddd9fd66f134dbc53f731107554c98175a63d4e93234478a113ffabb8"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.6"
   fimber_io:
     dependency: "direct main"
     description:
       name: fimber_io
-      url: "https://pub.dartlang.org"
+      sha256: "73eb090d4442f845a6ab4eeebbe973ca0f767fd67520ce4e2167aa2e3ae1bea9"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.6"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      url: "https://pub.dartlang.org"
+      sha256: c129209ba55f3d4272c89fb4a4994c15bea77fb6de63a82d45fb6bc5c94e4355
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "5fab93f5b354648efa62e7cc829c90efb68c8796eecf87e0888cae2d5f3accd4"
+      url: "https://pub.dev"
     source: hosted
     version: "4.5.2"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      url: "https://pub.dartlang.org"
+      sha256: "18b35ce111b0a4266abf723c825bcf9d4e2519d13638cc7f06f2a8dd960c75bc"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      url: "https://pub.dartlang.org"
+      sha256: "00a80947fce912f44d30c4fda0a271df3f3fbb7caca4fe15e6ae9ad3f0e5b87f"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.11"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "20e3c50e1272d380bfcaa459e01683d18977673716d165f399065604b5ffd458"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.3+26"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      url: "https://pub.dartlang.org"
+      sha256: dc010a6436333029fba858415fe65887c3fe44d8f6e6ea162bb8d3dd764fbcb6
+      url: "https://pub.dev"
     source: hosted
     version: "14.2.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: abda2d766486096eb1c568c7b20aef46180596c8b0708190b929133ff03e0a8d
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.10"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      url: "https://pub.dartlang.org"
+      sha256: "7a0ce957bd2210e8636325152234728874dad039f1c7271ba1be5c752fdc5888"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.11"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -436,7 +492,8 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      url: "https://pub.dartlang.org"
+      sha256: "890c51c8007f0182360e523518a0c732efb89876cb4669307af7efada5b55557"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.1"
   flutter_fgbg:
@@ -452,70 +509,80 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_fimber
-      url: "https://pub.dartlang.org"
+      sha256: "6b8ba81faca9c786573c3c7e4c94341b890e594803dc433ae57243a7355c917f"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
   flutter_inappwebview:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      url: "https://pub.dartlang.org"
+      sha256: "6d6c741ddba1dba5229d63ba75767064791a7ce845196b45e31105e93d67c949"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.0-beta.22"
   flutter_inappwebview_internal_annotations:
     dependency: transitive
     description:
       name: flutter_inappwebview_internal_annotations
-      url: "https://pub.dartlang.org"
+      sha256: "064a8ccbc76217dcd3b0fd6c6ea6f549e69b2849a0233b5bb46af9632c3ce2ff"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter_keyboard_visibility:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility
-      url: "https://pub.dartlang.org"
+      sha256: "86b71bbaffa38e885f5c21b1182408b9be6951fd125432cf6652c636254cef2d"
+      url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
   flutter_keyboard_visibility_linux:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_linux
-      url: "https://pub.dartlang.org"
+      sha256: "6fba7cd9bb033b6ddd8c2beb4c99ad02d728f1e6e6d9b9446667398b2ac39f08"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   flutter_keyboard_visibility_macos:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_macos
-      url: "https://pub.dartlang.org"
+      sha256: c5c49b16fff453dfdafdc16f26bdd8fb8d55812a1d50b0ce25fc8d9f2e53d086
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   flutter_keyboard_visibility_platform_interface:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: e43a89845873f7be10cb3884345ceb9aebf00a659f479d1c8f4293fcb37022a4
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   flutter_keyboard_visibility_web:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_web
-      url: "https://pub.dartlang.org"
+      sha256: d3771a2e752880c79203f8d80658401d0c998e4183edca05a149f5098ce6e3d1
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   flutter_keyboard_visibility_windows:
     dependency: transitive
     description:
       name: flutter_keyboard_visibility_windows
-      url: "https://pub.dartlang.org"
+      sha256: fc4b0f0b6be9b93ae527f3d527fb56ee2d918cd88bbca438c478af7bcfd0ef73
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   flutter_lints:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_localizations:
@@ -527,63 +594,72 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      url: "https://pub.dartlang.org"
+      sha256: "60fc7b78455b94e6de2333d2f95196d32cf5c22f4b0b0520a628804cb463503b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.7"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      url: "https://pub.dartlang.org"
+      sha256: cf471569b1ca68afaff92152147ef5a34ce7aa3ec3e8775ef58120ad8fec8180
+      url: "https://pub.dev"
     source: hosted
     version: "1.53.0"
   flutter_secure_storage:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      url: "https://pub.dartlang.org"
+      sha256: f2afec1f1762c040a349ea2a588e32f442da5d0db3494a52a929a97c9e550bc5
+      url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      url: "https://pub.dartlang.org"
+      sha256: "736436adaf91552433823f51ce22e098c2f0551db06b6596f58597a25b8ea797"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
       name: flutter_secure_storage_macos
-      url: "https://pub.dartlang.org"
+      sha256: ff0768a6700ea1d9620e03518e2e25eac86a8bd07ca3556e9617bfa5ace4bd00
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_secure_storage_platform_interface:
     dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: b3773190e385a3c8a382007893d678ae95462b3c2279e987b55d140d3b0cb81b
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter_secure_storage_web:
     dependency: transitive
     description:
       name: flutter_secure_storage_web
-      url: "https://pub.dartlang.org"
+      sha256: "42938e70d4b872e856e678c423cc0e9065d7d294f45bc41fc1981a4eb4beaffe"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   flutter_secure_storage_windows:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      url: "https://pub.dartlang.org"
+      sha256: ca89c8059cf439985aa83c59619b3674c7ef6cc2e86943d169a7369d6a69cab5
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.3"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      url: "https://pub.dartlang.org"
+      sha256: "6ff9fa12892ae074092de2fa6a9938fb21dbabfdaa2ff57dc697ff912fc8d4b2"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.6"
   flutter_test:
@@ -609,567 +685,648 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      url: "https://pub.dartlang.org"
+      sha256: e819441678f1679b719008ff2ff0ef045d66eed9f9ec81166ca0d9b02a187454
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   freezed_annotation:
     dependency: transitive
     description:
       name: freezed_annotation
-      url: "https://pub.dartlang.org"
+      sha256: aeac15850ef1b38ee368d4c53ba9a847e900bb2c53a4db3f6881cbb3cb684338
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   hex:
     dependency: "direct main"
     description:
       name: hex
-      url: "https://pub.dartlang.org"
+      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   hive:
     dependency: transitive
     description:
       name: hive
-      url: "https://pub.dartlang.org"
+      sha256: "8dcf6db979d7933da8217edcec84e9df1bdb4e4edc7fc77dbd5aa74356d6d941"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_client_helper:
     dependency: transitive
     description:
       name: http_client_helper
-      url: "https://pub.dartlang.org"
+      sha256: "1f32359bd07a064ad256d1f84ae5f973f69bc972e7287223fa198abe1d969c28"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   hydrated_bloc:
     dependency: "direct main"
     description:
       name: hydrated_bloc
-      url: "https://pub.dartlang.org"
+      sha256: "5871204f14b24638dc9d18d5b94cf22a66fc4be40756925cafff3a7553c7d7b7"
+      url: "https://pub.dev"
     source: hosted
     version: "9.0.0"
   image:
     dependency: "direct main"
     description:
       name: image
-      url: "https://pub.dartlang.org"
+      sha256: "1f9ecf99b08c92dedb699de1d28549f5d79b4423b48cf3f95d6968156db5dd67"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.12"
   image_cropper:
     dependency: "direct main"
     description:
       name: image_cropper
-      url: "https://pub.dartlang.org"
+      sha256: "85324928ee8a8be35a529446435ca53067865b9353c8681983472eeec66d780f"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   image_cropper_for_web:
     dependency: transitive
     description:
       name: image_cropper_for_web
-      url: "https://pub.dartlang.org"
+      sha256: "09e93a8ec0435adcaa23622ac090442872f18145d70b9ff605ffedcf97d56255"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   image_cropper_platform_interface:
     dependency: transitive
     description:
       name: image_cropper_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "62349e3aab63873ea9b9ab9f69d036ab8a0d74b3004beec4303981386cb9273f"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.3"
   image_picker:
     dependency: "direct main"
     description:
       name: image_picker
-      url: "https://pub.dartlang.org"
+      sha256: f98d76672d309c8b7030c323b3394669e122d52b307d2bbd8d06bd70f5b2aabe
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.6+1"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
-      url: "https://pub.dartlang.org"
+      sha256: b1cbfec0f5aef427a18eb573f5445af8c9c568626bf3388553e40c263d3f7368
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.5+5"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      url: "https://pub.dartlang.org"
+      sha256: "7d319fb74955ca46d9bf7011497860e3923bb67feebcf068f489311065863899"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.10"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
-      url: "https://pub.dartlang.org"
+      sha256: "39c013200046d14c58b71dc4fa3d00e425fc9c699d589136cd3ca018727c0493"
+      url: "https://pub.dev"
     source: hosted
     version: "0.8.6+6"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "7cef2f28f4f2fef99180f636c3d446b4ccbafd6ba0fad2adc9a80c4040f656b8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.6.2"
   ini:
     dependency: "direct main"
     description:
       name: ini
-      url: "https://pub.dartlang.org"
+      sha256: "12a76c53591ffdf86d1265be3f986888a6dfeb34a85957774bc65912d989a173"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   intl:
     dependency: "direct main"
     description:
       name: intl
-      url: "https://pub.dartlang.org"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
     source: hosted
     version: "0.18.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   local_auth:
     dependency: "direct main"
     description:
       name: local_auth
-      url: "https://pub.dartlang.org"
+      sha256: "8cea55dca20d1e0efa5480df2d47ae30851e7a24cb8e7d225be7e67ae8485aa4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   local_auth_android:
     dependency: "direct main"
     description:
       name: local_auth_android
-      url: "https://pub.dartlang.org"
+      sha256: ba48fe0e1cae140a0813ce68c2540250d7f573a8ae4d4b6c681b2d2583584953
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.17"
   local_auth_ios:
     dependency: "direct main"
     description:
       name: local_auth_ios
-      url: "https://pub.dartlang.org"
+      sha256: aa32478d7513066564139af57e11e2cad1bbd535c1efd224a88a8764c5665e3b
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.12"
   local_auth_platform_interface:
     dependency: transitive
     description:
       name: local_auth_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: fbb6973f2fd088e2677f39a5ab550aa1cfbc00997859d5e865569872499d6d61
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.6"
   local_auth_windows:
     dependency: transitive
     description:
       name: local_auth_windows
-      url: "https://pub.dartlang.org"
+      sha256: "888482e4f9ca3560e00bc227ce2badeb4857aad450c42a31c6cfc9dc21e0ccbc"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   mobile_scanner:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "531725451c7506f4c57b4720da1fe33a1394cdf9d4a5075a3a2dd51e21113928"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   mockito:
     dependency: "direct main"
     description:
       name: mockito
-      url: "https://pub.dartlang.org"
+      sha256: "2a8a17b82b1bde04d514e75d90d634a0ac23f6cb4991f6098009dd56836aeafe"
+      url: "https://pub.dev"
     source: hosted
     version: "5.3.2"
   nested:
     dependency: transitive
     description:
       name: nested
-      url: "https://pub.dartlang.org"
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   nm:
     dependency: transitive
     description:
       name: nm
-      url: "https://pub.dartlang.org"
+      sha256: "2c9aae4127bdc8993206464fcc063611e0e36e72018696cd9631023a31b24254"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_info_plus:
     dependency: "direct main"
     description:
       name: package_info_plus
-      url: "https://pub.dartlang.org"
+      sha256: f619162573096d428ccde2e33f92e05b5a179cd6f0e3120c1005f181bee8ed16
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   path:
     dependency: "direct main"
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   path_drawing:
     dependency: transitive
     description:
       name: path_drawing
-      url: "https://pub.dartlang.org"
+      sha256: bbb1934c0cbb03091af082a6389ca2080345291ef07a5fa6d6e078ba8682f977
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_parsing:
     dependency: transitive
     description:
       name: path_parsing
-      url: "https://pub.dartlang.org"
+      sha256: e3e67b1629e6f7e8100b367d3db6ba6af4b1f0bb80f64db18ef1fbabd2fa9ccf
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
-      url: "https://pub.dartlang.org"
+      sha256: dcea5feb97d8abf90cab9e9030b497fb7c3cbf26b7a1fe9e3ef7dcb0a1ddec95
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.12"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      url: "https://pub.dartlang.org"
+      sha256: a776c088d671b27f6e3aa8881d64b87b3e80201c64e8869b811325de7a76c15e
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.22"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "6637955e38a5f1851c023482c25a60c93972ea06c8608e2f25ad0064c46c0939"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
-      url: "https://pub.dartlang.org"
+      sha256: ab0987bf95bc591da42dffb38c77398fc43309f0b9b894dcc5d6f40c4b26c379
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.7"
   path_provider_platform_interface:
     dependency: "direct main"
     description:
       name: path_provider_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: f0abc8ebd7253741f05488b4813d936b4d07c6bae3e86148a09e342ee4b08e76
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
-      url: "https://pub.dartlang.org"
+      sha256: bcabbe399d4042b8ee687e17548d5d3f527255253b4a639f5f8d2094a9c2b45c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   petitparser:
     dependency: transitive
     description:
       name: petitparser
-      url: "https://pub.dartlang.org"
+      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   plugin_platform_interface:
     dependency: "direct main"
     description:
       name: plugin_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: dbf0f707c78beedc9200146ad3cb0ab4d5da13c246336987be6940f026500d3a
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   provider:
     dependency: transitive
     description:
       name: provider
-      url: "https://pub.dartlang.org"
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   puppeteer:
     dependency: transitive
     description:
       name: puppeteer
-      url: "https://pub.dartlang.org"
+      sha256: "4e235aaf9a338a45c9eb1ee38956e0ba369867bf144d7a27fdaf245409b2b87b"
+      url: "https://pub.dev"
     source: hosted
     version: "2.21.0"
   qr:
     dependency: transitive
     description:
       name: qr
-      url: "https://pub.dartlang.org"
+      sha256: "5c4208b4dc0d55c3184d10d83ee0ded6212dc2b5e2ba17c5a0c0aab279128d21"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   qr_flutter:
     dependency: "direct main"
     description:
       name: qr_flutter
-      url: "https://pub.dartlang.org"
+      sha256: c5c121c54cb6dd837b9b9d57eb7bc7ec6df4aee741032060c8833a678c80b87e
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
   rxdart:
     dependency: "direct main"
     description:
       name: rxdart
-      url: "https://pub.dartlang.org"
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.27.7"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
-      url: "https://pub.dartlang.org"
+      sha256: e387077716f80609bb979cd199331033326033ecd1c8f200a90c5f57b1c9f55e
+      url: "https://pub.dev"
     source: hosted
     version: "6.3.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "82ddd4ab9260c295e6e39612d4ff00390b9a7a21f1bb1da771e2f232d80ab8a1"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      url: "https://pub.dartlang.org"
+      sha256: "5949029e70abe87f75cfe59d17bf5c397619c4b74a099b10116baeb34786fad9"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.17"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      url: "https://pub.dartlang.org"
+      sha256: "955e9736a12ba776bdd261cf030232b30eadfcd9c79b32a3250dd4a494e8c8f7"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.15"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      url: "https://pub.dartlang.org"
+      sha256: "1ffa239043ab8baf881ec3094a3c767af9d10399b2839020b9e4d44c0bb23951"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
+      sha256: f8ea038aa6da37090093974ebdcf4397010605fd2ff65c37a66f9d28394cb874
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: da9431745ede5ece47bc26d5d73a9d3c6936ef6945c101a5aca46f62e52c1cf3
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      url: "https://pub.dartlang.org"
+      sha256: a4b5bc37fe1b368bbc81f953197d55e12f49d0296e7e412dfe2d2d77d6929958
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.4"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
+      sha256: "5eaf05ae77658d3521d0e993ede1af962d4b326cd2153d312df716dc250f00c9"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   simple_animations:
     dependency: "direct main"
     description:
       name: simple_animations
-      url: "https://pub.dartlang.org"
+      sha256: "6da9a59389d7f6695391f702b0893a0fc63aed2b4d41509cfc1f8781218db635"
+      url: "https://pub.dev"
     source: hosted
     version: "5.0.0+3"
   sky_engine:
@@ -1181,303 +1338,346 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      url: "https://pub.dartlang.org"
+      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.6"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      url: "https://pub.dartlang.org"
+      sha256: b2ed22d1d62c944ec0dac5cc687ae99cb3331c3ebe146d726ed24704634b5ccd
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.1"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      url: "https://pub.dartlang.org"
+      sha256: c282e374de7bfb9a26c22ebcf15bf96ffac08d053c392205b9b3231d4fc4abf3
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.1"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      url: "https://pub.dartlang.org"
+      sha256: db6350456720a4088a364bbe02052d43056a5ffbd4816fe9d28310dcfbe0dc05
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
       name: sqlite3_flutter_libs
-      url: "https://pub.dartlang.org"
+      sha256: ebfdab73610bbd2ec01d8f367b7a1b49ad3a01f398df436f283e4063173ceb7b
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.12"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   synchronized:
     dependency: "direct main"
     description:
       name: synchronized
-      url: "https://pub.dartlang.org"
+      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: b54d427664c00f2013ffb87797a698883c46aee9288e027a50b46eaee7486fa2
+      url: "https://pub.dev"
     source: hosted
     version: "1.22.2"
   test_api:
     dependency: "direct overridden"
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.18"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "95ecc12692d0dd59080ab2d38d9cf32c7e9844caba23ff6cd285690398ee8ef4"
+      url: "https://pub.dev"
     source: hosted
     version: "0.4.22"
   theme_provider:
     dependency: "direct main"
     description:
       name: theme_provider
-      url: "https://pub.dartlang.org"
+      sha256: "0f1d7235bf1b0b09a6b4c0dbefddab0309323c04d4ae8cd2f0e9178be85f8ae4"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.0"
   timeago:
     dependency: "direct main"
     description:
       name: timeago
-      url: "https://pub.dartlang.org"
+      sha256: "46c128312ab0ea144b146c0ac6426ddd96810efec2de3fccc425d00179cd8254"
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.0"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   uni_links:
     dependency: "direct main"
     description:
       name: uni_links
-      url: "https://pub.dartlang.org"
+      sha256: "051098acfc9e26a9fde03b487bef5d3d228ca8f67693480c6f33fd4fbb8e2b6e"
+      url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
   uni_links_platform_interface:
     dependency: transitive
     description:
       name: uni_links_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "929cf1a71b59e3b7c2d8a2605a9cf7e0b125b13bc858e55083d88c62722d4507"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   uni_links_web:
     dependency: transitive
     description:
       name: uni_links_web
-      url: "https://pub.dartlang.org"
+      sha256: "7539db908e25f67de2438e33cc1020b30ab94e66720b5677ba6763b25f6394df"
+      url: "https://pub.dev"
     source: hosted
     version: "0.1.0"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "698fa0b4392effdc73e9e184403b627362eb5fbf904483ac9defbb1c2191d809"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.8"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
-      url: "https://pub.dartlang.org"
+      sha256: "3e2f6dfd2c7d9cd123296cab8ef66cfc2c1a13f5845f42c7a0f365690a8a7dd1"
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.23"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
-      url: "https://pub.dartlang.org"
+      sha256: bb328b24d3bccc20bdf1024a0990ac4f869d57663660de9c936fb8c043edefe3
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.18"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
-      url: "https://pub.dartlang.org"
+      sha256: "318c42cba924e18180c029be69caf0a1a710191b9ec49bb42b5998fdcccee3cc"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
-      url: "https://pub.dartlang.org"
+      sha256: "41988b55570df53b3dd2a7fc90c76756a963de6a8c5f8e113330cb35992e2094"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
-      url: "https://pub.dartlang.org"
+      sha256: "4eae912628763eb48fc214522e58e942fd16ce195407dbf45638239523c759a6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
-      url: "https://pub.dartlang.org"
+      sha256: "44d79408ce9f07052095ef1f9a693c258d6373dc3944249374e30eff7219ccb0"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.14"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      url: "https://pub.dartlang.org"
+      sha256: "387e227c4b979034cc52afb11d66b04ed9b288ca1f45beeef39b2ea69e714fa5"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   validators:
     dependency: transitive
     description:
       name: validators
-      url: "https://pub.dartlang.org"
+      sha256: "884515951f831a9c669a41ed6c4d3c61c2a0e8ec6bca761a4480b28e99cecf5d"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
   vector_math:
     dependency: "direct main"
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: d069ad658b700fc5fb774771ac8997f226ca29a45e0a450776fff3d969c8ba8f
+      url: "https://pub.dev"
     source: hosted
     version: "10.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
-      url: "https://pub.dartlang.org"
+      sha256: c9ebe7ee4ab0c2194e65d3a07d8c54c5d00bb001b76081c4a04cdb8448b59e46
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:
       name: xdg_directories
-      url: "https://pub.dartlang.org"
+      sha256: bd512f03919aac5f1313eb8249f223bacf4927031bf60b02601f81f687689e86
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0+3"
   xml:
     dependency: transitive
     description:
       name: xml
-      url: "https://pub.dartlang.org"
+      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0"
+    version: "6.2.2"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.6 <3.0.0"
+  dart: ">=2.18.6 <4.0.0"
   flutter: ">=3.3.10"


### PR DESCRIPTION
This PR addresses https://github.com/breez/c-breez/issues/436

 #### Changes
- [Rename NavigationDrawer to BreezNavigationDrawer](https://github.com/breez/c-breez/commit/3ac0f8ad6650a474411b0695622965575a3994d0) ⚠️ 
  - Name conflicting with NavigationDrawer widget introduced in Flutter 3.7
 #### Dependency related changes
 - Add UIApplicationSupportsIndirectInputEvents migration
- Content hashing of archives
 #### Fix linter warnings
- [Remove '!' as OverlayState can't be null](https://github.com/breez/c-breez/commit/6738455ca82b3538b5470827d5c65823fc950038)
- [Don't use 'BuildContext's across async gaps.](https://github.com/breez/c-breez/commit/8a5c288f1c7f5c477d59ef6a423dde11865a4f35)
  - [ ] Test SuccessActionDialog and SpontaneousPayment dialog flows
- [Ignore body_might_complete_normally_catch_error for image picker](https://github.com/breez/c-breez/commit/f8ae979451499acadd085d5f728f18db9c7d2f40)
- [Return empty exchange rate list when fetchExchangeRates throws an error](https://github.com/breez/c-breez/commit/180c9265bbdf19dc1d0bdbd8182fc1c69339c4dc)
- [Migrate buildViewportChrome to buildOverscrollIndicator](https://github.com/breez/c-breez/commit/2c8834e72a4a56bc916ea6abdc34bec76d0efe34)
#### Update deprecated members
  - [Use colorScheme.background instead of backgroundColor](https://github.com/breez/c-breez/commit/622ffe875fd90b5d9679a59799814d9d63bb9aaa)
  - [Use bodyMedium instead of bodyText2](https://github.com/breez/c-breez/commit/dbc8f717f30f36c54fa9d99bbbccf15adcaf8003)
  - [Use bodySmall instead of caption](https://github.com/breez/c-breez/commit/0d362bab3ab78b14a011d936c8bb4376718bfa66) 
  - [Use labelLarge instead of button](https://github.com/breez/c-breez/commit/85b5d1bc4eba46e22881e997fe9f5b1939be1bdf) 
  - [Use colorScheme.error instead of errorColor](https://github.com/breez/c-breez/commit/4f824eb1793cccbdf2a378faabe6d4f389ccf067)
   - [Use displaySmall instead of headline3](https://github.com/breez/c-breez/commit/776f2c6aebe72069872a74feace484f2c203fbc6)
   - [Use headlineMedium instead of headline4](https://github.com/breez/c-breez/commit/9a26c57bece4649ea72c1218d3dff4fa7542de4d)
   - [Use headlineSmall instead of headline5](https://github.com/breez/c-breez/commit/4eb090293be1fa9daa4c6997774d78b8ad1302ab)
   - [Use titleLarge instead of headline6](https://github.com/breez/c-breez/commit/429471a078b5fb5eba64df72d951c401b71b512f)
   - [Use titleMedium instead of subtitle1](https://github.com/breez/c-breez/commit/b73a7ba5c0987852ed12912010c2cf0dd9ad0c0a) 
   - [Use titleSmall instead of subtitle2](https://github.com/breez/c-breez/commit/c3a574745548664a0fefb6779a6aaef27317743c)
   - [Use 'const' with the constructor to improve performance](https://github.com/breez/c-breez/commit/95943e13635ada7088c9d42e36f7dc6302e7caed)