### PR TITLE
Fix fee warning handling on receive

### DIFF
--- a/lib/widgets/receivable_btc_box.dart
+++ b/lib/widgets/receivable_btc_box.dart
@@ -94,24 +94,34 @@ class FeeMessage extends StatelessWidget {
 
     final minFee = lspInfo.channelMinimumFeeMsat ~/ 1000;
     final minFeeFormatted = currencyState.bitcoinCurrency.format(minFee);
-    final showMinFeeMessage = minFee > 0;
+    final minFeeAboveZero = minFee > 0;
     final setUpFee = (lspInfo.channelFeePermyriad / 100).toString();
     final liquidity = currencyState.bitcoinCurrency.format(
       accountState.maxInboundLiquidity,
     );
+    final liquidityAboveZero = accountState.maxInboundLiquidity > 0;
 
-    if (showMinFeeMessage) {
+    if (minFeeAboveZero && liquidityAboveZero) {
+      // A setup fee of {setUpFee}% with a minimum of {minFee} will be applied for receiving more than {liquidity}
       return texts.invoice_ln_address_warning_with_min_fee_account_connected(
         setUpFee,
         minFeeFormatted,
         liquidity,
       );
-    } else if (!showMinFeeMessage) {
+    } else if (!minFeeAboveZero && liquidityAboveZero) {
+      // A setup fee of {setUpFee}% will be applied for receiving more than {liquidity}.
       return texts.invoice_ln_address_warning_without_min_fee_account_connected(
         setUpFee,
         liquidity,
       );
+    } else if (minFeeAboveZero && !liquidityAboveZero) {
+      // A setup fee of {setUpFee}% with a minimum of {minFee} will be applied on the received amount.
+      return texts.invoice_ln_address_warning_with_min_fee_account_not_connected(
+        setUpFee,
+        minFeeFormatted,
+      );
     } else {
+      // A setup fee of {setUpFee}% will be applied on the received amount.
       return texts
           .invoice_ln_address_warning_without_min_fee_account_not_connected(
         setUpFee,


### PR DESCRIPTION
On a fresh setup (no channel open yet), creating an invoice would result in a fee warning like:

> A setup fee of 0.4% with a minimum of 2000 sats will be applied for receiving more than 0 sats.

The zero sat ending was due to the missing channel.

With this PR, the warning is

> A setup fee of 0.4% with a minimum of 2000 sats will be applied on the received amount.

Fixes https://github.com/breez/c-breez/issues/399