### PR TITLE
Use SDK Models for payment result handling

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -14,14 +14,14 @@ PODS:
   - Firebase/Messaging (10.3.0):
     - Firebase/CoreOnly
     - FirebaseMessaging (~> 10.3.0)
-  - firebase_core (2.4.1):
+  - firebase_core (2.5.0):
     - Firebase/CoreOnly (= 10.3.0)
     - Flutter
-  - firebase_dynamic_links (5.0.11):
+  - firebase_dynamic_links (5.0.12):
     - Firebase/DynamicLinks (= 10.3.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (14.2.1):
+  - firebase_messaging (14.2.2):
     - Firebase/Messaging (= 10.3.0)
     - firebase_core
     - Flutter
@@ -29,11 +29,11 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/Logger (~> 7.8)
-  - FirebaseCoreInternal (10.4.0):
+  - FirebaseCoreInternal (10.5.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseDynamicLinks (10.3.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.4.0):
+  - FirebaseInstallations (10.5.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -278,13 +278,13 @@ SPEC CHECKSUMS:
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: 413a8857dd5d9f1c399a39130850d02fe0feaf7e
   Firebase: f92fc551ead69c94168d36c2b26188263860acd9
-  firebase_core: bf59c32d2e53814f558efa20840c1902fa2fe461
-  firebase_dynamic_links: e5ca49679928f5d46e2db5168656975eae39d379
-  firebase_messaging: ee597229fc260f8fa491fa8f2d4a32dfbfa406fa
+  firebase_core: f95c8bbe65213d406d592573ad42a12d64849cb8
+  firebase_dynamic_links: e54ad1b1b2e5eb156d3a9df7373b68feef7293b3
+  firebase_messaging: 3daef9f9ee5b91de2f282895ec91cc5e5ca78556
   FirebaseCore: 988754646ab3bd4bdcb740f1bfe26b9f6c0d5f2a
-  FirebaseCoreInternal: e301297f4c15a17489e48ed722d733b1578e0c02
+  FirebaseCoreInternal: e463f41bb935cd049505bf7e9a5bdd7dcea90df6
   FirebaseDynamicLinks: 51c81d07bd63155bb56d76b0abdda79c8a3d8d02
-  FirebaseInstallations: 36b38c733fd37e50857e5e8d74138648f466f18c
+  FirebaseInstallations: 935bc4abb6f7a035cab7a0c31cb777b2be3dd254
   FirebaseMessaging: e345b219fd15d325f0cf2fef28cb8ce00d851b3f
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
@@ -319,7 +319,7 @@ SPEC CHECKSUMS:
   sqlite3_flutter_libs: c00751e981228acb63595236703da79d31282b63
   TOCropViewController: edfd4f25713d56905ad1e0b9f5be3fbe0f59c863
   uni_links: d97da20c7701486ba192624d99bffaaffcfc298a
-  url_launcher_ios: ae1517e5e344f5544fb090b079e11f399dfbe4d2
+  url_launcher_ios: fb12c43172927bb5cf75aeebd073f883801f1993
 
 PODFILE CHECKSUM: c96af939aa4bed7ae41ad6e1d2e156da5f5ee11a
 

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -193,7 +193,6 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       return callbackStatus;
     } catch (e) {
       _log.e("lnurlWithdraw error", ex: e);
-      _paymentResultStreamController.add(PaymentResult(error: e));
       rethrow;
     }
   }
@@ -221,7 +220,6 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       return lnurlPayResult;
     } catch (e) {
       _log.e("lnurlPay error", ex: e);
-      _paymentResultStreamController.add(PaymentResult(error: e));
       rethrow;
     }
   }

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -178,7 +178,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       if (callbackStatus is sdk.LnUrlWithdrawCallbackStatus_Ok) {
         _paymentResultStreamController.add(
           PaymentResult(
-            paymentInfo: state.payments.last,
+            paymentInfo: state.payments.first,
           ),
         );
       }
@@ -204,7 +204,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       );
       _paymentResultStreamController.add(
         PaymentResult(
-          paymentInfo: state.payments.last,
+          paymentInfo: state.payments.first,
           successAction: (lnurlPayResult is sdk.LnUrlPayResult_EndpointSuccess)
               ? lnurlPayResult.data
               : null,
@@ -223,7 +223,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     try {
       await _breezLib.sendPayment(bolt11: bolt11, amountSats: amountSats);
       _paymentResultStreamController.add(
-        PaymentResult(paymentInfo: state.payments.last),
+        PaymentResult(paymentInfo: state.payments.first),
       );
     } catch (e) {
       _log.e("sendPayment error", ex: e);
@@ -246,7 +246,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       await _breezLib.sendSpontaneousPayment(
           nodeId: nodeId, amountSats: amountSats);
       _paymentResultStreamController.add(
-        PaymentResult(paymentInfo: state.payments.last),
+        PaymentResult(paymentInfo: state.payments.first),
       );
     } catch (e) {
       _log.e("sendSpontaneousPayment error", ex: e);

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -95,7 +95,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       seed: seed,
     );
     _log.i("node registered successfully");
-    await _credentialsManager.storeCredentials(glCreds: creds, mnemonic: mnemonic);
+    await _credentialsManager.storeCredentials(
+      glCreds: creds,
+      mnemonic: mnemonic,
+    );
     emit(state.copyWith(initial: false));
     await _startSdkForever();
     _log.i("new node started");
@@ -113,7 +116,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       seed: seed,
     );
     _log.i("node recovered successfully");
-    await _credentialsManager.storeCredentials(glCreds: creds, mnemonic: mnemonic);
+    await _credentialsManager.storeCredentials(
+      glCreds: creds,
+      mnemonic: mnemonic,
+    );
     emit(state.copyWith(initial: false));
     await _startSdkForever();
     _log.i("recovered node started");
@@ -242,11 +248,13 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     int amountSats,
   ) async {
     _log.v("sendSpontaneousPayment: $nodeId, $description, $amountSats");
+    _log.i("description field is not being used by the SDK yet");
     try {
       await _breezLib.sendSpontaneousPayment(
-          nodeId: nodeId, amountSats: amountSats);
       _paymentResultStreamController.add(
         PaymentResult(paymentInfo: state.payments.first),
+        nodeId: nodeId,
+        amountSats: amountSats,
       );
     } catch (e) {
       _log.e("sendSpontaneousPayment error", ex: e);

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -8,7 +8,7 @@ import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/account/credential_manager.dart';
 import 'package:c_breez/bloc/account/payment_error.dart';
 import 'package:c_breez/bloc/account/payment_filters.dart';
-import 'package:c_breez/bloc/account/payment_result_data.dart';
+import 'package:c_breez/bloc/account/payment_result.dart';
 import 'package:c_breez/config.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:fimber/fimber.dart';
@@ -31,10 +31,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   static const String paymentFilterSettingsKey = "payment_filter_settings";
   static const int defaultInvoiceExpiry = Duration.secondsPerHour;
 
-  final StreamController<PaymentResultData> _paymentResultStreamController =
-      StreamController<PaymentResultData>();
+  final StreamController<PaymentResult> _paymentResultStreamController =
+      StreamController<PaymentResult>();
 
-  Stream<PaymentResultData> get paymentResultStream =>
+  Stream<PaymentResult> get paymentResultStream =>
       _paymentResultStreamController.stream;
 
   final StreamController<PaymentFilters> _paymentFiltersStreamController =
@@ -72,14 +72,14 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     );
   }
 
-  Future _startRegisteredNode() async {    
+  Future _startRegisteredNode() async {
     final credentials = await _credentialsManager.restoreCredentials();
     final seed = bip39.mnemonicToSeed(credentials.mnemonic);
     await _breezLib.initServices(
       config: (await Config.instance()).sdkConfig,
       seed: seed,
       creds: credentials.glCreds,
-    );    
+    );
     await _startSdkForever();
   }
 
@@ -116,10 +116,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     await _credentialsManager.storeCredentials(glCreds: creds, mnemonic: mnemonic);
     emit(state.copyWith(initial: false));
     await _startSdkForever();
-    _log.i("recovered node started");    
+    _log.i("recovered node started");
   }
 
-  Future _startSdkForever() async {            
+  Future _startSdkForever() async {
     await _startSdkOnce();
 
     // in case we failed to start (lack of inet connection probably)
@@ -127,14 +127,15 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
       StreamSubscription<ConnectivityResult>? subscription;
       subscription = Connectivity().onConnectivityChanged.listen((event) async {
         // we should try fetch the selected lsp information when internet is back.
-        if (event != ConnectivityResult.none && state.status == ConnectionStatus.DISCONNECTED) {
+        if (event != ConnectivityResult.none &&
+            state.status == ConnectionStatus.DISCONNECTED) {
           await _startSdkOnce();
           if (state.status == ConnectionStatus.CONNECTED) {
             subscription!.cancel();
             _onConnected();
           }
         }
-      });  
+      });
     } else {
       _onConnected();
     }
@@ -142,10 +143,10 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
 
   Future _startSdkOnce() async {
     try {
-    emit(state.copyWith(status: ConnectionStatus.CONNECTING));
-    await _breezLib.startNode();
-    emit(state.copyWith(status: ConnectionStatus.CONNECTED));
-    } catch(e) {
+      emit(state.copyWith(status: ConnectionStatus.CONNECTING));
+      await _breezLib.startNode();
+      emit(state.copyWith(status: ConnectionStatus.CONNECTED));
+    } catch (e) {
       emit(state.copyWith(status: ConnectionStatus.DISCONNECTED));
     }
   }
@@ -153,8 +154,9 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   // Once connected sync sdk periodically on foreground events.
   void _onConnected() {
     var lastSync = DateTime.fromMillisecondsSinceEpoch(0);
-    FGBGEvents.stream.listen((event) async {            
-      if (event == FGBGType.foreground && DateTime.now().difference(lastSync).inSeconds > nodeSyncInterval ) {
+    FGBGEvents.stream.listen((event) async {
+      if (event == FGBGType.foreground &&
+          DateTime.now().difference(lastSync).inSeconds > nodeSyncInterval) {
         await _breezLib.syncNode();
         lastSync = DateTime.now();
       }
@@ -168,13 +170,22 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     _log.v(
         "lnurlWithdraw amount: $amountSats, description: '$description', reqData: $reqData");
     try {
-      return _breezLib.lnurlWithdraw(
+      final callbackStatus = await _breezLib.lnurlWithdraw(
         amountSats: amountSats,
         reqData: reqData,
         description: description,
       );
+      if (callbackStatus is sdk.LnUrlWithdrawCallbackStatus_Ok) {
+        _paymentResultStreamController.add(
+          PaymentResult(
+            paymentInfo: state.payments.last,
+          ),
+        );
+      }
+      return callbackStatus;
     } catch (e) {
       _log.e("lnurlWithdraw error", ex: e);
+      _paymentResultStreamController.add(PaymentResult(error: e));
       rethrow;
     }
   }
@@ -186,13 +197,23 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   }) async {
     _log.v("lnurlPay amount: $amount, comment: '$comment', reqData: $reqData");
     try {
-      return _breezLib.lnurlPay(
+      final lnurlPayResult = await _breezLib.lnurlPay(
         userAmountSat: amount,
         reqData: reqData,
         comment: comment,
       );
+      _paymentResultStreamController.add(
+        PaymentResult(
+          paymentInfo: state.payments.last,
+          successAction: (lnurlPayResult is sdk.LnUrlPayResult_EndpointSuccess)
+              ? lnurlPayResult.data
+              : null,
+        ),
+      );
+      return lnurlPayResult;
     } catch (e) {
       _log.e("lnurlPay error", ex: e);
+      _paymentResultStreamController.add(PaymentResult(error: e));
       rethrow;
     }
   }
@@ -201,9 +222,12 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     _log.v("sendPayment: $bolt11, $amountSats");
     try {
       await _breezLib.sendPayment(bolt11: bolt11, amountSats: amountSats);
+      _paymentResultStreamController.add(
+        PaymentResult(paymentInfo: state.payments.last),
+      );
     } catch (e) {
       _log.e("sendPayment error", ex: e);
-      _paymentResultStreamController.add(PaymentResultData(error: e));
+      _paymentResultStreamController.add(PaymentResult(error: e));
       return Future.error(e);
     }
   }
@@ -219,11 +243,14 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   ) async {
     _log.v("sendSpontaneousPayment: $nodeId, $description, $amountSats");
     try {
-      return await _breezLib.sendSpontaneousPayment(
+      await _breezLib.sendSpontaneousPayment(
           nodeId: nodeId, amountSats: amountSats);
+      _paymentResultStreamController.add(
+        PaymentResult(paymentInfo: state.payments.last),
+      );
     } catch (e) {
       _log.e("sendSpontaneousPayment error", ex: e);
-      _paymentResultStreamController.add(PaymentResultData(error: e));
+      _paymentResultStreamController.add(PaymentResult(error: e));
       return Future.error(e);
     }
   }

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -178,19 +178,11 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     _log.v(
         "lnurlWithdraw amount: $amountSats, description: '$description', reqData: $reqData");
     try {
-      final callbackStatus = await _breezLib.lnurlWithdraw(
+      return await _breezLib.lnurlWithdraw(
         amountSats: amountSats,
         reqData: reqData,
         description: description,
       );
-      if (callbackStatus is sdk.LnUrlWithdrawCallbackStatus_Ok) {
-        _paymentResultStreamController.add(
-          PaymentResult(
-            paymentInfo: state.payments.first,
-          ),
-        );
-      }
-      return callbackStatus;
     } catch (e) {
       _log.e("lnurlWithdraw error", ex: e);
       rethrow;
@@ -204,20 +196,11 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
   }) async {
     _log.v("lnurlPay amount: $amount, comment: '$comment', reqData: $reqData");
     try {
-      final lnurlPayResult = await _breezLib.lnurlPay(
+      return await _breezLib.lnurlPay(
         userAmountSat: amount,
         reqData: reqData,
         comment: comment,
       );
-      _paymentResultStreamController.add(
-        PaymentResult(
-          paymentInfo: state.payments.first,
-          successAction: (lnurlPayResult is sdk.LnUrlPayResult_EndpointSuccess)
-              ? lnurlPayResult.data
-              : null,
-        ),
-      );
-      return lnurlPayResult;
     } catch (e) {
       _log.e("lnurlPay error", ex: e);
       rethrow;

--- a/lib/bloc/account/payment_error.dart
+++ b/lib/bloc/account/payment_error.dart
@@ -6,6 +6,14 @@ class PaymentExceededLimitError implements Exception {
   );
 }
 
+class PaymentBelowLimitError implements Exception {
+  final int limitSat;
+
+  const PaymentBelowLimitError(
+    this.limitSat,
+  );
+}
+
 class PaymentBelowReserveError implements Exception {
   final int reserveAmount;
 

--- a/lib/bloc/account/payment_result.dart
+++ b/lib/bloc/account/payment_result.dart
@@ -6,12 +6,10 @@ import 'package:c_breez/utils/exceptions.dart';
 class PaymentResult {
   final Payment? paymentInfo;
   final Object? error;
-  final SuccessAction? successAction;
 
   const PaymentResult({
     this.paymentInfo,
     this.error,
-    this.successAction,
   });
 
   String errorMessage(CurrencyState currencyState) {

--- a/lib/bloc/account/payment_result.dart
+++ b/lib/bloc/account/payment_result.dart
@@ -1,23 +1,23 @@
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
-import 'package:c_breez/routes/lnurl/payment/success_action/success_action_data.dart';
 import 'package:c_breez/utils/exceptions.dart';
 
-class PaymentResultData {
+class PaymentResult {
   final Payment? paymentInfo;
   final Object? error;
-  final SuccessActionData? successActionData;
+  final SuccessAction? successAction;
 
-  const PaymentResultData({
+  const PaymentResult({
     this.paymentInfo,
     this.error,
-    this.successActionData,
+    this.successAction,
   });
 
   String errorMessage(CurrencyState currencyState) {
     final texts = getSystemAppLocalizations();
-    String? displayMessage = error != null ? extractExceptionMessage(error!) : null;
+    String? displayMessage =
+        error != null ? extractExceptionMessage(error!) : null;
     return displayMessage != null
         ? texts.payment_error_to_send(displayMessage)
         : texts.payment_error_to_send_unknown_reason;

--- a/lib/bloc/input/input_bloc.dart
+++ b/lib/bloc/input/input_bloc.dart
@@ -59,7 +59,7 @@ class InputBloc extends Cubit<InputState> {
       emit(InputState(isLoading: true));
       try {
         final command = await breez_sdk.InputParser().parse(s);
-        _log.v("Parsed command: '$command'");
+        _log.v("Parsed command: '${command.protocol}'");
         switch (command.protocol) {
           case breez_sdk.InputProtocol.paymentRequest:
             return handlePaymentRequest(s, command);

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -56,7 +56,6 @@ class InputHandler {
     }).onError((error) {
       _handlingRequest = false;
       _setLoading(false);
-      showFlushbar(_context, message: extractExceptionMessage(error));
     });
   }
 
@@ -117,7 +116,8 @@ class InputHandler {
     } else if (action is SuccessAction_Url) {
       final description = action.field0.description;
       final url = action.field0.url;
-      _log.v("Handle LNURL payment page result with url action '$description', '$url'");
+      _log.v(
+          "Handle LNURL payment page result with url action '$description', '$url'");
     } else {
       _log.v("Handle LNURL payment page result with unknown action '$action'");
     }

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -2,7 +2,6 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
-import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
@@ -20,10 +19,7 @@ class PaymentResultHandler {
     accountBloc.paymentResultStream.delay(const Duration(seconds: 1)).listen(
       (paymentResult) async {
         _log.v("Received paymentResult: $paymentResult");
-        if (paymentResult.successAction != null) {
-          _log.v("paymentResult successAction: ${paymentResult.successAction}");
-          handleSuccessAction(context, paymentResult.successAction!);
-        } else if (paymentResult.paymentInfo != null) {
+        if (paymentResult.paymentInfo != null) {
           final texts = context.texts();
           showFlushbar(
             context,
@@ -43,20 +39,6 @@ class PaymentResultHandler {
           );
         }
       },
-    );
-  }
-
-  Future handleSuccessAction(
-    BuildContext context,
-    SuccessAction successAction,
-  ) async {
-    // Artificial delay for UX purposes
-    return Future.delayed(const Duration(seconds: 1)).then(
-      (_) => showDialog(
-        useRootNavigator: false,
-        context: context,
-        builder: (_) => SuccessActionDialog(successAction),
-      ),
     );
   }
 }

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -29,9 +29,10 @@ class PaymentResultHandler {
             context,
             messageWidget: SingleChildScrollView(
               child: Text(
-                  paymentResult.paymentInfo!.paymentType == PaymentType.Received
-                      ? texts.successful_payment_received
-                      : texts.home_payment_sent),
+                paymentResult.paymentInfo!.paymentType == PaymentType.Received
+                    ? texts.successful_payment_received
+                    : texts.home_payment_sent,
+              ),
             ),
           );
         } else if (paymentResult.error != null) {

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -1,7 +1,7 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/routes/lnurl/payment/success_action/success_action_data.dart';
 import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
@@ -15,13 +15,17 @@ class PaymentResultHandler {
     accountBloc.paymentResultStream.listen(
       (paymentResult) async {
         Future.delayed(const Duration(seconds: 1), () {
-          if (paymentResult.successActionData != null) {
-            handleSuccessAction(context, paymentResult.successActionData!);
+          if (paymentResult.successAction != null) {
+            handleSuccessAction(context, paymentResult.successAction!);
           } else if (paymentResult.paymentInfo != null) {
+            final texts = context.texts();
             showFlushbar(
               context,
               messageWidget: SingleChildScrollView(
-                child: Text(context.texts().home_payment_sent),
+                child: Text(paymentResult.paymentInfo!.paymentType ==
+                        PaymentType.Received
+                    ? texts.successful_payment_received
+                    : texts.home_payment_sent),
               ),
             );
           } else if (paymentResult.error != null) {
@@ -37,14 +41,14 @@ class PaymentResultHandler {
 
   Future handleSuccessAction(
     BuildContext context,
-    SuccessActionData successActionData,
+    SuccessAction successAction,
   ) async {
     // Artificial delay for UX purposes
     return Future.delayed(const Duration(seconds: 1)).then(
       (_) => showDialog(
         useRootNavigator: false,
         context: context,
-        builder: (_) => SuccessActionDialog(successActionData),
+        builder: (_) => SuccessActionDialog(successAction),
       ),
     );
   }

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -4,37 +4,43 @@ import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/widgets/flushbar.dart';
+import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
+import 'package:rxdart/rxdart.dart';
 
 class PaymentResultHandler {
+  final _log = FimberLog("PaymentResultHandler");
+
   final BuildContext context;
   final AccountBloc accountBloc;
   final CurrencyBloc currencyBloc;
 
   PaymentResultHandler(this.context, this.accountBloc, this.currencyBloc) {
-    accountBloc.paymentResultStream.listen(
+    _log.v("PaymentResultHandler created");
+    accountBloc.paymentResultStream.delay(const Duration(seconds: 1)).listen(
       (paymentResult) async {
-        Future.delayed(const Duration(seconds: 1), () {
-          if (paymentResult.successAction != null) {
-            handleSuccessAction(context, paymentResult.successAction!);
-          } else if (paymentResult.paymentInfo != null) {
-            final texts = context.texts();
-            showFlushbar(
-              context,
-              messageWidget: SingleChildScrollView(
-                child: Text(paymentResult.paymentInfo!.paymentType ==
-                        PaymentType.Received
-                    ? texts.successful_payment_received
-                    : texts.home_payment_sent),
-              ),
-            );
-          } else if (paymentResult.error != null) {
-            showFlushbar(
-              context,
-              message: paymentResult.errorMessage(currencyBloc.state),
-            );
-          }
-        });
+        _log.v("Received paymentResult: $paymentResult");
+        if (paymentResult.successAction != null) {
+          _log.v("paymentResult successAction: ${paymentResult.successAction}");
+          handleSuccessAction(context, paymentResult.successAction!);
+        } else if (paymentResult.paymentInfo != null) {
+          final texts = context.texts();
+          showFlushbar(
+            context,
+            messageWidget: SingleChildScrollView(
+              child: Text(
+                  paymentResult.paymentInfo!.paymentType == PaymentType.Received
+                      ? texts.successful_payment_received
+                      : texts.home_payment_sent),
+            ),
+          );
+        } else if (paymentResult.error != null) {
+          _log.v("paymentResult error: ${paymentResult.error}");
+          showFlushbar(
+            context,
+            message: paymentResult.errorMessage(currencyBloc.state),
+          );
+        }
       },
     );
   }

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -167,7 +167,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       useRootNavigator: false,
       context: context,
       barrierDismissible: false,
-      builder: (_) => LnulrWithdrawDialog(
+      builder: (_) => LNURLWithdrawDialog(
         requestData: data,
         amountSats: currencyBloc.state.bitcoinCurrency.parse(
           _amountController.text,

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -2,12 +2,15 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
+import 'package:c_breez/bloc/account/payment_error.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/routes/create_invoice/qr_code_dialog.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
+import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
+import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
@@ -22,9 +25,20 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class CreateInvoicePage extends StatefulWidget {
+  final Function(LNURLWithdrawPageResult? result)? onFinish;
+  final LnUrlWithdrawRequestData? requestData;
+  final String? domain;
+
   const CreateInvoicePage({
     Key? key,
-  }) : super(key: key);
+    this.requestData,
+    this.domain,
+    this.onFinish,
+  })  : assert(
+          requestData == null || (domain != null && onFinish != null),
+          "If you are using LNURL withdraw, you must provide a domain and an onFinish callback.",
+        ),
+        super(key: key);
 
   @override
   State<StatefulWidget> createState() {
@@ -43,6 +57,12 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
   @override
   void initState() {
     _doneAction = KeyboardDoneAction(focusNodes: [_amountFocusNode]);
+
+    final data = widget.requestData;
+    if (data != null) {
+      _amountController.text = (data.maxWithdrawable ~/ 1000).toString();
+      _descriptionController.text = data.defaultDescription;
+    }
     super.initState();
   }
 
@@ -119,12 +139,41 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       ),
       bottomNavigationBar: SingleButtonBottomBar(
         stickToBottom: true,
-        text: texts.invoice_action_create,
+        text: widget.requestData != null ? texts.invoice_action_redeem : texts.invoice_action_create,
         onPressed: () {
           if (_formKey.currentState?.validate() ?? false) {
-            _createInvoice(context);
+            final data = widget.requestData;
+            if (data != null) {
+              _withdraw(context, data);
+            } else {
+              _createInvoice(context);
+            }
           }
         },
+      ),
+    );
+  }
+
+  Future<void> _withdraw(
+    BuildContext context,
+    LnUrlWithdrawRequestData data,
+  ) async {
+    final CurrencyBloc currencyBloc = context.read<CurrencyBloc>();
+
+    final navigator = Navigator.of(context);
+    navigator.pop();
+
+    showDialog(
+      useRootNavigator: false,
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => LnulrWithdrawDialog(
+        requestData: data,
+        amountSats: currencyBloc.state.bitcoinCurrency.parse(
+          _amountController.text,
+        ),
+        domain: widget.domain!,
+        onFinish: widget.onFinish!,
       ),
     );
   }
@@ -185,10 +234,31 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     int? channelMinimumFee = lspInfo!.channelMinimumFeeMsat ~/ 1000;
 
     return PaymentValidator(
-      context.read<AccountBloc>().validatePayment,
-      context.read<CurrencyBloc>().state.bitcoinCurrency,
+      validatePayment: _validatePayment,
+      currency: context.read<CurrencyBloc>().state.bitcoinCurrency,
       channelMinimumFee: channelMinimumFee,
       texts: context.texts(),
     ).validateIncoming(amount);
+  }
+
+  void _validatePayment(
+    int amount,
+    bool outgoing, {
+    int? channelMinimumFee,
+  }) {
+    final data = widget.requestData;
+    if (data != null) {
+      if (amount > data.maxWithdrawable ~/ 1000) {
+        throw PaymentExceededLimitError(data.maxWithdrawable ~/ 1000);
+      }
+      if (amount < data.minWithdrawable ~/ 1000) {
+        throw PaymentBelowLimitError(data.minWithdrawable ~/ 1000);
+      }
+    }
+    return context.read<AccountBloc>().validatePayment(
+          amount,
+          outgoing,
+          channelMinimumFee: channelMinimumFee,
+        );
   }
 }

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -257,8 +257,8 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
     }
 
     return PaymentValidator(
-      accBloc.validatePayment,
-      currencyState.bitcoinCurrency,
+      validatePayment: accBloc.validatePayment,
+      currency: currencyState.bitcoinCurrency,
       channelMinimumFee: channelMinimumFee,
       texts: context.texts(),
     ).validateIncoming(amount);

--- a/lib/routes/lnurl/payment/pay_response.dart
+++ b/lib/routes/lnurl/payment/pay_response.dart
@@ -2,7 +2,7 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/utils/exceptions.dart';
 
 class LNURLPaymentPageResult {
-  final SuccessAction? successAction;
+  final SuccessActionProcessed? successAction;
   final Object? error;
 
   const LNURLPaymentPageResult({

--- a/lib/routes/lnurl/payment/success_action/success_action_data.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_data.dart
@@ -1,6 +1,0 @@
-class SuccessActionData {
-  final String message;
-  final String? url;
-
-  SuccessActionData(this.message, this.url);
-}

--- a/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
@@ -1,5 +1,4 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/utils/external_browser.dart';
@@ -7,9 +6,10 @@ import 'package:c_breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 
 class SuccessActionDialog extends StatefulWidget {
-  final SuccessAction successAction;
+  final String message;
+  final String? url;
 
-  const SuccessActionDialog(this.successAction);
+  const SuccessActionDialog({required this.message, this.url});
 
   @override
   State<StatefulWidget> createState() {
@@ -22,7 +22,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final texts = context.texts();
-    final successAction = widget.successAction;
+
     return AlertDialog(
       content: SizedBox(
         width: MediaQuery.of(context).size.width,
@@ -30,13 +30,8 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           children: [
-            if (successAction is SuccessAction_Message) ...[
-              Message(successAction.field0.message)
-            ],
-            if (successAction is SuccessAction_Url) ...[
-              Message(successAction.field0.description),
-              URLText(successAction.field0.url)
-            ],
+            Message(widget.message),
+            if (widget.url != null) ...[URLText(widget.url!)]
           ],
         ),
       ),
@@ -59,7 +54,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
             style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
-        if (successAction is SuccessAction_Url) ...[
+        if (widget.url != null) ...[
           TextButton(
             style: ButtonStyle(
               overlayColor: MaterialStateProperty.resolveWith<Color>(
@@ -77,11 +72,12 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
               style: themeData.primaryTextTheme.labelLarge,
             ),
             onPressed: () async {
+              final String url = widget.url!;
               final navigator = Navigator.of(context);
               try {
                 await launchLinkOnExternalBrowser(
                   context,
-                  linkAddress: successAction.field0.url,
+                  linkAddress: url,
                 );
                 navigator.pop();
               } catch (e) {

--- a/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
+++ b/lib/routes/lnurl/payment/success_action/success_action_dialog.dart
@@ -1,15 +1,15 @@
 import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/routes/lnurl/payment/success_action/success_action_data.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/utils/external_browser.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
 
 class SuccessActionDialog extends StatefulWidget {
-  final SuccessActionData successActionData;
+  final SuccessAction successAction;
 
-  const SuccessActionDialog(this.successActionData);
+  const SuccessActionDialog(this.successAction);
 
   @override
   State<StatefulWidget> createState() {
@@ -22,7 +22,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final texts = context.texts();
-
+    final successAction = widget.successAction;
     return AlertDialog(
       content: SizedBox(
         width: MediaQuery.of(context).size.width,
@@ -30,10 +30,13 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
           mainAxisAlignment: MainAxisAlignment.center,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Message(widget.successActionData.message),
-            if (widget.successActionData.url != null) ...[
-              URLText(widget.successActionData.url!)
-            ]
+            if (successAction is SuccessAction_Message) ...[
+              Message(successAction.field0.message)
+            ],
+            if (successAction is SuccessAction_Url) ...[
+              Message(successAction.field0.description),
+              URLText(successAction.field0.url)
+            ],
           ],
         ),
       ),
@@ -56,7 +59,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
             style: themeData.primaryTextTheme.labelLarge,
           ),
         ),
-        if (widget.successActionData.url != null) ...[
+        if (successAction is SuccessAction_Url) ...[
           TextButton(
             style: ButtonStyle(
               overlayColor: MaterialStateProperty.resolveWith<Color>(
@@ -78,7 +81,7 @@ class SuccessActionDialogState extends State<SuccessActionDialog> {
               try {
                 await launchLinkOnExternalBrowser(
                   context,
-                  linkAddress: widget.successActionData.url!,
+                  linkAddress: successAction.field0.url,
                 );
                 navigator.pop();
               } catch (e) {
@@ -112,8 +115,8 @@ class Message extends StatelessWidget {
           child: SingleChildScrollView(
             child: AutoSizeText(
               message,
-              style:
-                  themeData.primaryTextTheme.displaySmall!.copyWith(fontSize: 16),
+              style: themeData.primaryTextTheme.displaySmall!
+                  .copyWith(fontSize: 16),
               textAlign: message.length > 40 && !message.contains("\n")
                   ? TextAlign.start
                   : TextAlign.center,

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -9,15 +9,15 @@ import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-final _log = FimberLog("LnulrWithdrawDialog");
+final _log = FimberLog("LNURLWithdrawDialog");
 
-class LnulrWithdrawDialog extends StatefulWidget {
+class LNURLWithdrawDialog extends StatefulWidget {
   final Function(LNURLWithdrawPageResult? result) onFinish;
   final sdk.LnUrlWithdrawRequestData requestData;
   final int amountSats;
   final String domain;
 
-  const LnulrWithdrawDialog({
+  const LNURLWithdrawDialog({
     super.key,
     required this.requestData,
     required this.amountSats,
@@ -26,10 +26,10 @@ class LnulrWithdrawDialog extends StatefulWidget {
   });
 
   @override
-  State<LnulrWithdrawDialog> createState() => _LnulrWithdrawDialogState();
+  State<LNURLWithdrawDialog> createState() => _LNURLWithdrawDialogState();
 }
 
-class _LnulrWithdrawDialogState extends State<LnulrWithdrawDialog> with SingleTickerProviderStateMixin {
+class _LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> with SingleTickerProviderStateMixin {
   late Animation<double> _opacityAnimation;
   Future<LNURLWithdrawPageResult>? _future;
   var finishCalled = false;

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -114,8 +114,8 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
                         focusNode: _amountFocusNode,
                         controller: _amountController,
                         validatorFn: PaymentValidator(
-                          accBloc.validatePayment,
-                          currencyState.bitcoinCurrency,
+                          validatePayment: accBloc.validatePayment,
+                          currency: currencyState.bitcoinCurrency,
                           texts: context.texts(),
                         ).validateOutgoing,
                         style: theme.FieldTextStyle.textStyle),

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -7,8 +7,8 @@ String extractExceptionMessage(Object exception) {
   _log.v("extractExceptionMessage: $exception");
   if (exception is FfiException) {
     if (exception.message.isNotEmpty) {
-      final message = exception.message;
-      final innerErrorMessage = _extractInnerErrorMessage(message);
+      final message = exception.message.replaceAll("\n", " ").trim();
+      final innerErrorMessage = _extractInnerErrorMessage(message)?.trim();
       return innerErrorMessage ?? message;
     }
   }
@@ -20,6 +20,8 @@ String? _extractInnerErrorMessage(String content) {
   _log.v("extractInnerErrorMessage: $content");
   final innerMessageRegex = RegExp(r'((?<=message: \\")(.*)(?=.*\\"))');
   final messageRegex = RegExp(r'((?<=message: ")(.*)(?=.*"))');
+  final causedByRegex = RegExp(r'((?<=Caused by: )(.*)(?=.*))');
   return innerMessageRegex.stringMatch(content) ??
-      messageRegex.stringMatch(content);
+      messageRegex.stringMatch(content) ??
+      causedByRegex.stringMatch(content);
 }

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -12,12 +12,14 @@ String extractExceptionMessage(Object exception) {
       return innerErrorMessage ?? message;
     }
   }
-  return exception.toString();
+  return _extractInnerErrorMessage(exception.toString()) ??
+      exception.toString();
 }
 
 String? _extractInnerErrorMessage(String content) {
   _log.v("extractInnerErrorMessage: $content");
   final innerMessageRegex = RegExp(r'((?<=message: \\")(.*)(?=.*\\"))');
   final messageRegex = RegExp(r'((?<=message: ")(.*)(?=.*"))');
-  return innerMessageRegex.stringMatch(content) ?? messageRegex.stringMatch(content);
+  return innerMessageRegex.stringMatch(content) ??
+      messageRegex.stringMatch(content);
 }

--- a/lib/utils/lnurl.dart
+++ b/lib/utils/lnurl.dart
@@ -1,51 +1,13 @@
-import 'package:dart_lnurl/dart_lnurl.dart';
 import 'package:email_validator/email_validator.dart';
 import 'package:fimber/fimber.dart';
 
-RegExp _lnurlPrefix = RegExp(",*?((lnurl)([0-9]{1,}[a-z0-9]+){1})");
-
-/// https://github.com/fiatjaf/lnurl-rfc/blob/luds/17.md
-RegExp _lnurlRfc17Prefix = RegExp("(lnurl)(c|w|p)");
 String _lightningProtocolPrefix = "lightning:";
 final _log = FimberLog("lnurl");
-
-bool isLNURL(String url) {
-  var lower = url.toLowerCase();
-  if (lower.startsWith(_lightningProtocolPrefix)) {
-    lower = lower.substring(_lightningProtocolPrefix.length);
-  }
-  var firstMatch = _lnurlPrefix.firstMatch(lower);
-  if (firstMatch != null && firstMatch.start == 0) {
-    return true;
-  }
-  firstMatch = _lnurlRfc17Prefix.firstMatch(lower);
-  if (firstMatch != null && firstMatch.start == 0) {
-    return true;
-  }
-  try {
-    Uri uri = Uri.parse(lower);
-    String? lightning = uri.queryParameters["lightning"];
-    return lightning != null &&
-        (_lnurlPrefix.firstMatch(lightning) != null ||
-            _lnurlRfc17Prefix.firstMatch(lightning) != null);
-  } on FormatException {
-    // do nothing.
-  }
-  return false;
-}
 
 bool isLightningAddress(String uri) {
   var result = false;
   var v = parseLightningAddress(uri);
   result = v != null && v.isNotEmpty;
-  return result;
-}
-
-bool isLightningAddressURI(String uri) {
-  var result = false;
-
-  result = uri.toLowerCase().startsWith(_lightningProtocolPrefix) &&
-      isLightningAddress(uri);
   return result;
 }
 
@@ -68,19 +30,4 @@ String? parseLightningAddress(String? uri) {
     _log.i('parseLightningAddress: got "$result"');
   }
   return result;
-}
-
-String getSuccessActionMessage(LNURLPayResult lnurlPayResult) {
-  switch (lnurlPayResult.successAction!.tag) {
-    case 'aes':
-      return decryptSuccessActionAesPayload(
-        preimage: lnurlPayResult.pr,
-        successAction: lnurlPayResult.successAction!,
-      );
-    case 'url':
-      return lnurlPayResult.successAction!.description!;
-    case 'message':
-      return lnurlPayResult.successAction!.message!;
-  }
-  return '';
 }

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -1,21 +1,21 @@
+import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:c_breez/bloc/account/payment_error.dart';
 import 'package:c_breez/models/currency.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:breez_translations/generated/breez_translations.dart';
 
 class PaymentValidator {
-  final BitcoinCurrency _currency;
+  final BitcoinCurrency currency;
   final void Function(
     int amount,
     bool outgoing, {
     int? channelMinimumFee,
-  }) _validatePayment;
+  }) validatePayment;
   final int? channelMinimumFee;
   final BreezTranslations texts;
 
-  PaymentValidator(
-    this._validatePayment,
-    this._currency, {
+  const PaymentValidator({
+    required this.validatePayment,
+    required this.currency,
     this.channelMinimumFee,
     required this.texts,
   });
@@ -30,20 +30,24 @@ class PaymentValidator {
 
   String? _validate(int amount, bool outgoing) {
     try {
-      _validatePayment(amount, outgoing, channelMinimumFee: channelMinimumFee);
+      validatePayment(amount, outgoing, channelMinimumFee: channelMinimumFee);
     } on PaymentExceededLimitError catch (e) {
       return texts.invoice_payment_validator_error_payment_exceeded_limit(
-        _currency.format(e.limitSat),
+        currency.format(e.limitSat),
+      );
+    } on PaymentBelowLimitError catch (e) {
+      return texts.invoice_payment_validator_error_payment_below_invoice_limit(
+        currency.format(e.limitSat),
       );
     } on PaymentBelowReserveError catch (e) {
       return texts.invoice_payment_validator_error_payment_below_limit(
-        _currency.format(e.reserveAmount),
+        currency.format(e.reserveAmount),
       );
     } on InsufficientLocalBalanceError {
       return texts.invoice_payment_validator_error_insufficient_local_balance;
     } on PaymentBelowSetupFeesError catch (e) {
       return texts.invoice_payment_validator_error_payment_below_setup_fees_error(
-        _currency.format(e.setupFees),
+        currency.format(e.setupFees),
       );
     } catch (e) {
       return texts.invoice_payment_validator_error_unknown(

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -195,8 +195,8 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
                 focusNode: _amountFocusNode,
                 controller: _invoiceAmountController,
                 validatorFn: PaymentValidator(
-                  context.read<AccountBloc>().validatePayment,
-                  currencyState.bitcoinCurrency,
+                  validatePayment: context.read<AccountBloc>().validatePayment,
+                  currency: currencyState.bitcoinCurrency,
                   texts: context.texts(),
                 ).validateOutgoing,
                 style: themeData.dialogTheme.contentTextStyle!
@@ -274,8 +274,8 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
   Widget? _buildErrorMessage(
       BuildContext context, CurrencyState currencyState) {
     final validationError = PaymentValidator(
-      context.read<AccountBloc>().validatePayment,
-      currencyState.bitcoinCurrency,
+      validatePayment: context.read<AccountBloc>().validatePayment,
+      currency: currencyState.bitcoinCurrency,
       texts: context.texts(),
     ).validateOutgoing(
       amountToPay(currencyState),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -116,8 +116,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "39e45c8d5ba54d486f812b9a952962bc216fab14"
-      resolved-ref: "39e45c8d5ba54d486f812b9a952962bc216fab14"
+      ref: "9712a53bd3a079e95e5405fd1fafd5ccb7e8e855"
+      resolved-ref: "9712a53bd3a079e95e5405fd1fafd5ccb7e8e855"
       url: "https://github.com/breez/Breez-Translations"
     source: git
     version: "1.0.0"
@@ -1450,10 +1450,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: fad866af0eab867e2c96623e25fe9f7e4d598a1f19e3da3a70b52fe4083cb145
+      sha256: "5301f54eb6fe945daa99bc8df6ece3f88b5ceaa6f996f250efdaaf63e22886be"
       url: "https://pub.dev"
     source: hosted
-    version: "1.23.0"
+    version: "1.23.1"
   test_api:
     dependency: "direct overridden"
     description:
@@ -1466,10 +1466,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: d345256d1f4a63c8193ba40e4657dea57c2f92a6b7501657ec7f3f57dd26769d
+      sha256: d2e9240594b409565524802b84b7b39341da36dd6fd8e1660b53ad928ec3e9af
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.23"
+    version: "0.4.24"
   theme_provider:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -254,18 +254,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "745ebcccb1ef73768386154428a55250bc8d44059c19fd27aecda2a6dc013a22"
+      sha256: "8875e8ed511a49f030e313656154e4bbbcef18d68dfd32eb853fac10bce48e96"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: b8795b9238bf83b64375f63492034cb3d8e222af4d9ce59dda085edf038fa06f
+      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.3"
+    version: "1.2.4"
   convert:
     dependency: transitive
     description:
@@ -618,10 +618,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_linux
-      sha256: "736436adaf91552433823f51ce22e098c2f0551db06b6596f58597a25b8ea797"
+      sha256: "0912ae29a572230ad52d8a4697e5518d7f0f429052fd51df7e5a7952c7efe2a3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   flutter_secure_storage_macos:
     dependency: transitive
     description:
@@ -821,10 +821,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: b1cbfec0f5aef427a18eb573f5445af8c9c568626bf3388553e40c263d3f7368
+      sha256: "385f12ee9c7288575572c7873a332016ec45ebd092e1c2f6bd421b4a9ad21f1d"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.5+5"
+    version: "0.8.5+6"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -1029,10 +1029,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: f619162573096d428ccde2e33f92e05b5a179cd6f0e3120c1005f181bee8ed16
+      sha256: "8df5ab0a481d7dc20c0e63809e90a588e496d276ba53358afc4c4443d0a00697"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1221,10 +1221,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: e387077716f80609bb979cd199331033326033ecd1c8f200a90c5f57b1c9f55e
+      sha256: "8c6892037b1824e2d7e8f59d54b3105932899008642e6372e5079c6939b4b625"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "6.3.1"
   share_plus_platform_interface:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "3ff770dfff04a67b0863dff205a0936784de1b87a5e99b11c693fc10e66a9ce3"
+      sha256: "6215ac7d00ed98300b72f45ed2b38c2ca841f9f4e6965fab33cbd591e45e4473"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.12"
+    version: "1.0.13"
   analyzer:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.5"
+    version: "3.3.6"
   args:
     dependency: transitive
     description:
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: bech32
-      sha256: c36ff22d905b5864cafa7a3cf5e65dd2ca26cff30db1d6a9bd1bbfa2a231e58f
+      sha256: "156cbace936f7720c79a79d16a03efad343b1ef17106716e04b8b8e39f99f7f7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   bip39:
     dependency: "direct main"
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: bloc
-      sha256: bd4f8027bfa60d96c8046dec5ce74c463b2c918dce1b0d36593575995344534a
+      sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "8.1.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -270,26 +270,26 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "196284f26f69444b7f5c50692b55ec25da86d9e500451dc09333bf2e3ad69259"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
+      sha256: "2fb815080e44a09b85e0f2ca8a820b15053982b2e714b59267719e8a9ff17097"
       url: "https://pub.dev"
     source: hosted
-    version: "1.6.2"
+    version: "1.6.3"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: f71079978789bc2fe78d79227f1f8cfe195b31bbd8db2399b0d15a4b96fb843b
+      sha256: "0b0036e8cccbfbe0555fd83c1d31a6f30b77a96b598b35a5d36dd41f718695e9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+2"
+    version: "0.3.3+4"
   crypto:
     dependency: transitive
     description:
@@ -359,10 +359,10 @@ packages:
     dependency: "direct main"
     description:
       name: extended_image
-      sha256: d7e32f19a5c5ee3bfbcb3ff68492d3857bae00acd56e38048a8d53218871998b
+      sha256: "5854d0d05ee0c687d1852af9db05f15cfe058520fa56f417075705c5bce965d4"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.4"
+    version: "6.4.0"
   extended_image_library:
     dependency: transitive
     description:
@@ -415,74 +415,74 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: c129209ba55f3d4272c89fb4a4994c15bea77fb6de63a82d45fb6bc5c94e4355
+      sha256: be13e431c0c950f0fc66bdb67b41b8059121d7e7d8bbbc21fb59164892d561f8
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.5.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "5fab93f5b354648efa62e7cc829c90efb68c8796eecf87e0888cae2d5f3accd4"
+      sha256: "5615b30c36f55b2777d0533771deda7e5730e769e5d3cb7fda79e9bed86cfa55"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "18b35ce111b0a4266abf723c825bcf9d4e2519d13638cc7f06f2a8dd960c75bc"
+      sha256: "4b3a41410f3313bb95fd560aa5eb761b6ad65c185de772c72231e8b4aeed6d18"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      sha256: "00a80947fce912f44d30c4fda0a271df3f3fbb7caca4fe15e6ae9ad3f0e5b87f"
+      sha256: "6db5fca5e0013d5c26ef6fa40ba6525253aec14209cdde397acc6db5d2df6bc9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.11"
+    version: "5.0.12"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: "20e3c50e1272d380bfcaa459e01683d18977673716d165f399065604b5ffd458"
+      sha256: "91171dc24b3d3388f259650aa98ffc44c423d0a7ad115e7a9f4c66b66acf7913"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3+26"
+    version: "0.2.3+27"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: dc010a6436333029fba858415fe65887c3fe44d8f6e6ea162bb8d3dd764fbcb6
+      sha256: dbccddc62fef6f3745ba83062bfd1fbf2eb6a931db4c73d03f85c5772dfdec7f
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.2"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: abda2d766486096eb1c568c7b20aef46180596c8b0708190b929133ff03e0a8d
+      sha256: "564a47ea76db9cd2d17e7d95790428ad3de9d0075795d14c4c901ba0bf518e1a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.2.10"
+    version: "4.2.11"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: "7a0ce957bd2210e8636325152234728874dad039f1c7271ba1be5c752fdc5888"
+      sha256: "76291494583a003d4ce0d613c41cb87c58fab25773317daa66a245f537e1c3f7"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.11"
+    version: "3.2.12"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -492,10 +492,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "890c51c8007f0182360e523518a0c732efb89876cb4669307af7efada5b55557"
+      sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.1"
+    version: "8.1.2"
   flutter_fgbg:
     dependency: "direct main"
     description:
@@ -773,18 +773,18 @@ packages:
     dependency: "direct main"
     description:
       name: hydrated_bloc
-      sha256: "5871204f14b24638dc9d18d5b94cf22a66fc4be40756925cafff3a7553c7d7b7"
+      sha256: eb92d88061b6b911c48779b08a91c8a9f3a3aa8475f80d9380045375d9876536
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "9.1.0"
   image:
     dependency: "direct main"
     description:
       name: image
-      sha256: "1f9ecf99b08c92dedb699de1d28549f5d79b4423b48cf3f95d6968156db5dd67"
+      sha256: "3686865febd85c57a632d87a0fb1f0a8a9ef602fdb68d909c3e9aa29ec70fd24"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.12"
+    version: "4.0.13"
   image_cropper:
     dependency: "direct main"
     description:
@@ -837,10 +837,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_ios
-      sha256: "39c013200046d14c58b71dc4fa3d00e425fc9c699d589136cd3ca018727c0493"
+      sha256: "8ffb14b43713d7c43fb21299cc18181cc5b39bd3ea1cc427a085c6400fe5aa52"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.6+6"
+    version: "0.8.6+7"
   image_picker_platform_interface:
     dependency: transitive
     description:
@@ -909,10 +909,10 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: ba48fe0e1cae140a0813ce68c2540250d7f573a8ae4d4b6c681b2d2583584953
+      sha256: cfcbc4936e288d61ef85a04feef6b95f49ba496d4fd98364e6abafb462b06a1f
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.17"
+    version: "1.0.18"
   local_auth_ios:
     dependency: "direct main"
     description:
@@ -941,10 +941,10 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: c0bbfe94d46aedf9b8b3e695cf3bd48c8e14b35e3b2c639e0aa7755d589ba946
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
@@ -1189,10 +1189,10 @@ packages:
     dependency: transitive
     description:
       name: puppeteer
-      sha256: "4e235aaf9a338a45c9eb1ee38956e0ba369867bf144d7a27fdaf245409b2b87b"
+      sha256: "1304d8044054a8c89df648ef12352cf840ed2d34bbfbfa03d91537c72ae0f2c7"
       url: "https://pub.dev"
     source: hosted
-    version: "2.21.0"
+    version: "2.22.0"
   qr:
     dependency: transitive
     description:
@@ -1253,10 +1253,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "1ffa239043ab8baf881ec3094a3c767af9d10399b2839020b9e4d44c0bb23951"
+      sha256: "2b55c18636a4edc529fa5cd44c03d3f3100c00513f518c5127c951978efcccd0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   shared_preferences_linux:
     dependency: transitive
     description:
@@ -1338,10 +1338,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "2d79738b6bbf38a43920e2b8d189e9a3ce6cc201f4b8fc76be5e4fe377b1c38d"
+      sha256: c2bea18c95cfa0276a366270afaa2850b09b4a76db95d546f3d003dcc7011298
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.6"
+    version: "1.2.7"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1370,18 +1370,18 @@ packages:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: b2ed22d1d62c944ec0dac5cc687ae99cb3331c3ebe146d726ed24704634b5ccd
+      sha256: bfd6973aaeeb93475bc0d875ac9aefddf7965ef22ce09790eb963992ffc5183f
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2+2"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: c282e374de7bfb9a26c22ebcf15bf96ffac08d053c392205b9b3231d4fc4abf3
+      sha256: e435a9dcd0ca79ba6aea677468e6f7cb8859891294a8f34226685f2cf2002ea2
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.1+1"
   sqlite3:
     dependency: transitive
     description:
@@ -1450,10 +1450,10 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: b54d427664c00f2013ffb87797a698883c46aee9288e027a50b46eaee7486fa2
+      sha256: fad866af0eab867e2c96623e25fe9f7e4d598a1f19e3da3a70b52fe4083cb145
       url: "https://pub.dev"
     source: hosted
-    version: "1.22.2"
+    version: "1.23.0"
   test_api:
     dependency: "direct overridden"
     description:
@@ -1466,10 +1466,10 @@ packages:
     dependency: transitive
     description:
       name: test_core
-      sha256: "95ecc12692d0dd59080ab2d38d9cf32c7e9844caba23ff6cd285690398ee8ef4"
+      sha256: d345256d1f4a63c8193ba40e4657dea57c2f92a6b7501657ec7f3f57dd26769d
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.22"
+    version: "0.4.23"
   theme_provider:
     dependency: "direct main"
     description:
@@ -1530,10 +1530,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: "698fa0b4392effdc73e9e184403b627362eb5fbf904483ac9defbb1c2191d809"
+      sha256: e8f2efc804810c0f2f5b485f49e7942179f56eabcfe81dce3387fec4bb55876b
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.8"
+    version: "6.1.9"
   url_launcher_android:
     dependency: transitive
     description:
@@ -1546,10 +1546,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_ios
-      sha256: bb328b24d3bccc20bdf1024a0990ac4f869d57663660de9c936fb8c043edefe3
+      sha256: "0a5af0aefdd8cf820dd739886efb1637f1f24489900204f50984634c07a54815"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.18"
+    version: "6.1.0"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1618,10 +1618,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: d069ad658b700fc5fb774771ac8997f226ca29a45e0a450776fff3d969c8ba8f
+      sha256: a4040e9852e56bf8a3c5a2e08a56f6facd76e75500cf2a922ce5d52394c4998a
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "11.0.1"
   watcher:
     dependency: transitive
     description:
@@ -1679,5 +1679,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.6 <4.0.0"
+  dart: ">=2.19.0 <3.0.0"
   flutter: ">=3.3.10"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   breez_translations:
     git:
       url: https://github.com/breez/Breez-Translations
-      ref: 39e45c8d5ba54d486f812b9a952962bc216fab14
+      ref: 9712a53bd3a079e95e5405fd1fafd5ccb7e8e855
   clipboard_watcher:
     git:
       url: https://github.com/ademar111190/clipboard_watcher

--- a/test/mock/breez_bridge_mock.dart
+++ b/test/mock/breez_bridge_mock.dart
@@ -21,7 +21,14 @@ class BreezBridgeMock extends Mock implements BreezBridge {
 
   @override
   Future<Config> defaultConfig(EnvironmentType envType) async {
-    return Config(breezserver: '', mempoolspaceUrl: '', network: Network.Bitcoin, paymentTimeoutSec: 10, workingDir: '.', maxfeepercent: 0.5);
+    return Config(
+      breezserver: '',
+      mempoolspaceUrl: '',
+      network: Network.Bitcoin,
+      paymentTimeoutSec: 10,
+      workingDir: '.',
+      maxfeepercent: 0.5,
+    );
   }
 
   @override
@@ -98,4 +105,9 @@ class BreezBridgeMock extends Mock implements BreezBridge {
 
   @override
   Stream<List<Payment>> get paymentsStream => paymentsController.stream;
+
+  final paymentResultController = StreamController<Payment>.broadcast();
+
+  @override
+  Stream<Payment> get paymentResultStream => paymentResultController.stream;
 }

--- a/test/utils/exceptions_test.dart
+++ b/test/utils/exceptions_test.dart
@@ -37,4 +37,21 @@ void main() {
       'all routehints were unusable.',
     );
   });
+
+  test("caused by", () {
+    final message = extractExceptionMessage(const FfiException(
+      "RESULT_ERROR",
+      "error sending request for url (https://legend.lnbits.com/withdraw/api/v1/lnurl/cb/ngRuVZspEzjNFNzMFoqBjf?"
+          "id_unique_hash=RN8TLkyoxj8GaKgcTTcq4P&k1=FcjuJjwmfXJWhZXYVRpwCL&"
+          "pr=lnbc100n1p37zsutsp5pen5py8k4tmh2yntwk63h0w8mzgze3rvnq8mffmh9e37jmw0l5vqpp5t2ax0ahjesquymq4q6kegexcww"
+          "8mx6pkxpg3wyd4rjcghwl0dcfqdqdwehh2cmgv4e8xxqyjw5qcqpxrzjqwk7573qcyfskzw33jnvs0shq9tzy28sd86naqlgkdga9p8"
+          "z74fs9mmdhw49gpqe6cqqqqlgqqqqqzsqyg9qyysgq5qunm49m4zec3d237xa505djea5pl8v68y2p79lm4437tw0s0mexprzh3qak8"
+          "yrprsfz3tww4l2d5lng2877cd92jg5mdnh42ehl70cqmjf7ex): connection closed before message completed Caused "
+          "by: connection closed before message completed",
+    ));
+    expect(
+      message,
+      'connection closed before message completed',
+    );
+  });
 }


### PR DESCRIPTION
This draft PR is a continuation of #442 and addresses #403

#### Changes
- Differentiate between payment types when displaying payment result flushbar
- Replace SuccessActionData with SuccessAction from SDK
- Rename PaymentResultData -> PaymentResult
- Add payment results of lnurlPay, lnurlWithdraw, sendPayment and sendSpontaneousPayment to paymentResultStream
- Replace wait logic after receiving an event with emitting results with a delay and add logs(by @ademar111190)
- Ran dart format on changed files 
   - We should have the same approach with formatting as we do on breez-sdk and not have any formatting changes in PRs
   
#### SDK Suggestions  @roeierez @ok300 
@ademar111190 and I think it's better to have a paymentResultStream on the SDK as we are already doing with other notifications(event, synced etc) Instead of managing it on AccountBloc. This ensures we'll have the right data at the right time. Before we solve the known issues and work more on this PR we'd like hear your input.

#### Known issues
- Multiple flushbars shown for flows that throw an error in InputHandler
   - One from InputHandler's error handler, one from PaymentResultHandler. We should remove payment result related logic from descendants of InputHandler.

#### Issues encountered
- Flushbar position on iOS looks weird
  - Possible solutions:
    - Display flushbar on top of bottom sheet when on home page, 
    - Deploy a visual trick by using a system navigation bar color that contrasts with bottom sheet(send-qr-receive) background color