### PR TITLE
Add LN Address information to Payment Details Dialog

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_ln_address.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_dialog_ln_address.dart
@@ -1,0 +1,33 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart';
+import 'package:flutter/material.dart';
+
+class PaymentDetailsDialogLnAddress extends StatelessWidget {
+  final Payment paymentInfo;
+  final AutoSizeGroup? labelAutoSizeGroup;
+  final AutoSizeGroup? valueAutoSizeGroup;
+
+  const PaymentDetailsDialogLnAddress({
+    super.key,
+    required this.paymentInfo,
+    this.labelAutoSizeGroup,
+    this.valueAutoSizeGroup,
+  });
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final details = paymentInfo.details.data;
+    if (details is LnPaymentDetails && details.lnAddress != null) {
+      return ShareablePaymentRow(
+        title: texts.payment_details_dialog_share_lightning_address,
+        sharedValue: details.lnAddress!,
+        labelAutoSizeGroup: labelAutoSizeGroup,
+        valueAutoSizeGroup: valueAutoSizeGroup,
+      );
+    } else {
+      return Container();
+    }
+  }
+}

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -7,6 +7,7 @@ import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_description.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_destination_pubkey.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_expiration.dart';
+import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_ln_address.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_success_action.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart';
@@ -61,6 +62,11 @@ class PaymentDetailsDialog extends StatelessWidget {
                 valueAutoSizeGroup: _valueGroup,
               ),
               PaymentDetailsDialogDate(
+                paymentInfo: paymentInfo,
+                labelAutoSizeGroup: _labelGroup,
+                valueAutoSizeGroup: _valueGroup,
+              ),
+              PaymentDetailsDialogLnAddress(
                 paymentInfo: paymentInfo,
                 labelAutoSizeGroup: _labelGroup,
                 valueAutoSizeGroup: _valueGroup,


### PR DESCRIPTION
This PR is part of 
- https://github.com/breez/c-breez/issues/497

LN Address information is added to Payment Details Dialog.

It seems like ln address information isn't added properly to payment info on SDK side or we need an additional parameter when paying to an ln address to notify SDK that ln address needs to be attached to the payment.