### PR TITLE
Uses clipboard watcher upstream repository

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -148,7 +148,7 @@ PODS:
     - Flutter
     - FlutterMacOS
   - PromisesObjC (2.2.0)
-  - Protobuf (3.22.0)
+  - Protobuf (3.22.1)
   - ReachabilitySwift (5.0.0)
   - share_plus (0.0.1):
     - Flutter
@@ -317,7 +317,7 @@ SPEC CHECKSUMS:
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
-  Protobuf: 5e6cbc143d02fe08585d86b0098f8b755d2caaab
+  Protobuf: d7f7c8329edf5eb8af65547a8ba3e9c1cee927d5
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -196,12 +196,11 @@ packages:
   clipboard_watcher:
     dependency: "direct main"
     description:
-      path: "."
-      ref: f12cdc89d1aba43e36f4af21c54efb10413095bd
-      resolved-ref: f12cdc89d1aba43e36f4af21c54efb10413095bd
-      url: "https://github.com/ademar111190/clipboard_watcher"
-    source: git
-    version: "0.1.3"
+      name: clipboard_watcher
+      sha256: "2fa9c728f46962668dbc1c07870695c9163524f8dbea25dc176277d1ef1cc2bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,7 @@ dependencies:
     git:
       url: https://github.com/breez/Breez-Translations
       ref: a52f6dc57c7eca00b230fe5a5dc7e0a1437a098a
-  clipboard_watcher:
-    git:
-      url: https://github.com/ademar111190/clipboard_watcher
-      ref: f12cdc89d1aba43e36f4af21c54efb10413095bd
+  clipboard_watcher: ^0.2.0
   connectivity_plus: ^3.0.3
   drag_and_drop_lists: ^0.3.3
   duration: ^3.0.12


### PR DESCRIPTION
The upstream repo merged our changes so we can use it directly now.

Related: https://github.com/breez/c-breez/issues/521