### PR TITLE
ensure selected LSP, defer checking connection to lsp

### DIFF
--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -7,7 +7,6 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/routes/create_invoice/qr_code_dialog.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
@@ -170,23 +169,17 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     navigator.pop();
 
     showDialog(
-      useRootNavigator: false,
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => BlocBuilder<LSPBloc, LspState?>(
-        buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
-        builder: (context, state) {
-          return LNURLWithdrawDialog(
-            requestData: data,
-            amountSats: currencyBloc.state.bitcoinCurrency.parse(
-              _amountController.text,
-            ),
-            domain: widget.domain!,
-            onFinish: widget.onFinish!,
-          );
-        },
-      ),
-    );
+        useRootNavigator: false,
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => LNURLWithdrawDialog(
+              requestData: data,
+              amountSats: currencyBloc.state.bitcoinCurrency.parse(
+                _amountController.text,
+              ),
+              domain: widget.domain!,
+              onFinish: widget.onFinish!,
+            ));
   }
 
   Future _createInvoice(BuildContext context) async {
@@ -216,16 +209,7 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
     );
 
     return showDialog(
-      useRootNavigator: false,
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => BlocBuilder<LSPBloc, LspState?>(
-        buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
-        builder: (context, state) {
-          return dialog;
-        },
-      ),
-    );
+        useRootNavigator: false, context: context, barrierDismissible: false, builder: (_) => dialog);
   }
 
   void onPaymentFinished(

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -7,6 +7,7 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
+import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/routes/create_invoice/qr_code_dialog.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
@@ -172,13 +173,18 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       useRootNavigator: false,
       context: context,
       barrierDismissible: false,
-      builder: (_) => LNURLWithdrawDialog(
-        requestData: data,
-        amountSats: currencyBloc.state.bitcoinCurrency.parse(
-          _amountController.text,
-        ),
-        domain: widget.domain!,
-        onFinish: widget.onFinish!,
+      builder: (_) => BlocBuilder<LSPBloc, LspState?>(
+        buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
+        builder: (context, state) {
+          return LNURLWithdrawDialog(
+            requestData: data,
+            amountSats: currencyBloc.state.bitcoinCurrency.parse(
+              _amountController.text,
+            ),
+            domain: widget.domain!,
+            onFinish: widget.onFinish!,
+          );
+        },
       ),
     );
   }
@@ -213,7 +219,12 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
       useRootNavigator: false,
       context: context,
       barrierDismissible: false,
-      builder: (_) => dialog,
+      builder: (_) => BlocBuilder<LSPBloc, LspState?>(
+        buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
+        builder: (context, state) {
+          return dialog;
+        },
+      ),
     );
   }
 

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -26,7 +26,7 @@ class BottomActionsBar extends StatelessWidget {
     return BlocBuilder<AccountBloc, AccountState>(
       builder: (context, account) {
         return BlocBuilder<LSPBloc, LspState?>(builder: (context, lspState) {
-          final connected = lspState?.lspInfo != null;
+          final selectedLsp = (lspState?.selectedLspId != null);
 
           return BottomAppBar(
             child: SizedBox(
@@ -36,14 +36,14 @@ class BottomActionsBar extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
                   SendOptions(
-                    connected: connected,
+                    selectedLsp: selectedLsp,
                     firstPaymentItemKey: firstPaymentItemKey,
                     actionsGroup: actionsGroup,
                   ),
                   Container(width: 64),
                   ReceiveOptions(
                     account: account,
-                    connected: connected,
+                    selectedLsp: selectedLsp,
                     firstPaymentItemKey: firstPaymentItemKey,
                     actionsGroup: actionsGroup,
                   )
@@ -58,13 +58,13 @@ class BottomActionsBar extends StatelessWidget {
 }
 
 class SendOptions extends StatelessWidget {
-  final bool connected;
+  final bool selectedLsp;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const SendOptions({
     Key? key,
-    required this.connected,
+    required this.selectedLsp,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -78,7 +78,7 @@ class SendOptions extends StatelessWidget {
         context: context,
         builder: (context) {
           return SendOptionsBottomSheet(
-            connected: connected,
+            selectedLsp: selectedLsp,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },
@@ -92,14 +92,14 @@ class SendOptions extends StatelessWidget {
 
 class ReceiveOptions extends StatelessWidget {
   final AccountState account;
-  final bool connected;
+  final bool selectedLsp;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const ReceiveOptions({
     Key? key,
     required this.account,
-    required this.connected,
+    required this.selectedLsp,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -113,7 +113,7 @@ class ReceiveOptions extends StatelessWidget {
         builder: (context) {
           return ReceiveOptionsBottomSheet(
             account: account,
-            connected: connected,
+            selectedLsp: selectedLsp,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -2,8 +2,6 @@ import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
-import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart';
 import 'package:flutter/material.dart';
@@ -23,48 +21,38 @@ class BottomActionsBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final actionsGroup = AutoSizeGroup();
 
-    return BlocBuilder<AccountBloc, AccountState>(
-      builder: (context, account) {
-        return BlocBuilder<LSPBloc, LspState?>(builder: (context, lspState) {
-          final isLspSelected = (lspState?.selectedLspId != null);
-
-          return BottomAppBar(
-            child: SizedBox(
-              height: 60,
-              child: Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: [
-                  SendOptions(
-                    isLspSelected: isLspSelected,
-                    firstPaymentItemKey: firstPaymentItemKey,
-                    actionsGroup: actionsGroup,
-                  ),
-                  Container(width: 64),
-                  ReceiveOptions(
-                    account: account,
-                    isLspSelected: isLspSelected,
-                    firstPaymentItemKey: firstPaymentItemKey,
-                    actionsGroup: actionsGroup,
-                  )
-                ],
+    return BlocBuilder<AccountBloc, AccountState>(builder: (context, account) {
+      return BottomAppBar(
+        child: SizedBox(
+          height: 60,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              SendOptions(
+                firstPaymentItemKey: firstPaymentItemKey,
+                actionsGroup: actionsGroup,
               ),
-            ),
-          );
-        });
-      },
-    );
+              Container(width: 64),
+              ReceiveOptions(
+                account: account,
+                firstPaymentItemKey: firstPaymentItemKey,
+                actionsGroup: actionsGroup,
+              )
+            ],
+          ),
+        ),
+      );
+    });
   }
 }
 
 class SendOptions extends StatelessWidget {
-  final bool isLspSelected;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const SendOptions({
     Key? key,
-    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -78,7 +66,6 @@ class SendOptions extends StatelessWidget {
         context: context,
         builder: (context) {
           return SendOptionsBottomSheet(
-            isLspSelected: isLspSelected,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },
@@ -92,14 +79,12 @@ class SendOptions extends StatelessWidget {
 
 class ReceiveOptions extends StatelessWidget {
   final AccountState account;
-  final bool isLspSelected;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const ReceiveOptions({
     Key? key,
     required this.account,
-    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -113,7 +98,6 @@ class ReceiveOptions extends StatelessWidget {
         builder: (context) {
           return ReceiveOptionsBottomSheet(
             account: account,
-            isLspSelected: isLspSelected,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -26,7 +26,7 @@ class BottomActionsBar extends StatelessWidget {
     return BlocBuilder<AccountBloc, AccountState>(
       builder: (context, account) {
         return BlocBuilder<LSPBloc, LspState?>(builder: (context, lspState) {
-          final selectedLsp = (lspState?.selectedLspId != null);
+          final isLspSelected = (lspState?.selectedLspId != null);
 
           return BottomAppBar(
             child: SizedBox(
@@ -36,14 +36,14 @@ class BottomActionsBar extends StatelessWidget {
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
                   SendOptions(
-                    selectedLsp: selectedLsp,
+                    isLspSelected: isLspSelected,
                     firstPaymentItemKey: firstPaymentItemKey,
                     actionsGroup: actionsGroup,
                   ),
                   Container(width: 64),
                   ReceiveOptions(
                     account: account,
-                    selectedLsp: selectedLsp,
+                    isLspSelected: isLspSelected,
                     firstPaymentItemKey: firstPaymentItemKey,
                     actionsGroup: actionsGroup,
                   )
@@ -58,13 +58,13 @@ class BottomActionsBar extends StatelessWidget {
 }
 
 class SendOptions extends StatelessWidget {
-  final bool selectedLsp;
+  final bool isLspSelected;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const SendOptions({
     Key? key,
-    required this.selectedLsp,
+    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -78,7 +78,7 @@ class SendOptions extends StatelessWidget {
         context: context,
         builder: (context) {
           return SendOptionsBottomSheet(
-            selectedLsp: selectedLsp,
+            isLspSelected: isLspSelected,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },
@@ -92,14 +92,14 @@ class SendOptions extends StatelessWidget {
 
 class ReceiveOptions extends StatelessWidget {
   final AccountState account;
-  final bool selectedLsp;
+  final bool isLspSelected;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const ReceiveOptions({
     Key? key,
     required this.account,
-    required this.selectedLsp,
+    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -113,7 +113,7 @@ class ReceiveOptions extends StatelessWidget {
         builder: (context) {
           return ReceiveOptionsBottomSheet(
             account: account,
-            selectedLsp: selectedLsp,
+            isLspSelected: isLspSelected,
             firstPaymentItemKey: firstPaymentItemKey,
           );
         },

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -12,12 +12,10 @@ import 'bottom_action_item_image.dart';
 
 class ReceiveOptionsBottomSheet extends StatelessWidget {
   final AccountState account;
-  final bool isLspSelected;
   final GlobalKey firstPaymentItemKey;
 
   const ReceiveOptionsBottomSheet({
     super.key,
-    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.account,
   });
@@ -34,10 +32,8 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
           children: [
             const SizedBox(height: 8.0),
             ListTile(
-              enabled: isLspSelected,
-              leading: BottomActionItemImage(
+              leading: const BottomActionItemImage(
                 iconAssetPath: "src/icon/paste.png",
-                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_invoice,
@@ -51,10 +47,8 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
               indent: 72.0,
             ),
             ListTile(
-              enabled: isLspSelected,
-              leading: BottomActionItemImage(
+              leading: const BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -12,12 +12,12 @@ import 'bottom_action_item_image.dart';
 
 class ReceiveOptionsBottomSheet extends StatelessWidget {
   final AccountState account;
-  final bool connected;
+  final bool selectedLsp;
   final GlobalKey firstPaymentItemKey;
 
   const ReceiveOptionsBottomSheet({
     super.key,
-    required this.connected,
+    required this.selectedLsp,
     required this.firstPaymentItemKey,
     required this.account,
   });
@@ -34,10 +34,10 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
           children: [
             const SizedBox(height: 8.0),
             ListTile(
-              enabled: connected,
+              enabled: selectedLsp,
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/paste.png",
-                enabled: connected,
+                enabled: selectedLsp,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_invoice,
@@ -51,10 +51,10 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
               indent: 72.0,
             ),
             ListTile(
-              enabled: connected,
+              enabled: selectedLsp,
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: connected,
+                enabled: selectedLsp,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -12,12 +12,12 @@ import 'bottom_action_item_image.dart';
 
 class ReceiveOptionsBottomSheet extends StatelessWidget {
   final AccountState account;
-  final bool selectedLsp;
+  final bool isLspSelected;
   final GlobalKey firstPaymentItemKey;
 
   const ReceiveOptionsBottomSheet({
     super.key,
-    required this.selectedLsp,
+    required this.isLspSelected,
     required this.firstPaymentItemKey,
     required this.account,
   });
@@ -34,10 +34,10 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
           children: [
             const SizedBox(height: 8.0),
             ListTile(
-              enabled: selectedLsp,
+              enabled: isLspSelected,
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/paste.png",
-                enabled: selectedLsp,
+                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_invoice,
@@ -51,10 +51,10 @@ class ReceiveOptionsBottomSheet extends StatelessWidget {
               indent: 72.0,
             ),
             ListTile(
-              enabled: selectedLsp,
+              enabled: isLspSelected,
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: selectedLsp,
+                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_receive_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -11,10 +11,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SendOptionsBottomSheet extends StatelessWidget {
-  final bool isLspSelected;
   final GlobalKey firstPaymentItemKey;
 
-  const SendOptionsBottomSheet({super.key, required this.isLspSelected, required this.firstPaymentItemKey});
+  const SendOptionsBottomSheet({super.key, required this.firstPaymentItemKey});
 
   @override
   Widget build(BuildContext context) {
@@ -29,10 +28,8 @@ class SendOptionsBottomSheet extends StatelessWidget {
           children: [
             const SizedBox(height: 8.0),
             ListTile(
-              enabled: isLspSelected,
-              leading: BottomActionItemImage(
+              leading: const BottomActionItemImage(
                 iconAssetPath: "src/icon/paste.png",
-                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_paste_invoice,
@@ -47,9 +44,9 @@ class SendOptionsBottomSheet extends StatelessWidget {
             ),
             ListTile(
               enabled: false, // TODO: back to connected when we integrate with the SDK
-              leading: BottomActionItemImage(
+              leading: const BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: isLspSelected,
+                enabled: false, //  TODO: back to connected when we integrate with the SDK
               ),
               title: Text(
                 texts.bottom_action_bar_send_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -13,10 +13,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SendOptionsBottomSheet extends StatelessWidget {
-  final bool selectedLsp;
+  final bool isLspSelected;
   final GlobalKey firstPaymentItemKey;
 
-  const SendOptionsBottomSheet({super.key, required this.selectedLsp, required this.firstPaymentItemKey});
+  const SendOptionsBottomSheet({super.key, required this.isLspSelected, required this.firstPaymentItemKey});
 
   @override
   Widget build(BuildContext context) {
@@ -34,10 +34,10 @@ class SendOptionsBottomSheet extends StatelessWidget {
               buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
               builder: (context, lspState) {
                 return ListTile(
-                  enabled: selectedLsp,
+                  enabled: isLspSelected,
                   leading: BottomActionItemImage(
                     iconAssetPath: "src/icon/paste.png",
-                    enabled: selectedLsp,
+                    enabled: isLspSelected,
                   ),
                   title: Text(
                     texts.bottom_action_bar_paste_invoice,
@@ -56,7 +56,7 @@ class SendOptionsBottomSheet extends StatelessWidget {
               enabled: false, // TODO: back to connected when we integrate with the SDK
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: selectedLsp,
+                enabled: isLspSelected,
               ),
               title: Text(
                 texts.bottom_action_bar_send_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -43,10 +43,10 @@ class SendOptionsBottomSheet extends StatelessWidget {
               indent: 72.0,
             ),
             ListTile(
-              enabled: false, // TODO: back to connected when we integrate with the SDK
+              enabled: false, // TODO: enable when we integrate with the SDK
               leading: const BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: false, //  TODO: back to connected when we integrate with the SDK
+                enabled: false, //  TODO: enable when we integrate with the SDK
               ),
               title: Text(
                 texts.bottom_action_bar_send_btc_address,

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,7 +1,5 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/input/input_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/models/clipboard.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
@@ -30,22 +28,17 @@ class SendOptionsBottomSheet extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             const SizedBox(height: 8.0),
-            BlocBuilder<LSPBloc, LspState?>(
-              buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
-              builder: (context, lspState) {
-                return ListTile(
-                  enabled: isLspSelected,
-                  leading: BottomActionItemImage(
-                    iconAssetPath: "src/icon/paste.png",
-                    enabled: isLspSelected,
-                  ),
-                  title: Text(
-                    texts.bottom_action_bar_paste_invoice,
-                    style: theme.bottomSheetTextStyle,
-                  ),
-                  onTap: () => _pasteTapped(context, inputBloc, snapshot.data, firstPaymentItemKey),
-                );
-              },
+            ListTile(
+              enabled: isLspSelected,
+              leading: BottomActionItemImage(
+                iconAssetPath: "src/icon/paste.png",
+                enabled: isLspSelected,
+              ),
+              title: Text(
+                texts.bottom_action_bar_paste_invoice,
+                style: theme.bottomSheetTextStyle,
+              ),
+              onTap: () => _pasteTapped(context, inputBloc, snapshot.data, firstPaymentItemKey),
             ),
             Divider(
               height: 0.0,

--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,5 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/input/input_bloc.dart';
+import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
+import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/models/clipboard.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
@@ -11,10 +13,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SendOptionsBottomSheet extends StatelessWidget {
-  final bool connected;
+  final bool selectedLsp;
   final GlobalKey firstPaymentItemKey;
 
-  const SendOptionsBottomSheet({super.key, required this.connected, required this.firstPaymentItemKey});
+  const SendOptionsBottomSheet({super.key, required this.selectedLsp, required this.firstPaymentItemKey});
 
   @override
   Widget build(BuildContext context) {
@@ -28,17 +30,22 @@ class SendOptionsBottomSheet extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             const SizedBox(height: 8.0),
-            ListTile(
-              enabled: connected,
-              leading: BottomActionItemImage(
-                iconAssetPath: "src/icon/paste.png",
-                enabled: connected,
-              ),
-              title: Text(
-                texts.bottom_action_bar_paste_invoice,
-                style: theme.bottomSheetTextStyle,
-              ),
-              onTap: () => _pasteTapped(context, inputBloc, snapshot.data, firstPaymentItemKey),
+            BlocBuilder<LSPBloc, LspState?>(
+              buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
+              builder: (context, lspState) {
+                return ListTile(
+                  enabled: selectedLsp,
+                  leading: BottomActionItemImage(
+                    iconAssetPath: "src/icon/paste.png",
+                    enabled: selectedLsp,
+                  ),
+                  title: Text(
+                    texts.bottom_action_bar_paste_invoice,
+                    style: theme.bottomSheetTextStyle,
+                  ),
+                  onTap: () => _pasteTapped(context, inputBloc, snapshot.data, firstPaymentItemKey),
+                );
+              },
             ),
             Divider(
               height: 0.0,
@@ -49,7 +56,7 @@ class SendOptionsBottomSheet extends StatelessWidget {
               enabled: false, // TODO: back to connected when we integrate with the SDK
               leading: BottomActionItemImage(
                 iconAssetPath: "src/icon/bitcoin.png",
-                enabled: connected,
+                enabled: selectedLsp,
               ),
               title: Text(
                 texts.bottom_action_bar_send_btc_address,

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -23,16 +23,16 @@ class QrActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<LSPBloc, LspState?>(
       builder: (context, lspState) {
-        final connected = (lspState?.lspInfo != null);
+        final selectedLsp = (lspState?.selectedLspId != null);
 
         return Padding(
           padding: const EdgeInsets.only(top: 32.0),
           child: FloatingActionButton(
-            onPressed: (connected) ? () => _scanBarcode(context) : null,
+            onPressed: (selectedLsp) ? () => _scanBarcode(context) : null,
             child: SvgPicture.asset(
               "src/icon/qr_scan.svg",
               colorFilter: ColorFilter.mode(
-                connected ? theme.BreezColors.white[500]! : Theme.of(context).disabledColor,
+                selectedLsp ? theme.BreezColors.white[500]! : Theme.of(context).disabledColor,
                 BlendMode.srcATop,
               ),
               fit: BoxFit.contain,

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -23,16 +23,16 @@ class QrActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<LSPBloc, LspState?>(
       builder: (context, lspState) {
-        final selectedLsp = (lspState?.selectedLspId != null);
+        final isLspSelected = (lspState?.selectedLspId != null);
 
         return Padding(
           padding: const EdgeInsets.only(top: 32.0),
           child: FloatingActionButton(
-            onPressed: (selectedLsp) ? () => _scanBarcode(context) : null,
+            onPressed: (isLspSelected) ? () => _scanBarcode(context) : null,
             child: SvgPicture.asset(
               "src/icon/qr_scan.svg",
               colorFilter: ColorFilter.mode(
-                selectedLsp ? theme.BreezColors.white[500]! : Theme.of(context).disabledColor,
+                isLspSelected ? theme.BreezColors.white[500]! : Theme.of(context).disabledColor,
                 BlendMode.srcATop,
               ),
               fit: BoxFit.contain,

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -23,16 +23,14 @@ class QrActionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocBuilder<LSPBloc, LspState?>(
       builder: (context, lspState) {
-        final isLspSelected = (lspState?.selectedLspId != null);
-
         return Padding(
           padding: const EdgeInsets.only(top: 32.0),
           child: FloatingActionButton(
-            onPressed: (isLspSelected) ? () => _scanBarcode(context) : null,
+            onPressed: () => _scanBarcode(context),
             child: SvgPicture.asset(
               "src/icon/qr_scan.svg",
               colorFilter: ColorFilter.mode(
-                isLspSelected ? theme.BreezColors.white[500]! : Theme.of(context).disabledColor,
+                theme.BreezColors.white[500]!,
                 BlendMode.srcATop,
               ),
               fit: BoxFit.contain,

--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -1,6 +1,8 @@
 import 'package:breez_sdk/breez_bridge.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
+import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/bloc/swap_in/swap_in_bloc.dart';
 import 'package:c_breez/bloc/swap_in/swap_in_state.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/inprogress_swap.dart';
@@ -31,49 +33,53 @@ class SwapPageState extends State<SwapPage> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<SwapInBloc, SwapInState>(builder: (context, swapState) {
-      final SwapInBloc swapInBloc = context.read();
-      final texts = context.texts();
-
-      return Scaffold(
-        appBar: AppBar(
-          automaticallyImplyLeading: false,
-          leading: const back_button.BackButton(),
-          title: Text(texts.invoice_btc_address_title),
-        ),
-        body: swapState.isLoading
-            ? const AddressWidgetPlaceholder()
-            : SingleChildScrollView(
-                child: Column(
-                  children: [
-                    ...[
-                      if (swapState.unused != null)
-                        DepositWidget(swapState.unused!)
-                      else if (swapState.inProgress != null)
-                        SwapInprogress(swap: swapState.inProgress!)
-                    ],
-                    if (swapState.error != null) ...[
-                      Padding(
-                        padding: const EdgeInsets.only(
-                          top: 50.0,
-                          left: 30.0,
-                          right: 30.0,
-                        ),
-                        child: Text(swapState.error!, textAlign: TextAlign.center),
-                      ),
-                    ]
-                  ],
-                ),
-              ),
-        bottomNavigationBar: swapState.error != null
-            ? SingleButtonBottomBar(
-                text: texts.invoice_btc_address_action_retry,
-                onPressed: () async {
-                  swapInBloc.pollSwapAddress();
-                },
-              )
-            : const SizedBox(),
-      );
-    });
+    return BlocBuilder<LSPBloc, LspState?>(
+      buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
+      builder: (context, lspState) {
+        return BlocBuilder<SwapInBloc, SwapInState>(builder: (context, swapState) {
+          final SwapInBloc swapInBloc = context.read();
+          final texts = context.texts();
+          return Scaffold(
+            appBar: AppBar(
+              automaticallyImplyLeading: false,
+              leading: const back_button.BackButton(),
+              title: Text(texts.invoice_btc_address_title),
+            ),
+            body: swapState.isLoading
+                ? const AddressWidgetPlaceholder()
+                : SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        ...[
+                          if (swapState.unused != null)
+                            DepositWidget(swapState.unused!)
+                          else if (swapState.inProgress != null)
+                            SwapInprogress(swap: swapState.inProgress!)
+                        ],
+                        if (swapState.error != null) ...[
+                          const Padding(
+                            padding: EdgeInsets.only(
+                              top: 50.0,
+                              left: 30.0,
+                              right: 30.0,
+                            ),
+                            child: Text("Error swapping", textAlign: TextAlign.center),
+                          ),
+                        ]
+                      ],
+                    ),
+                  ),
+            bottomNavigationBar: swapState.error != null
+                ? SingleButtonBottomBar(
+                    text: texts.invoice_btc_address_action_retry,
+                    onPressed: () async {
+                      swapInBloc.pollSwapAddress();
+                    },
+                  )
+                : const SizedBox(),
+          );
+        });
+      },
+    );
   }
 }

--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -1,8 +1,6 @@
 import 'package:breez_sdk/breez_bridge.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/bloc/swap_in/swap_in_bloc.dart';
 import 'package:c_breez/bloc/swap_in/swap_in_state.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/inprogress_swap.dart';
@@ -33,53 +31,48 @@ class SwapPageState extends State<SwapPage> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<LSPBloc, LspState?>(
-      buildWhen: (previous, current) => previous?.lspInfo != null || current?.lspInfo != null,
-      builder: (context, lspState) {
-        return BlocBuilder<SwapInBloc, SwapInState>(builder: (context, swapState) {
-          final SwapInBloc swapInBloc = context.read();
-          final texts = context.texts();
-          return Scaffold(
-            appBar: AppBar(
-              automaticallyImplyLeading: false,
-              leading: const back_button.BackButton(),
-              title: Text(texts.invoice_btc_address_title),
-            ),
-            body: swapState.isLoading
-                ? const AddressWidgetPlaceholder()
-                : SingleChildScrollView(
-                    child: Column(
-                      children: [
-                        ...[
-                          if (swapState.unused != null)
-                            DepositWidget(swapState.unused!)
-                          else if (swapState.inProgress != null)
-                            SwapInprogress(swap: swapState.inProgress!)
-                        ],
-                        if (swapState.error != null) ...[
-                          const Padding(
-                            padding: EdgeInsets.only(
-                              top: 50.0,
-                              left: 30.0,
-                              right: 30.0,
-                            ),
-                            child: Text("Error swapping", textAlign: TextAlign.center),
-                          ),
-                        ]
-                      ],
-                    ),
-                  ),
-            bottomNavigationBar: swapState.error != null
-                ? SingleButtonBottomBar(
-                    text: texts.invoice_btc_address_action_retry,
-                    onPressed: () async {
-                      swapInBloc.pollSwapAddress();
-                    },
-                  )
-                : const SizedBox(),
-          );
-        });
-      },
-    );
+    return BlocBuilder<SwapInBloc, SwapInState>(builder: (context, swapState) {
+      final SwapInBloc swapInBloc = context.read();
+      final texts = context.texts();
+      return Scaffold(
+        appBar: AppBar(
+          automaticallyImplyLeading: false,
+          leading: const back_button.BackButton(),
+          title: Text(texts.invoice_btc_address_title),
+        ),
+        body: swapState.isLoading
+            ? const AddressWidgetPlaceholder()
+            : SingleChildScrollView(
+                child: Column(
+                  children: [
+                    ...[
+                      if (swapState.unused != null)
+                        DepositWidget(swapState.unused!)
+                      else if (swapState.inProgress != null)
+                        SwapInprogress(swap: swapState.inProgress!)
+                    ],
+                    if (swapState.error != null) ...[
+                      const Padding(
+                        padding: EdgeInsets.only(
+                          top: 50.0,
+                          left: 30.0,
+                          right: 30.0,
+                        ),
+                        child: Text("Error swapping", textAlign: TextAlign.center),
+                      ),
+                    ]
+                  ],
+                ),
+              ),
+        bottomNavigationBar: swapState.error != null
+            ? SingleButtonBottomBar(
+                text: texts.invoice_btc_address_action_retry,
+                onPressed: () async {
+                  swapInBloc.pollSwapAddress();
+                },
+              )
+            : const SizedBox(),
+      );
+    });
   }
 }


### PR DESCRIPTION
# About pr

Since it can take some time to establish a connection the the LSP we first checking if the user has selected a LSP. 

This should solve the issue where the QR button looks as if it disabled ref #489. 

I do not have to much experience with state management in flutter and are not sure if I have followed best practices and would appreciate if you could review this too.

We most likely can defer checking if the _swapper_ **Receive via BTC** is connected to the LSP until a later state of the app. Not sure where to do this.
