### PR TITLE
Handle lnurl errors

### DIFF
--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -29,6 +29,9 @@ Future handleLNURL(
   } else if (requestData is LnUrlWithdrawRequestData) {
     _log.v("Handling withdrawalParams: $requestData");
     return handleWithdrawRequest(context, requestData);
+  } else if (requestData is LnUrlErrorData) {
+    _log.v("Handling lnurl error: $requestData");
+    throw requestData.reason;
   }
   _log.w("Unsupported lnurl $requestData");
   throw context.texts().lnurl_error_unsupported;


### PR DESCRIPTION
Throws error from LnUrlErrorData itself instead of the generic Unsupported LNUrl message.