### PR TITLE
Create any non-existing parent paths while creating credentials & mnemonic phrase files

### DIFF
--- a/lib/bloc/account/credential_manager.dart
+++ b/lib/bloc/account/credential_manager.dart
@@ -72,10 +72,10 @@ class CredentialsManager {
     try {
       final Directory tempDir = await getTemporaryDirectory();
       var keysDir = tempDir.createTempSync("keys");
-      final File credentialsFile = File('${keysDir.path}/creds');
+      final File credentialsFile = await File('${keysDir.path}/creds').create(recursive: true);
       Credentials credentials = await restoreCredentials();
       credentialsFile.writeAsString(jsonEncode(credentials.toGreenlightCredentialsJson()));
-      final File mnemonicFile = File('${keysDir.path}/phrase');
+      final File mnemonicFile = await File('${keysDir.path}/phrase').create(recursive: true);
       mnemonicFile.writeAsString(credentials.mnemonic);
       return [credentialsFile, mnemonicFile];
     } catch (e) {

--- a/lib/routes/dev/commands.dart
+++ b/lib/routes/dev/commands.dart
@@ -7,6 +7,7 @@ import 'package:c_breez/routes/dev/commands_list.dart';
 import 'package:c_breez/routes/ui_test/ui_test_page.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/route.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:path/path.dart';
@@ -50,11 +51,12 @@ class DevelopersView extends StatelessWidget {
               color: themeData.iconTheme.color,
             ),
             itemBuilder: (context) => [
-              Choice(
-                title: "Export Keys",
-                icon: Icons.phone_android,
-                function: _exportKeys,
-              ),
+              if (kDebugMode)
+                Choice(
+                  title: "Export Keys",
+                  icon: Icons.phone_android,
+                  function: _exportKeys,
+                ),
               Choice(
                 title: "Test UI Widgets",
                 icon: Icons.phone_android,


### PR DESCRIPTION
This PR addresses #477
Any non-existing parent paths are created while creating credentials & mnemonic phrase files.

Encountered error on a fresh install on iOS
```
2023-02-21T18:39:45.626265 :: E :: Main :: FlutterError: PathNotFoundException: Cannot open file, path = '/var/mobile/Containers/Data/Application/5C1A9724-9A20-4FFA-AFE8-E41906665739/Library/Caches/keysNKkDCQ/creds' (OS Error: No such file or directory, errno = 2) ::  :: 0 ::  :: 
PathNotFoundException: Cannot open file, path = '/var/mobile/Containers/Data/Application/5C1A9724-9A20-4FFA-AFE8-E41906665739/Library/Caches/keysNKkDCQ/creds' (OS Error: No such file or directory, errno = 2) :: 
	#0      _checkForErrorResponse (dart:io/common.dart:42)
	#1      _File.open.<anonymous closure> (dart:io/file_impl.dart:364)
	#2      _rootRunUnary (dart:async/zone.dart:1406)
	<asynchronous suspension>
	#3      DevelopersView._exportKeys (package:c_breez/routes/dev/commands.dart:98)
	<asynchronous suspension>
```

