### PR TITLE
Correct how PaymentDetails data is accessed

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart
@@ -14,20 +14,14 @@ class PaymentDetailsDestinationPubkey extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
-
-    LnPaymentDetails? paymentDetails;
-    if (paymentInfo.details is LnPaymentDetails) {
-      paymentDetails = paymentInfo.details as LnPaymentDetails;
-    }
-    final destinationPubkey = paymentDetails?.destinationPubkey.trim();
-
-    if (destinationPubkey == null || destinationPubkey.isEmpty) {
+    final details = paymentInfo.details.data;
+    if (details is LnPaymentDetails && details.destinationPubkey.isNotEmpty) {
+      return ShareablePaymentRow(
+        title: texts.payment_details_dialog_single_info_node_id,
+        sharedValue: details.destinationPubkey,
+      );
+    } else {
       return Container();
     }
-
-    return ShareablePaymentRow(
-      title: texts.payment_details_dialog_single_info_node_id,
-      sharedValue: destinationPubkey,
-    );
   }
 }

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart
@@ -38,6 +38,29 @@ class PaymentDetailsDialogExpiration extends StatelessWidget {
               group: labelAutoSizeGroup,
             ),
           ),
+          // TODO: Add pendingExpirationTimestamp information once implemented
+          /*
+          Expanded(
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              reverse: true,
+              padding: const EdgeInsets.only(left: 8.0),
+              child: AutoSizeText(
+                BreezDateUtils.formatYearMonthDayHourMinute(
+                  DateTime.fromMillisecondsSinceEpoch(
+                    paymentInfo.pendingExpirationTimestamp
+                        .toInt() *
+                        1000,
+                  ),
+                ),
+                style: themeData.primaryTextTheme.headlineMedium,
+                textAlign: TextAlign.right,
+                maxLines: 1,
+                group: labelAutoSizeGroup,
+              ),
+            ),
+          )
+          */
         ],
       ),
     );

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart
@@ -15,19 +15,14 @@ class PaymentDetailsPreimage extends StatelessWidget {
   Widget build(BuildContext context) {
     final texts = context.texts();
 
-    LnPaymentDetails? paymentDetails;
-    if (paymentInfo.details is LnPaymentDetails) {
-      paymentDetails = paymentInfo.details as LnPaymentDetails;
-    }
-    final preimage = paymentDetails?.paymentPreimage.trim();
-
-    if (preimage == null || preimage.isEmpty) {
+    final details = paymentInfo.details.data;
+    if (details is LnPaymentDetails && details.paymentPreimage.isNotEmpty) {
+      return ShareablePaymentRow(
+        title: texts.payment_details_dialog_single_info_pre_image,
+        sharedValue: details.paymentPreimage,
+      );
+    } else {
       return Container();
     }
-
-    return ShareablePaymentRow(
-      title: texts.payment_details_dialog_single_info_pre_image,
-      sharedValue: preimage,
-    );
   }
 }

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -15,15 +15,19 @@ final AutoSizeGroup _valueGroup = AutoSizeGroup();
 
 final _log = FimberLog("PaymentDetailsDialog");
 
-Future<void> showPaymentDetailsDialog(
-  BuildContext context,
-  Payment paymentInfo,
-) {
-  _log.v("showPaymentDetailsDialog: ${paymentInfo.id}");
-  return showDialog<void>(
-    useRootNavigator: false,
-    context: context,
-    builder: (_) => AlertDialog(
+class PaymentDetailsDialog extends StatelessWidget {
+  final Payment paymentInfo;
+
+  PaymentDetailsDialog({
+    super.key,
+    required this.paymentInfo,
+  }) {
+    _log.v("PaymentDetailsDialog for payment: ${paymentInfo.id}");
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
       titlePadding: EdgeInsets.zero,
       title: PaymentDetailsDialogTitle(
         paymentInfo: paymentInfo,
@@ -69,6 +73,6 @@ Future<void> showPaymentDetailsDialog(
           top: Radius.circular(13.0),
         ),
       ),
-    ),
-  );
+    );
+  }
 }

--- a/lib/routes/home/widgets/payments_list/payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item.dart
@@ -87,7 +87,15 @@ class _PaymentItemState extends State<PaymentItem> {
                   child: PaymentItemSubtitle(widget._paymentInfo),
                 ),
                 trailing: PaymentItemAmount(widget._paymentInfo),
-                onTap: () => _showDetail(context),
+                onTap: () {
+                  showDialog<void>(
+                    useRootNavigator: false,
+                    context: context,
+                    builder: (_) => PaymentDetailsDialog(
+                      paymentInfo: widget._paymentInfo,
+                    ),
+                  );
+                },
               ),
             ],
           ),
@@ -105,9 +113,5 @@ class _PaymentItemState extends State<PaymentItem> {
       ),
     );
     return diff > -duration;
-  }
-
-  void _showDetail(BuildContext context) {
-    showPaymentDetailsDialog(context, widget._paymentInfo);
   }
 }


### PR DESCRIPTION
Upon reading #413 and seeing preimage widget was already in place on #434 I noticed type checking for LnPaymentDetails was wrong in two instances, which I figured out because I almost did the same mistake when implementing #432
 
####  Changes:
- https://github.com/breez/c-breez/commit/44c0c9366428021bb75b7986743b2df009d4dade Extracted PaymentDetailsDialog to a widget as a continuation of #434 
- https://github.com/breez/c-breez/commit/d7f39b847beadf9b3fd7ba3f74a2946a12be4fe1 Use PaymentDetails.data to check against LnPaymentDetails
- https://github.com/breez/c-breez/commit/f3516b4b7573e8829992820bc02945703bbe814a Re-added missing pendingExpirationTimestamp `TODO` comment