### PR TITLE
Persist AppMode* and Preferences expansion state

### DIFF
--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -84,16 +84,22 @@ class UserProfileBloc extends Cubit<UserProfileState> with HydratedMixin {
     String? image,
     bool? registrationRequested,
     bool? hideBalance,
+    AppMode? appMode,
+    bool? expandPreferences,
   }) {
-    _log.v("updateProfile $name $color $animal $image $registrationRequested $hideBalance");
+    _log.v(
+        "updateProfile $name $color $animal $image $registrationRequested $hideBalance $appMode $expandPreferences");
     var profile = state.profileSettings;
     profile = profile.copyWith(
-        name: name ?? profile.name,
-        color: color ?? profile.color,
-        animal: animal ?? profile.animal,
-        image: image ?? profile.image,
-        registrationRequested: registrationRequested ?? profile.registrationRequested,
-        hideBalance: hideBalance ?? profile.hideBalance);
+      name: name ?? profile.name,
+      color: color ?? profile.color,
+      animal: animal ?? profile.animal,
+      image: image ?? profile.image,
+      registrationRequested: registrationRequested ?? profile.registrationRequested,
+      hideBalance: hideBalance ?? profile.hideBalance,
+      appMode: appMode ?? profile.appMode,
+      expandPreferences: expandPreferences ?? profile.expandPreferences,
+    );
     emit(state.copyWith(profileSettings: profile));
   }
 

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -10,6 +10,7 @@ class UserProfileSettings {
   final bool registrationRequested;
   final bool hideBalance;
   final AppMode appMode;
+  final bool expandPreferences;
 
   const UserProfileSettings._({
     this.userID,
@@ -21,6 +22,7 @@ class UserProfileSettings {
     this.registrationRequested = false,
     this.hideBalance = false,
     this.appMode = AppMode.balance,
+    this.expandPreferences = true,
   });
 
   UserProfileSettings.initial() : this._();
@@ -34,6 +36,8 @@ class UserProfileSettings {
     String? userID,
     bool? registrationRequested,
     bool? hideBalance,
+    AppMode? appMode,
+    bool? expandPreferences,
   }) {
     return UserProfileSettings._(
       userID: userID ?? this.userID,
@@ -44,6 +48,8 @@ class UserProfileSettings {
       token: token ?? this.token,
       registrationRequested: registrationRequested ?? this.registrationRequested,
       hideBalance: hideBalance ?? this.hideBalance,
+      appMode: appMode ?? this.appMode,
+      expandPreferences: expandPreferences ?? this.expandPreferences,
     );
   }
 
@@ -63,7 +69,8 @@ class UserProfileSettings {
         image = json['image'],
         registrationRequested = json['registrationRequested'] ?? json['token'] != null,
         hideBalance = json['hideBalance'] ?? false,
-        appMode = AppMode.values[json["appMode"] ?? 0];
+        appMode = AppMode.values[json["appMode"] ?? 0],
+        expandPreferences = json['expandPreferences'] ?? true;
 
   Map<String, dynamic> toJson() => {
         'userID': userID,
@@ -75,5 +82,6 @@ class UserProfileSettings {
         'registrationRequested': registrationRequested,
         'hideBalance': hideBalance,
         'appMode': appMode.index,
+        'expandPreferences': expandPreferences,
       };
 }

--- a/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
+++ b/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
@@ -42,12 +42,14 @@ class DrawerItemConfigGroup {
   final String? groupTitle;
   final String? groupAssetImage;
   final bool withDivider;
+  final bool isExpanded;
 
   const DrawerItemConfigGroup(
     this.items, {
     this.groupTitle,
     this.groupAssetImage,
     this.withDivider = true,
+    this.isExpanded = true,
   });
 }
 
@@ -131,6 +133,7 @@ class BreezNavigationDrawer extends StatelessWidget {
           title: group.groupTitle ?? "",
           icon: group.groupAssetImage == null ? null : AssetImage(group.groupAssetImage!),
           controller: _scrollController,
+          isExpanded: group.isExpanded,
         )
       ];
     }
@@ -375,6 +378,7 @@ class _ExpansionTile extends StatelessWidget {
   final String title;
   final AssetImage? icon;
   final ScrollController controller;
+  final bool isExpanded;
 
   const _ExpansionTile({
     Key? key,
@@ -382,6 +386,7 @@ class _ExpansionTile extends StatelessWidget {
     required this.title,
     required this.icon,
     required this.controller,
+    this.isExpanded = true,
   }) : super(key: key);
 
   @override
@@ -402,7 +407,7 @@ class _ExpansionTile extends StatelessWidget {
                   style: theme.drawerItemTextStyle,
                 ),
         ),
-        initiallyExpanded: true,
+        initiallyExpanded: isExpanded,
         leading: Padding(
           padding: const EdgeInsets.only(left: 8.0),
           child: (icon?.assetName ?? "") == ""
@@ -425,6 +430,7 @@ class _ExpansionTile extends StatelessWidget {
                 ))
             .toList(),
         onExpansionChanged: (isExpanded) {
+          context.read<UserProfileBloc>().updateProfile(expandPreferences: isExpanded);
           if (isExpanded) {
             Timer(
               const Duration(milliseconds: 200),

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -84,6 +84,7 @@ class HomeDrawerState extends State<HomeDrawer> {
           _filterItems(_drawerConfigToFilter(context)),
           groupTitle: texts.home_drawer_item_title_preferences,
           groupAssetImage: "",
+          isExpanded: settings.expandPreferences,
         ),
       ],
       (screenName) {


### PR DESCRIPTION
This issue addresses #499 

- Preferences tiles expansion state is now being persisted
- AppMode isn't being used at the moment but it was missing from updateProfile & UserProfileSettings.copyWith.

_This whole drawer logic needs another round of refactoring & simplification imo._