### PR TITLE
Add domain to request data

### DIFF
--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -46,6 +46,7 @@ Future<LNURLPaymentPageResult?> handlePayRequest(
     maxSendable: payParams.maxSendable,
     metadataStr: payParams.metadata,
     commentAllowed: payParams.commentAllowed,
+    domain: payParams.domain,
   );
   if (fixedAmount && !(payParams.commentAllowed > 0)) {
     // Show dialog if payment is of fixed amount with no payer comment allowed


### PR DESCRIPTION
The domain field was added to breez SDK, but it is missing on c-breez; I'm adding it to fix the build.