### PR TITLE
Replicate description logic from breez mobile on items where data is available

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart
@@ -17,7 +17,7 @@ class PaymentDetailsDialogDescription extends StatelessWidget {
     final texts = context.texts();
     final themeData = Theme.of(context);
 
-    final description = paymentInfo.extractTitle(texts);
+    final description = paymentInfo.extractDescription(texts);
     if (description.isEmpty) {
       return Container();
     }

--- a/lib/utils/extensions/payment_extensions.dart
+++ b/lib/utils/extensions/payment_extensions.dart
@@ -26,4 +26,33 @@ extension PaymentExtensions on Payment {
 
     return texts.wallet_dashboard_payment_item_no_title;
   }
+
+  String extractDescription(BreezTranslations texts) {
+    final description = this.description?.replaceAll("\n", " ").trim();
+
+    if (description != null && description.startsWith("Bitrefill")) {
+      return description.substring(9, description.length).trimLeft();
+    }
+
+    if (description != null && description.isNotEmpty) {
+      return extractPosMessage(description) ?? description;
+    }
+
+    final details = this.details;
+    if (details is PaymentDetails_ClosedChannel) {
+      final state = details.data.state;
+      switch (state) {
+        case ChannelState.PendingOpen:
+          return texts.payment_info_title_pending_opened_channel;
+        case ChannelState.Opened:
+          return texts.payment_info_title_opened_channel;
+        case ChannelState.PendingClose:
+          return texts.payment_info_title_pending_closed_channel;
+        case ChannelState.Closed:
+          return texts.payment_info_title_closed_channel;
+      }
+    }
+
+    return texts.wallet_dashboard_payment_item_no_title;
+  }
 }


### PR DESCRIPTION
Fix https://github.com/breez/c-breez/issues/461

Some data is not available on c breez, so we are not 100% equal; reference: https://github.com/breez/breezmobile/blob/232f1178d86b1b7152a03036ab33aafcf0c933a9/lib/bloc/account/account_model.dart#L774

