### PR TITLE
Swap in progress

### DIFF
--- a/lib/bloc/swap_in/swap_in_bloc.dart
+++ b/lib/bloc/swap_in/swap_in_bloc.dart
@@ -1,0 +1,52 @@
+import 'dart:async';
+
+import 'package:breez_sdk/breez_bridge.dart';
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:c_breez/bloc/swap_in/swap_in_state.dart';
+import 'package:c_breez/utils/exceptions.dart';
+import 'package:fimber/fimber.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class SwapInBloc extends Cubit<SwapInState> {
+  final _log = FimberLog("SwapInBloc");
+  final BreezBridge _breezLib;
+  late Timer timer;   
+
+  SwapInBloc(this._breezLib)
+      : super(SwapInState(null, null, isLoading:true)) {
+    getBTCAddress();    
+  }
+
+  getBTCAddress() {
+    _log.i("swap in address polling started");
+    emit(SwapInState(null, null, isLoading: true));
+    timer = Timer.periodic(const Duration(seconds: 5), refreshAddresses);
+    refreshAddresses(timer);
+  }
+
+  @override
+  Future<void> close() {
+    timer.cancel();
+    _log.i("swap in address polling finished");
+    return super.close();
+  }
+
+  void refreshAddresses(Timer timer) async {
+    final currentState = state;
+    try {      
+      final swapInProgress = (await _breezLib.inProgressSwap());
+      SwapInfo? swapUnused = currentState.unused;
+      if (swapInProgress != null) {
+        swapUnused = null;
+      }else {
+        swapUnused = (await _breezLib.receiveOnchain());
+      }
+      emit(SwapInState(swapInProgress, swapUnused));
+    } catch (e) {
+      final errorMessage = extractExceptionMessage(e);
+      emit(SwapInState(null, null, error: errorMessage));
+      timer.cancel();
+      _log.i("swap in address polling finished due to error");
+    }
+  }
+}

--- a/lib/bloc/swap_in/swap_in_bloc.dart
+++ b/lib/bloc/swap_in/swap_in_bloc.dart
@@ -14,10 +14,10 @@ class SwapInBloc extends Cubit<SwapInState> {
 
   SwapInBloc(this._breezLib)
       : super(SwapInState(null, null, isLoading:true)) {
-    getBTCAddress();    
+    pollSwapAddress();    
   }
 
-  getBTCAddress() {
+  pollSwapAddress() {
     _log.i("swap in address polling started");
     emit(SwapInState(null, null, isLoading: true));
     timer = Timer.periodic(const Duration(seconds: 5), refreshAddresses);

--- a/lib/bloc/swap_in/swap_in_state.dart
+++ b/lib/bloc/swap_in/swap_in_state.dart
@@ -1,0 +1,10 @@
+import 'package:breez_sdk/bridge_generated.dart';
+
+class SwapInState {
+  final SwapInfo? inProgress;
+  final SwapInfo? unused;
+  final bool isLoading;
+  final String? error;
+
+  SwapInState(this.inProgress, this.unused, {this.isLoading=false, this.error});
+}

--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -1,11 +1,14 @@
 import 'package:breez_sdk/breez_bridge.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/swap_in/swap_in_bloc.dart';
+import 'package:c_breez/bloc/swap_in/swap_in_state.dart';
+import 'package:c_breez/routes/subswap/swap/widgets/inprogress_swap.dart';
 import 'package:c_breez/services/injector.dart';
-import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'widgets/address_widget_placeholder.dart';
 import 'widgets/deposit_widget.dart';
@@ -21,70 +24,56 @@ class SwapPage extends StatefulWidget {
 
 class SwapPageState extends State<SwapPage> {
   final BreezBridge breezLib = ServiceInjector().breezLib;
-  SwapInfo? swap;
+  SwapInfo? swapInProgress;
+  SwapInfo? swapUnused;
   String? bitcoinAddress;
   String? errorMessage;
 
   @override
-  void didChangeDependencies() {
-    getBTCAddress();
-    super.didChangeDependencies();
-  }
-
-  void getBTCAddress() async {
-    try {
-      swap = (await breezLib.receiveOnchain());
-    } catch (e) {
-      errorMessage = extractExceptionMessage(e);
-    } finally {
-      setState(() {});
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
-    final texts = context.texts();
-    final bool isLoading = swap == null && errorMessage == null;
+    return BlocBuilder<SwapInBloc, SwapInState>(builder: (context, swapState) {
+      final SwapInBloc swapInBloc = context.read();
+      final texts = context.texts();
 
-    return Scaffold(
-      appBar: AppBar(
-        automaticallyImplyLeading: false,
-        leading: const back_button.BackButton(),
-        title: Text(texts.invoice_btc_address_title),
-      ),
-      body: isLoading
-          ? const AddressWidgetPlaceholder()
-          : SingleChildScrollView(
-              child: Column(
-                children: [
-                  if (swap != null) ...[DepositWidget(swap!)],
-                  if (errorMessage != null) ...[
-                    Padding(
-                      padding: const EdgeInsets.only(
-                        top: 50.0,
-                        left: 30.0,
-                        right: 30.0,
+      return Scaffold(
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          leading: const back_button.BackButton(),
+          title: Text(texts.invoice_btc_address_title),
+        ),
+        body: swapState.isLoading
+            ? const AddressWidgetPlaceholder()
+            : SingleChildScrollView(
+                child: Column(
+                  children: [
+                    ...[
+                      if (swapState.unused != null)
+                        DepositWidget(swapState.unused!)
+                      else if (swapState.inProgress != null)
+                        SwapInprogress(swap: swapState.inProgress!)
+                    ],
+                    if (swapState.error != null) ...[
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: 50.0,
+                          left: 30.0,
+                          right: 30.0,
+                        ),
+                        child: Text(swapState.error!, textAlign: TextAlign.center),
                       ),
-                      child: Text(errorMessage!, textAlign: TextAlign.center),
-                    ),
-                  ]
-                ],
+                    ]
+                  ],
+                ),
               ),
-            ),
-      bottomNavigationBar: errorMessage != null
-          ? SingleButtonBottomBar(
-              text: errorMessage != null
-                  ? texts.invoice_btc_address_action_retry
-                  : texts.invoice_btc_address_action_close,
-              onPressed: () async {
-                if (errorMessage != null) {
-                  getBTCAddress();
-                } else {
-                  Navigator.of(context).pop();
-                }
-              },
-            )
-          : const SizedBox(),
-    );
+        bottomNavigationBar: swapState.error != null
+            ? SingleButtonBottomBar(
+                text: texts.invoice_btc_address_action_retry,
+                onPressed: () async {
+                  swapInBloc.getBTCAddress();
+                },
+              )
+            : const SizedBox(),
+      );
+    });
   }
 }

--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -69,7 +69,7 @@ class SwapPageState extends State<SwapPage> {
             ? SingleButtonBottomBar(
                 text: texts.invoice_btc_address_action_retry,
                 onPressed: () async {
-                  swapInBloc.getBTCAddress();
+                  swapInBloc.pollSwapAddress();
                 },
               )
             : const SizedBox(),

--- a/lib/routes/subswap/swap/widgets/inprogress_swap.dart
+++ b/lib/routes/subswap/swap/widgets/inprogress_swap.dart
@@ -15,13 +15,14 @@ class SwapInprogress extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
+    final swapTxs = swap.unconfirmedTxIds.followedBy(swap.confirmedTxIds).toList();
 
     return Column(
       mainAxisSize: MainAxisSize.max,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         _ContentWrapper(content: Text(texts.add_funds_error_deposit, textAlign: TextAlign.center), top: 50.0,),
-        if (swap.unconfirmedTxIds.isNotEmpty) _ContentWrapper(content: _TxLink(txid: swap.unconfirmedTxIds[0])),
+        if (swapTxs.isNotEmpty) _ContentWrapper(content: _TxLink(txid: swapTxs[0])),
         if (swap.lastRedeemError != null) _ContentWrapper(content: Text(swap.lastRedeemError!, textAlign: TextAlign.center)),
       ],
     );

--- a/lib/routes/subswap/swap/widgets/inprogress_swap.dart
+++ b/lib/routes/subswap/swap/widgets/inprogress_swap.dart
@@ -1,0 +1,69 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/services/injector.dart';
+import 'package:c_breez/widgets/flushbar.dart';
+import 'package:c_breez/widgets/link_launcher.dart';
+import 'package:flutter/material.dart';
+
+class SwapInprogress extends StatelessWidget {
+  final SwapInfo swap;
+
+  const SwapInprogress({
+    required this.swap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();    
+    final List<String> swapTransactions = [];
+    swapTransactions.addAll(swap.unconfirmedTxIds);
+    swapTransactions.addAll(swap.unconfirmedTxIds);
+
+    return Column(
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(
+            top: 50.0,
+            left: 30.0,
+            right: 30.0,
+          ),
+          child: Text(
+            texts.add_funds_error_withdraw,
+            textAlign: TextAlign.center,
+          ),
+        ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (swapTransactions.isNotEmpty) Padding(
+              padding: const EdgeInsets.only(
+                top: 30.0,
+                left: 30.0,
+                right: 30.0,
+              ),
+              child: _linkLauncher(context, swapTransactions[0]),
+            ),
+          ],
+        )
+      ],
+    );
+  }
+
+  Widget _linkLauncher(BuildContext context, String unconfirmedTxID) {
+    final texts = context.texts();
+    return LinkLauncher(
+      linkName: unconfirmedTxID,
+      linkAddress: "https://blockstream.info/tx/$unconfirmedTxID",
+      onCopy: () {
+        ServiceInjector().device.setClipboardText(unconfirmedTxID);
+        showFlushbar(
+          context,
+          message: texts.add_funds_transaction_id_copied,
+          duration: const Duration(seconds: 3),
+        );
+      },
+    );
+  }
+}

--- a/lib/routes/subswap/swap/widgets/inprogress_swap.dart
+++ b/lib/routes/subswap/swap/widgets/inprogress_swap.dart
@@ -14,56 +14,59 @@ class SwapInprogress extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final texts = context.texts();    
-    final List<String> swapTransactions = [];
-    swapTransactions.addAll(swap.unconfirmedTxIds);
-    swapTransactions.addAll(swap.unconfirmedTxIds);
+    final texts = context.texts();
 
     return Column(
       mainAxisSize: MainAxisSize.max,
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        Padding(
-          padding: const EdgeInsets.only(
-            top: 50.0,
-            left: 30.0,
-            right: 30.0,
-          ),
-          child: Text(
-            texts.add_funds_error_withdraw,
-            textAlign: TextAlign.center,
-          ),
-        ),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (swapTransactions.isNotEmpty) Padding(
-              padding: const EdgeInsets.only(
-                top: 30.0,
-                left: 30.0,
-                right: 30.0,
-              ),
-              child: _linkLauncher(context, swapTransactions[0]),
-            ),
-          ],
-        )
+        _ContentWrapper(content: Text(texts.add_funds_error_deposit, textAlign: TextAlign.center), top: 50.0,),
+        if (swap.unconfirmedTxIds.isNotEmpty) _ContentWrapper(content: _TxLink(txid: swap.unconfirmedTxIds[0])),
+        if (swap.lastRedeemError != null) _ContentWrapper(content: Text(swap.lastRedeemError!, textAlign: TextAlign.center)),
       ],
     );
   }
+}
 
-  Widget _linkLauncher(BuildContext context, String unconfirmedTxID) {
-    final texts = context.texts();
+class _TxLink extends StatelessWidget {
+  final String txid;
+
+  const _TxLink({required this.txid});
+
+  @override
+  Widget build(BuildContext context) {
+    final text = context.texts();
+
     return LinkLauncher(
-      linkName: unconfirmedTxID,
-      linkAddress: "https://blockstream.info/tx/$unconfirmedTxID",
+      linkName: txid,
+      linkAddress: "https://blockstream.info/tx/$txid",
       onCopy: () {
-        ServiceInjector().device.setClipboardText(unconfirmedTxID);
+        ServiceInjector().device.setClipboardText(txid);
         showFlushbar(
           context,
-          message: texts.add_funds_transaction_id_copied,
+          message: text.add_funds_transaction_id_copied,
           duration: const Duration(seconds: 3),
         );
       },
+    );
+  }
+}
+
+class _ContentWrapper extends StatelessWidget {
+  final Widget content;
+  final double top;
+
+  const _ContentWrapper({required this.content, this.top=30.0});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.only(
+        top: top,
+        left: 30.0,
+        right: 30.0,
+      ),
+      child: content,
     );
   }
 }

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -5,6 +5,7 @@ import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/refund/refund_bloc.dart';
 import 'package:c_breez/bloc/security/security_bloc.dart';
 import 'package:c_breez/bloc/security/security_state.dart';
+import 'package:c_breez/bloc/swap_in/swap_in_bloc.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
@@ -24,6 +25,7 @@ import 'package:c_breez/routes/splash/splash_page.dart';
 import 'package:c_breez/routes/subswap/swap/get_refund/get_refund_page.dart';
 import 'package:c_breez/routes/subswap/swap/swap_page.dart';
 import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_page.dart';
+import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/theme/breez_dark_theme.dart';
 import 'package:c_breez/theme/breez_light_theme.dart';
 import 'package:c_breez/widgets/route.dart';
@@ -36,8 +38,7 @@ const String THEME_ID_PREFERENCE_KEY = "themeID";
 
 class UserApp extends StatelessWidget {
   final GlobalKey _appKey = GlobalKey();
-  final GlobalKey<NavigatorState> _homeNavigatorKey =
-      GlobalKey<NavigatorState>();
+  final GlobalKey<NavigatorState> _homeNavigatorKey = GlobalKey<NavigatorState>();
 
   @override
   Widget build(BuildContext context) {
@@ -72,8 +73,8 @@ class UserApp extends StatelessWidget {
             SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
               statusBarColor: Colors.transparent,
             ));
-            return BlocBuilder2<AccountBloc, AccountState, SecurityBloc,
-                SecurityState>(builder: (context, accState, securityState) {
+            return BlocBuilder2<AccountBloc, AccountState, SecurityBloc, SecurityState>(
+                builder: (context, accState, securityState) {
               return MaterialApp(
                 key: _appKey,
                 title: getSystemAppLocalizations().app_name,
@@ -84,16 +85,12 @@ class UserApp extends StatelessWidget {
                   final MediaQueryData data = MediaQuery.of(context);
                   return MediaQuery(
                     data: data.copyWith(
-                      textScaleFactor: (data.textScaleFactor >= 1.3)
-                          ? 1.3
-                          : data.textScaleFactor,
+                      textScaleFactor: (data.textScaleFactor >= 1.3) ? 1.3 : data.textScaleFactor,
                     ),
                     child: child!,
                   );
                 },
-                initialRoute: securityState.pinStatus == PinStatus.enabled
-                    ? "lockscreen"
-                    : "splash",
+                initialRoute: securityState.pinStatus == PinStatus.enabled ? "lockscreen" : "splash",
                 onGenerateRoute: (RouteSettings settings) {
                   switch (settings.name) {
                     case '/intro':
@@ -127,8 +124,7 @@ class UserApp extends StatelessWidget {
                       return FadeInRoute(
                         builder: (_) => WillPopScope(
                           onWillPop: () async {
-                            return !await _homeNavigatorKey.currentState!
-                                .maybePop();
+                            return !await _homeNavigatorKey.currentState!.maybePop();
                           },
                           child: Navigator(
                             initialRoute: "/",
@@ -160,13 +156,15 @@ class UserApp extends StatelessWidget {
                                   );
                                 case '/swap_page':
                                   return FadeInRoute(
-                                    builder: (_) => const SwapPage(),
+                                    builder: (_) => BlocProvider(
+                                      create: (BuildContext context) => SwapInBloc(ServiceInjector().breezLib),
+                                      child: const SwapPage(),
+                                    ),
                                     settings: settings,
                                   );
                                 case '/fiat_currency':
                                   return FadeInRoute(
-                                    builder: (_) =>
-                                        const FiatCurrencySettings(),
+                                    builder: (_) => const FiatCurrencySettings(),
                                     settings: settings,
                                   );
                                 case '/security':
@@ -195,8 +193,7 @@ class UserApp extends StatelessWidget {
                                 case '/withdraw_funds':
                                   return FadeInRoute(
                                     builder: (_) => WithdrawFundsAddressPage(
-                                      withdrawKind:
-                                          settings.arguments as WithdrawKind,
+                                      withdrawKind: settings.arguments as WithdrawKind,
                                     ),
                                     settings: settings,
                                   );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1085,10 +1085,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "6637955e38a5f1851c023482c25a60c93972ea06c8608e2f25ad0064c46c0939"
+      sha256: "62a68e7e1c6c459f9289859e2fae58290c981ce21d1697faf54910fe1faa4c74"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   path_provider_linux:
     dependency: transitive
     description:
@@ -1586,10 +1586,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: "387e227c4b979034cc52afb11d66b04ed9b288ca1f45beeef39b2ea69e714fa5"
+      sha256: b6217370f8eb1fd85c8890c539f5a639a01ab209a36db82c921ebeacefc7a615
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   uuid:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR fixed the user experience in 'Receive via BTC address' flow.
We now:
1. Allow only one inprogress swap at a time and at most one "unused" swap address at a time.
2. Aware of mempool transactions using polling the in progress swap.

depends on https://github.com/breez/breez-sdk/actions/runs/4015673422