### PR TITLE
Support LNURL Auth base spec

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -208,6 +208,18 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     }
   }
 
+  Future<sdk.LnUrlCallbackStatus> lnurlAuth({
+    required sdk.LnUrlAuthRequestData reqData,
+  }) async {
+    _log.v("lnurlAuth amount: reqData: $reqData");
+    try {
+      return await _breezLib.lnurlAuth(reqData: reqData);
+    } catch (e) {
+      _log.e("lnurlAuth error", ex: e);
+      rethrow;
+    }
+  }
+
   Future sendPayment(String bolt11, int? amountSats) async {
     _log.v("sendPayment: $bolt11, $amountSats");
     try {

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -3,10 +3,7 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/input/input_bloc.dart';
 import 'package:c_breez/bloc/input/input_state.dart';
 import 'package:c_breez/models/invoice.dart';
-import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
-
 import 'package:c_breez/routes/lnurl/lnurl_invoice_delegate.dart';
-import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/routes/spontaneous_payment/spontaneous_payment_page.dart';
 import 'package:c_breez/utils/exceptions.dart';
@@ -14,7 +11,6 @@ import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/loader.dart';
 import 'package:c_breez/widgets/payment_dialogs/payment_request_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
-import 'package:c_breez/widgets/transparent_page_route.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -96,7 +92,7 @@ class InputHandler {
         .then((result) {
           _log.v("Input state handled: $result");
           if (result is LNURLPageResult && result.protocol != null) {
-            _handleLNURLPageResult(result);
+            handleLNURLPageResult(_context, result);
           }
         })
         .whenComplete(() => _handlingRequest = false)
@@ -108,83 +104,6 @@ class InputHandler {
             showFlushbar(_context, message: extractExceptionMessage(error, _context.texts()));
           }
         });
-  }
-
-  void _handleLNURLPageResult(LNURLPageResult result) {
-    switch (result.protocol) {
-      case LnUrlProtocol.Pay:
-        _handleLNURLPaymentPageResult(result);
-        break;
-      case LnUrlProtocol.Withdraw:
-        _handleLNURLWithdrawPageResult(result);
-        break;
-      case LnUrlProtocol.Auth:
-        _handleLNURLAuthPageResult(result);
-        break;
-      default:
-        break;
-    }
-  }
-
-  void _handleLNURLPaymentPageResult(LNURLPageResult result) {
-    if (result.successAction != null) {
-      _handleSuccessAction(result.successAction!);
-    } else {
-      _log.v("Handle LNURL payment page result with error '${result.error}'");
-      throw Exception(
-        extractExceptionMessage(
-          result.error!,
-          _context.texts(),
-          defaultErrorMsg: _context.texts().lnurl_payment_page_unknown_error,
-        ),
-      );
-    }
-  }
-
-  Future _handleSuccessAction(SuccessActionProcessed successAction) {
-    String message = '';
-    String? url;
-    if (successAction is SuccessActionProcessed_Message) {
-      message = successAction.data.message;
-      _log.v("Handle LNURL payment page result with message action '$message'");
-    } else if (successAction is SuccessActionProcessed_Url) {
-      message = successAction.data.description;
-      url = successAction.data.url;
-      _log.v("Handle LNURL payment page result with url action '$message', '$url'");
-    } else if (successAction is SuccessActionProcessed_Aes) {
-      message = "${successAction.data.description} ${successAction.data.plaintext}";
-      _log.v("Handle LNURL payment page result with aes action '$message'");
-    }
-    // Artificial delay for UX purposes
-    return Future.delayed(const Duration(seconds: 1)).then(
-      (_) => showDialog(
-        useRootNavigator: false,
-        context: _context,
-        builder: (_) => SuccessActionDialog(
-          message: message,
-          url: url,
-        ),
-      ),
-    );
-  }
-
-  void _handleLNURLWithdrawPageResult(LNURLPageResult result) {
-    if (result.error == null) {
-      _log.v("Handle LNURL withdraw page result with success");
-      Navigator.of(_context).push(
-        TransparentPageRoute((ctx) => const SuccessfulPaymentRoute()),
-      );
-    } else {
-      _log.v("Handle LNURL withdraw page result with error '${result.error}'");
-      throw result.error!;
-    }
-  }
-
-  void _handleLNURLAuthPageResult(LNURLPageResult result) {
-    if (result.error != null) {
-      _log.v("Handle LNURL auth page result with error '${result.error}'");
-      throw result.error!;
-    }
   }
 
   _setLoading(bool visible) {

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -4,6 +4,7 @@ import 'package:c_breez/bloc/input/input_bloc.dart';
 import 'package:c_breez/bloc/input/input_state.dart';
 import 'package:c_breez/models/invoice.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
+import 'package:c_breez/routes/lnurl/auth/auth_response.dart';
 import 'package:c_breez/routes/lnurl/lnurl_invoice_delegate.dart';
 import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
 import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
@@ -99,6 +100,8 @@ class InputHandler {
             _handleLNURLPaymentPageResult(result);
           } else if (result is LNURLWithdrawPageResult) {
             _handleLNURLWithdrawPageResult(result);
+          } else if (result is LNURLAuthPageResult) {
+            _handleLNURLAuthPageResult(result);
           }
         })
         .whenComplete(() => _handlingRequest = false)
@@ -162,6 +165,13 @@ class InputHandler {
       );
     } else {
       _log.v("Handle LNURL withdraw page result with error '${result.error}'");
+      throw result.error!;
+    }
+  }
+
+  void _handleLNURLAuthPageResult(LNURLAuthPageResult result) {
+    if (result.error != null) {
+      _log.v("Handle LNURL auth page result with error '${result.error}'");
       throw result.error!;
     }
   }

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -9,8 +9,8 @@ import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/routes/create_invoice/qr_code_dialog.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
+import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart';
-import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
@@ -28,7 +28,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 final _log = FimberLog("CreateInvoicePage");
 
 class CreateInvoicePage extends StatefulWidget {
-  final Function(LNURLWithdrawPageResult? result)? onFinish;
+  final Function(LNURLPageResult? result)? onFinish;
   final LnUrlWithdrawRequestData? requestData;
 
   const CreateInvoicePage({

--- a/lib/routes/lnurl/auth/auth_response.dart
+++ b/lib/routes/lnurl/auth/auth_response.dart
@@ -1,5 +1,0 @@
-class LNURLAuthPageResult {
-  final Object? error;
-
-  LNURLAuthPageResult({this.error});
-}

--- a/lib/routes/lnurl/auth/auth_response.dart
+++ b/lib/routes/lnurl/auth/auth_response.dart
@@ -1,0 +1,5 @@
+class LNURLAuthPageResult {
+  final Object? error;
+
+  LNURLAuthPageResult({this.error});
+}

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -23,9 +23,6 @@ Future<LNURLPageResult?> handleAuthRequest(
         navigator.push(loaderRoute);
         try {
           final resp = await context.read<AccountBloc>().lnurlAuth(reqData: requestData);
-          if (loaderRoute.isActive) {
-            navigator.removeRoute(loaderRoute);
-          }
           if (resp is LnUrlCallbackStatus_Ok) {
             log.v("LNURL auth success");
             return const LNURLPageResult(protocol: LnUrlProtocol.Auth);

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -1,0 +1,55 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/routes/lnurl/auth/auth_response.dart';
+import 'package:c_breez/routes/lnurl/auth/login_text.dart';
+import 'package:c_breez/widgets/error_dialog.dart';
+import 'package:c_breez/widgets/loader.dart';
+import 'package:fimber/fimber.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+final _log = FimberLog("handleLNURLAuthRequest");
+
+Future<LNURLAuthPageResult?> handleAuthRequest(
+  BuildContext context,
+  LnUrlAuthRequestData requestData,
+) async {
+  return promptAreYouSure(context, null, LoginText(domain: requestData.domain)).then(
+    (permitted) async {
+      if (permitted == true) {
+        final texts = context.texts();
+        final navigator = Navigator.of(context);
+        final loaderRoute = createLoaderRoute(context);
+        navigator.push(loaderRoute);
+        try {
+          final resp = await context.read<AccountBloc>().lnurlAuth(reqData: requestData);
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+          if (resp is LnUrlCallbackStatus_Ok) {
+            _log.v("LNURL auth success");
+            return LNURLAuthPageResult();
+          } else if (resp is LnUrlCallbackStatus_ErrorStatus) {
+            _log.v("LNURL auth failed: ${resp.data.reason}");
+            return LNURLAuthPageResult(error: resp.data.reason);
+          } else {
+            _log.w("Unknown response from lnurlAuth: $resp");
+            return LNURLAuthPageResult(error: texts.lnurl_payment_page_unknown_error);
+          }
+        } catch (e) {
+          _log.w("Error authenticating LNURL auth", ex: e);
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+          return LNURLAuthPageResult(error: e);
+        } finally {
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+        }
+      }
+      return Future.value();
+    },
+  );
+}

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -1,8 +1,8 @@
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
-import 'package:c_breez/routes/lnurl/auth/auth_response.dart';
 import 'package:c_breez/routes/lnurl/auth/login_text.dart';
+import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/widgets/error_dialog.dart';
 import 'package:c_breez/widgets/loader.dart';
 import 'package:fimber/fimber.dart';
@@ -11,7 +11,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _log = FimberLog("handleLNURLAuthRequest");
 
-Future<LNURLAuthPageResult?> handleAuthRequest(
+Future<LNURLPageResult?> handleAuthRequest(
   BuildContext context,
   LnUrlAuthRequestData requestData,
 ) async {
@@ -29,20 +29,23 @@ Future<LNURLAuthPageResult?> handleAuthRequest(
           }
           if (resp is LnUrlCallbackStatus_Ok) {
             _log.v("LNURL auth success");
-            return LNURLAuthPageResult();
+            return const LNURLPageResult(protocol: LnUrlProtocol.Auth);
           } else if (resp is LnUrlCallbackStatus_ErrorStatus) {
             _log.v("LNURL auth failed: ${resp.data.reason}");
-            return LNURLAuthPageResult(error: resp.data.reason);
+            return LNURLPageResult(protocol: LnUrlProtocol.Auth, error: resp.data.reason);
           } else {
             _log.w("Unknown response from lnurlAuth: $resp");
-            return LNURLAuthPageResult(error: texts.lnurl_payment_page_unknown_error);
+            return LNURLPageResult(
+              protocol: LnUrlProtocol.Auth,
+              error: texts.lnurl_payment_page_unknown_error,
+            );
           }
         } catch (e) {
           _log.w("Error authenticating LNURL auth", ex: e);
           if (loaderRoute.isActive) {
             navigator.removeRoute(loaderRoute);
           }
-          return LNURLAuthPageResult(error: e);
+          return LNURLPageResult(protocol: LnUrlProtocol.Auth, error: e);
         } finally {
           if (loaderRoute.isActive) {
             navigator.removeRoute(loaderRoute);

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -9,12 +9,11 @@ import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-final _log = FimberLog("handleLNURLAuthRequest");
-
 Future<LNURLPageResult?> handleAuthRequest(
   BuildContext context,
   LnUrlAuthRequestData requestData,
 ) async {
+  final log = FimberLog("handleLNURLAuthRequest");
   return promptAreYouSure(context, null, LoginText(domain: requestData.domain)).then(
     (permitted) async {
       if (permitted == true) {
@@ -28,20 +27,20 @@ Future<LNURLPageResult?> handleAuthRequest(
             navigator.removeRoute(loaderRoute);
           }
           if (resp is LnUrlCallbackStatus_Ok) {
-            _log.v("LNURL auth success");
+            log.v("LNURL auth success");
             return const LNURLPageResult(protocol: LnUrlProtocol.Auth);
           } else if (resp is LnUrlCallbackStatus_ErrorStatus) {
-            _log.v("LNURL auth failed: ${resp.data.reason}");
+            log.v("LNURL auth failed: ${resp.data.reason}");
             return LNURLPageResult(protocol: LnUrlProtocol.Auth, error: resp.data.reason);
           } else {
-            _log.w("Unknown response from lnurlAuth: $resp");
+            log.w("Unknown response from lnurlAuth: $resp");
             return LNURLPageResult(
               protocol: LnUrlProtocol.Auth,
               error: texts.lnurl_payment_page_unknown_error,
             );
           }
         } catch (e) {
-          _log.w("Error authenticating LNURL auth", ex: e);
+          log.w("Error authenticating LNURL auth", ex: e);
           if (loaderRoute.isActive) {
             navigator.removeRoute(loaderRoute);
           }
@@ -55,4 +54,12 @@ Future<LNURLPageResult?> handleAuthRequest(
       return Future.value();
     },
   );
+}
+
+void handleLNURLAuthPageResult(LNURLPageResult result) {
+  final log = FimberLog("handleLNURLAuthPageResult");
+  if (result.error != null) {
+    log.v("Handle LNURL auth page result with error '${result.error}'");
+    throw result.error!;
+  }
 }

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -56,10 +56,16 @@ Future<LNURLPageResult?> handleAuthRequest(
   );
 }
 
-void handleLNURLAuthPageResult(LNURLPageResult result) {
+void handleLNURLAuthPageResult(BuildContext context, LNURLPageResult result) {
   final log = FimberLog("handleLNURLAuthPageResult");
-  if (result.error != null) {
+  if (result.hasError) {
     log.v("Handle LNURL auth page result with error '${result.error}'");
+    promptError(
+      context,
+      context.texts().lnurl_webview_error_title,
+      Text(result.errorMessage),
+      okFunc: () => Navigator.of(context).pop(),
+    );
     throw result.error!;
   }
 }

--- a/lib/routes/lnurl/auth/login_text.dart
+++ b/lib/routes/lnurl/auth/login_text.dart
@@ -1,0 +1,30 @@
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:flutter/material.dart';
+
+class LoginText extends StatelessWidget {
+  final String domain;
+
+  const LoginText({required this.domain});
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+    return RichText(
+      text: TextSpan(
+        style: themeData.dialogTheme.contentTextStyle,
+        text: texts.handler_lnurl_login_anonymously,
+        children: [
+          TextSpan(
+            text: domain,
+            style: themeData.dialogTheme.contentTextStyle!.copyWith(fontWeight: FontWeight.bold),
+          ),
+          TextSpan(
+            text: "?",
+            style: themeData.dialogTheme.contentTextStyle,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -8,6 +8,8 @@ import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_handler.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 
+import 'widgets/lnurl_page_result.dart';
+
 Future handleLNURL(
   BuildContext context,
   GlobalKey firstPaymentItemKey,
@@ -30,4 +32,20 @@ Future handleLNURL(
   }
   log.w("Unsupported lnurl $requestData");
   throw context.texts().lnurl_error_unsupported;
+}
+
+void handleLNURLPageResult(BuildContext context, LNURLPageResult result) {
+  switch (result.protocol) {
+    case LnUrlProtocol.Pay:
+      handleLNURLPaymentPageResult(context, result);
+      break;
+    case LnUrlProtocol.Withdraw:
+      handleLNURLWithdrawPageResult(context, result);
+      break;
+    case LnUrlProtocol.Auth:
+      handleLNURLAuthPageResult(result);
+      break;
+    default:
+      break;
+  }
 }

--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -5,10 +5,14 @@ import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
+import 'package:c_breez/routes/lnurl/auth/auth_response.dart';
+import 'package:c_breez/routes/lnurl/auth/login_text.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
 import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
 import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
+import 'package:c_breez/widgets/error_dialog.dart';
+import 'package:c_breez/widgets/loader.dart';
 import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:fimber/fimber.dart';
@@ -29,6 +33,9 @@ Future handleLNURL(
   } else if (requestData is LnUrlWithdrawRequestData) {
     _log.v("Handling withdrawalParams: $requestData");
     return handleWithdrawRequest(context, requestData);
+  } else if (requestData is LnUrlAuthRequestData) {
+    _log.v("Handling lnurl auth: $requestData");
+    return handleAuthRequest(context, requestData);
   } else if (requestData is LnUrlErrorData) {
     _log.v("Handling lnurl error: $requestData");
     throw requestData.reason;
@@ -116,4 +123,47 @@ Future<LNURLWithdrawPageResult?> handleWithdrawRequest(
   );
 
   return completer.future;
+}
+
+Future<LNURLAuthPageResult?> handleAuthRequest(
+  BuildContext context,
+  LnUrlAuthRequestData requestData,
+) async {
+  return promptAreYouSure(context, null, LoginText(domain: requestData.domain)).then(
+    (permitted) async {
+      if (permitted == true) {
+        final texts = context.texts();
+        final navigator = Navigator.of(context);
+        final loaderRoute = createLoaderRoute(context);
+        navigator.push(loaderRoute);
+        try {
+          final resp = await context.read<AccountBloc>().lnurlAuth(reqData: requestData);
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+          if (resp is sdk.LnUrlCallbackStatus_Ok) {
+            _log.v("LNURL auth success");
+            return LNURLAuthPageResult();
+          } else if (resp is sdk.LnUrlCallbackStatus_ErrorStatus) {
+            _log.v("LNURL auth failed: ${resp.data.reason}");
+            return LNURLAuthPageResult(error: resp.data.reason);
+          } else {
+            _log.w("Unknown response from lnurlAuth: $resp");
+            return LNURLAuthPageResult(error: texts.lnurl_payment_page_unknown_error);
+          }
+        } catch (e) {
+          _log.w("Error authenticating LNURL auth", ex: e);
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+          return LNURLAuthPageResult(error: e);
+        } finally {
+          if (loaderRoute.isActive) {
+            navigator.removeRoute(loaderRoute);
+          }
+        }
+      }
+      return Future.value();
+    },
+  );
 }

--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -1,169 +1,33 @@
 import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
-import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/account/account_bloc.dart';
-import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
-import 'package:c_breez/routes/lnurl/auth/auth_response.dart';
-import 'package:c_breez/routes/lnurl/auth/login_text.dart';
-import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
-import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
-import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
-import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
-import 'package:c_breez/widgets/error_dialog.dart';
-import 'package:c_breez/widgets/loader.dart';
-import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
-import 'package:c_breez/widgets/route.dart';
+import 'package:c_breez/routes/lnurl/auth/lnurl_auth_handler.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_handler.dart';
+import 'package:c_breez/routes/lnurl/withdraw/lnurl_withdraw_handler.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
-
-final _log = FimberLog("handleLNURL");
 
 Future handleLNURL(
   BuildContext context,
   GlobalKey firstPaymentItemKey,
   dynamic requestData,
 ) {
-  _log.v("Handling lnurl requestData: $requestData");
+  final log = FimberLog("handleLNURL");
+  log.v("Handling lnurl requestData: $requestData");
   if (requestData is LnUrlPayRequestData) {
-    _log.v("Handling payParams: $requestData");
+    log.v("Handling payParams: $requestData");
     return handlePayRequest(context, firstPaymentItemKey, requestData);
   } else if (requestData is LnUrlWithdrawRequestData) {
-    _log.v("Handling withdrawalParams: $requestData");
+    log.v("Handling withdrawalParams: $requestData");
     return handleWithdrawRequest(context, requestData);
   } else if (requestData is LnUrlAuthRequestData) {
-    _log.v("Handling lnurl auth: $requestData");
+    log.v("Handling lnurl auth: $requestData");
     return handleAuthRequest(context, requestData);
   } else if (requestData is LnUrlErrorData) {
-    _log.v("Handling lnurl error: $requestData");
+    log.v("Handling lnurl error: $requestData");
     throw requestData.reason;
   }
-  _log.w("Unsupported lnurl $requestData");
+  log.w("Unsupported lnurl $requestData");
   throw context.texts().lnurl_error_unsupported;
-}
-
-Future<LNURLPaymentPageResult?> handlePayRequest(
-  BuildContext context,
-  GlobalKey firstPaymentItemKey,
-  LnUrlPayRequestData requestData,
-) async {
-  LNURLPaymentInfo? paymentInfo;
-  bool fixedAmount = requestData.minSendable == requestData.maxSendable;
-  if (fixedAmount && !(requestData.commentAllowed > 0)) {
-    // Show dialog if payment is of fixed amount with no payer comment allowed
-    paymentInfo = await showDialog<LNURLPaymentInfo>(
-      useRootNavigator: false,
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => LNURLPaymentDialog(requestData: requestData),
-    );
-  } else {
-    paymentInfo = await Navigator.of(context).push<LNURLPaymentInfo>(
-      FadeInRoute(
-        builder: (_) => LNURLPaymentPage(requestData: requestData),
-      ),
-    );
-  }
-  if (paymentInfo == null) {
-    return Future.value();
-  }
-  // Artificial wait for UX purposes
-  await Future.delayed(const Duration(milliseconds: 800));
-  // Show Processing Payment Dialog
-  // ignore: use_build_context_synchronously
-  return await showDialog(
-    useRootNavigator: false,
-    context: context,
-    barrierDismissible: false,
-    builder: (_) => ProcessingPaymentDialog(
-      isLnurlPayment: true,
-      firstPaymentItemKey: firstPaymentItemKey,
-      paymentFunc: () => context.read<AccountBloc>().lnurlPay(
-            amount: paymentInfo!.amount,
-            comment: paymentInfo.comment,
-            reqData: requestData,
-          ),
-    ),
-  ).then((result) {
-    if (result is LnUrlPayResult) {
-      if (result is sdk.LnUrlPayResult_EndpointSuccess) {
-        _log.v("LNURL payment success, action: ${result.data}");
-        return LNURLPaymentPageResult(
-          successAction: result.data,
-        );
-      } else if (result is sdk.LnUrlPayResult_EndpointError) {
-        _log.v("LNURL payment failed: ${result.data.reason}");
-        return LNURLPaymentPageResult(
-          error: result.data.reason,
-        );
-      }
-    }
-    _log.w("Error sending LNURL payment", ex: result);
-    throw LNURLPaymentPageResult(error: result).errorMessage;
-  });
-}
-
-Future<LNURLWithdrawPageResult?> handleWithdrawRequest(
-  BuildContext context,
-  LnUrlWithdrawRequestData requestData,
-) async {
-  Completer<LNURLWithdrawPageResult?> completer = Completer();
-  Navigator.of(context).push(
-    MaterialPageRoute(
-      builder: (_) => CreateInvoicePage(
-        requestData: requestData,
-        onFinish: (LNURLWithdrawPageResult? response) {
-          completer.complete(response);
-          Navigator.of(context).popUntil((route) => route.settings.name == "/");
-        },
-      ),
-    ),
-  );
-
-  return completer.future;
-}
-
-Future<LNURLAuthPageResult?> handleAuthRequest(
-  BuildContext context,
-  LnUrlAuthRequestData requestData,
-) async {
-  return promptAreYouSure(context, null, LoginText(domain: requestData.domain)).then(
-    (permitted) async {
-      if (permitted == true) {
-        final texts = context.texts();
-        final navigator = Navigator.of(context);
-        final loaderRoute = createLoaderRoute(context);
-        navigator.push(loaderRoute);
-        try {
-          final resp = await context.read<AccountBloc>().lnurlAuth(reqData: requestData);
-          if (loaderRoute.isActive) {
-            navigator.removeRoute(loaderRoute);
-          }
-          if (resp is sdk.LnUrlCallbackStatus_Ok) {
-            _log.v("LNURL auth success");
-            return LNURLAuthPageResult();
-          } else if (resp is sdk.LnUrlCallbackStatus_ErrorStatus) {
-            _log.v("LNURL auth failed: ${resp.data.reason}");
-            return LNURLAuthPageResult(error: resp.data.reason);
-          } else {
-            _log.w("Unknown response from lnurlAuth: $resp");
-            return LNURLAuthPageResult(error: texts.lnurl_payment_page_unknown_error);
-          }
-        } catch (e) {
-          _log.w("Error authenticating LNURL auth", ex: e);
-          if (loaderRoute.isActive) {
-            navigator.removeRoute(loaderRoute);
-          }
-          return LNURLAuthPageResult(error: e);
-        } finally {
-          if (loaderRoute.isActive) {
-            navigator.removeRoute(loaderRoute);
-          }
-        }
-      }
-      return Future.value();
-    },
-  );
 }

--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -43,7 +43,7 @@ void handleLNURLPageResult(BuildContext context, LNURLPageResult result) {
       handleLNURLWithdrawPageResult(context, result);
       break;
     case LnUrlProtocol.Auth:
-      handleLNURLAuthPageResult(result);
+      handleLNURLAuthPageResult(context, result);
       break;
     default:
       break;

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -4,7 +4,7 @@ import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/models/currency.dart';
-import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/utils/fiat_conversion.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -1,9 +1,12 @@
 import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
+import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
+import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:fimber/fimber.dart';
@@ -73,4 +76,47 @@ Future<LNURLPageResult?> handlePayRequest(
     _log.w("Error sending LNURL payment", ex: result);
     throw LNURLPageResult(error: result).errorMessage;
   });
+}
+
+void handleLNURLPaymentPageResult(BuildContext context, LNURLPageResult result) {
+  if (result.successAction != null) {
+    _handleSuccessAction(context, result.successAction!);
+  } else {
+    _log.v("Handle LNURL payment page result with error '${result.error}'");
+    final texts = context.texts();
+    throw Exception(
+      extractExceptionMessage(
+        result.error!,
+        texts,
+        defaultErrorMsg: texts.lnurl_payment_page_unknown_error,
+      ),
+    );
+  }
+}
+
+Future _handleSuccessAction(BuildContext context, SuccessActionProcessed successAction) {
+  String message = '';
+  String? url;
+  if (successAction is SuccessActionProcessed_Message) {
+    message = successAction.data.message;
+    _log.v("Handle LNURL payment page result with message action '$message'");
+  } else if (successAction is SuccessActionProcessed_Url) {
+    message = successAction.data.description;
+    url = successAction.data.url;
+    _log.v("Handle LNURL payment page result with url action '$message', '$url'");
+  } else if (successAction is SuccessActionProcessed_Aes) {
+    message = "${successAction.data.description} ${successAction.data.plaintext}";
+    _log.v("Handle LNURL payment page result with aes action '$message'");
+  }
+  // Artificial delay for UX purposes
+  return Future.delayed(const Duration(seconds: 1)).then(
+    (_) => showDialog(
+      useRootNavigator: false,
+      context: context,
+      builder: (_) => SuccessActionDialog(
+        message: message,
+        url: url,
+      ),
+    ),
+  );
 }

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -38,8 +38,6 @@ Future<LNURLPageResult?> handlePayRequest(
   if (paymentInfo == null) {
     return Future.value();
   }
-  // Artificial wait for UX purposes
-  await Future.delayed(const Duration(milliseconds: 800));
   // Show Processing Payment Dialog
   // ignore: use_build_context_synchronously
   return await showDialog(
@@ -99,15 +97,12 @@ Future _handleSuccessAction(BuildContext context, SuccessActionProcessed success
     message = "${successAction.data.description} ${successAction.data.plaintext}";
     _log.v("Handle LNURL payment page result with aes action '$message'");
   }
-  // Artificial delay for UX purposes
-  return Future.delayed(const Duration(seconds: 1)).then(
-    (_) => showDialog(
-      useRootNavigator: false,
-      context: context,
-      builder: (_) => SuccessActionDialog(
-        message: message,
-        url: url,
-      ),
+  return showDialog(
+    useRootNavigator: false,
+    context: context,
+    builder: (_) => SuccessActionDialog(
+      message: message,
+      url: url,
     ),
   );
 }

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -1,12 +1,10 @@
 import 'package:breez_sdk/bridge_generated.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
 import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialog.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
-import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:fimber/fimber.dart';
@@ -81,16 +79,9 @@ Future<LNURLPageResult?> handlePayRequest(
 void handleLNURLPaymentPageResult(BuildContext context, LNURLPageResult result) {
   if (result.successAction != null) {
     _handleSuccessAction(context, result.successAction!);
-  } else {
+  } else if (result.hasError) {
     _log.v("Handle LNURL payment page result with error '${result.error}'");
-    final texts = context.texts();
-    throw Exception(
-      extractExceptionMessage(
-        result.error!,
-        texts,
-        defaultErrorMsg: texts.lnurl_payment_page_unknown_error,
-      ),
-    );
+    throw Exception(result.errorMessage);
   }
 }
 

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -1,8 +1,9 @@
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
-import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
+import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:fimber/fimber.dart';
@@ -11,7 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _log = FimberLog("handleLNURLPayRequest");
 
-Future<LNURLPaymentPageResult?> handlePayRequest(
+Future<LNURLPageResult?> handlePayRequest(
   BuildContext context,
   GlobalKey firstPaymentItemKey,
   LnUrlPayRequestData requestData,
@@ -57,17 +58,19 @@ Future<LNURLPaymentPageResult?> handlePayRequest(
     if (result is LnUrlPayResult) {
       if (result is LnUrlPayResult_EndpointSuccess) {
         _log.v("LNURL payment success, action: ${result.data}");
-        return LNURLPaymentPageResult(
+        return LNURLPageResult(
+          protocol: LnUrlProtocol.Pay,
           successAction: result.data,
         );
       } else if (result is LnUrlPayResult_EndpointError) {
         _log.v("LNURL payment failed: ${result.data.reason}");
-        return LNURLPaymentPageResult(
+        return LNURLPageResult(
+          protocol: LnUrlProtocol.Pay,
           error: result.data.reason,
         );
       }
     }
     _log.w("Error sending LNURL payment", ex: result);
-    throw LNURLPaymentPageResult(error: result).errorMessage;
+    throw LNURLPageResult(error: result).errorMessage;
   });
 }

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -1,0 +1,73 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_dialog.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_page.dart';
+import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
+import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
+import 'package:c_breez/widgets/route.dart';
+import 'package:fimber/fimber.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+final _log = FimberLog("handleLNURLPayRequest");
+
+Future<LNURLPaymentPageResult?> handlePayRequest(
+  BuildContext context,
+  GlobalKey firstPaymentItemKey,
+  LnUrlPayRequestData requestData,
+) async {
+  LNURLPaymentInfo? paymentInfo;
+  bool fixedAmount = requestData.minSendable == requestData.maxSendable;
+  if (fixedAmount && !(requestData.commentAllowed > 0)) {
+    // Show dialog if payment is of fixed amount with no payer comment allowed
+    paymentInfo = await showDialog<LNURLPaymentInfo>(
+      useRootNavigator: false,
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => LNURLPaymentDialog(requestData: requestData),
+    );
+  } else {
+    paymentInfo = await Navigator.of(context).push<LNURLPaymentInfo>(
+      FadeInRoute(
+        builder: (_) => LNURLPaymentPage(requestData: requestData),
+      ),
+    );
+  }
+  if (paymentInfo == null) {
+    return Future.value();
+  }
+  // Artificial wait for UX purposes
+  await Future.delayed(const Duration(milliseconds: 800));
+  // Show Processing Payment Dialog
+  // ignore: use_build_context_synchronously
+  return await showDialog(
+    useRootNavigator: false,
+    context: context,
+    barrierDismissible: false,
+    builder: (_) => ProcessingPaymentDialog(
+      isLnurlPayment: true,
+      firstPaymentItemKey: firstPaymentItemKey,
+      paymentFunc: () => context.read<AccountBloc>().lnurlPay(
+            amount: paymentInfo!.amount,
+            comment: paymentInfo.comment,
+            reqData: requestData,
+          ),
+    ),
+  ).then((result) {
+    if (result is LnUrlPayResult) {
+      if (result is LnUrlPayResult_EndpointSuccess) {
+        _log.v("LNURL payment success, action: ${result.data}");
+        return LNURLPaymentPageResult(
+          successAction: result.data,
+        );
+      } else if (result is LnUrlPayResult_EndpointError) {
+        _log.v("LNURL payment failed: ${result.data.reason}");
+        return LNURLPaymentPageResult(
+          error: result.data.reason,
+        );
+      }
+    }
+    _log.w("Error sending LNURL payment", ex: result);
+    throw LNURLPaymentPageResult(error: result).errorMessage;
+  });
+}

--- a/lib/routes/lnurl/payment/lnurl_payment_info.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_info.dart
@@ -1,0 +1,9 @@
+class LNURLPaymentInfo {
+  final int amount;
+  final String? comment;
+
+  const LNURLPaymentInfo({
+    required this.amount,
+    this.comment,
+  });
+}

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -5,14 +5,13 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/routes/lnurl/payment/pay_response.dart';
+import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_metadata.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
-
 // import 'package:email_validator/email_validator.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';

--- a/lib/routes/lnurl/widgets/lnurl_page_result.dart
+++ b/lib/routes/lnurl/widgets/lnurl_page_result.dart
@@ -15,7 +15,11 @@ class LNURLPageResult {
 
   bool get hasError => error != null;
 
-  String get errorMessage => extractExceptionMessage(error ?? "", getSystemAppLocalizations());
+  String get errorMessage => extractExceptionMessage(
+        error ?? "",
+        getSystemAppLocalizations(),
+        defaultErrorMsg: getSystemAppLocalizations().lnurl_payment_page_unknown_error,
+      );
 }
 
 // Supported LNURL specs

--- a/lib/routes/lnurl/widgets/lnurl_page_result.dart
+++ b/lib/routes/lnurl/widgets/lnurl_page_result.dart
@@ -2,11 +2,13 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/utils/exceptions.dart';
 
-class LNURLPaymentPageResult {
+class LNURLPageResult {
+  final LnUrlProtocol? protocol;
   final SuccessActionProcessed? successAction;
   final Object? error;
 
-  const LNURLPaymentPageResult({
+  const LNURLPageResult({
+    this.protocol,
     this.successAction,
     this.error,
   });
@@ -16,12 +18,5 @@ class LNURLPaymentPageResult {
   String get errorMessage => extractExceptionMessage(error ?? "", getSystemAppLocalizations());
 }
 
-class LNURLPaymentInfo {
-  final int amount;
-  final String? comment;
-
-  const LNURLPaymentInfo({
-    required this.amount,
-    this.comment,
-  });
-}
+// Supported LNURL specs
+enum LnUrlProtocol { Auth, Pay, Withdraw }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -1,7 +1,7 @@
 import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
-import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
+import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/loading_animated_text.dart';
@@ -12,7 +12,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 final _log = FimberLog("LNURLWithdrawDialog");
 
 class LNURLWithdrawDialog extends StatefulWidget {
-  final Function(LNURLWithdrawPageResult? result) onFinish;
+  final Function(LNURLPageResult? result) onFinish;
   final sdk.LnUrlWithdrawRequestData requestData;
   final int amountSats;
 
@@ -29,7 +29,7 @@ class LNURLWithdrawDialog extends StatefulWidget {
 
 class _LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> with SingleTickerProviderStateMixin {
   late Animation<double> _opacityAnimation;
-  Future<LNURLWithdrawPageResult>? _future;
+  Future<LNURLPageResult>? _future;
   var finishCalled = false;
 
   @override
@@ -133,7 +133,7 @@ class _LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> with SingleTi
     );
   }
 
-  Future<LNURLWithdrawPageResult> _withdraw(BuildContext context) async {
+  Future<LNURLPageResult> _withdraw(BuildContext context) async {
     _log.v("Withdraw ${widget.amountSats} sats");
     final texts = context.texts();
     final accountBloc = context.read<AccountBloc>();
@@ -150,25 +150,27 @@ class _LNURLWithdrawDialogState extends State<LNURLWithdrawDialog> with SingleTi
       );
       if (resp is sdk.LnUrlCallbackStatus_Ok) {
         _log.v("LNURL withdraw success");
-        return LNURLWithdrawPageResult();
+        return const LNURLPageResult(protocol: LnUrlProtocol.Withdraw);
       } else if (resp is sdk.LnUrlCallbackStatus_ErrorStatus) {
         _log.v("LNURL withdraw failed: ${resp.data.reason}");
-        return LNURLWithdrawPageResult(
+        return LNURLPageResult(
+          protocol: LnUrlProtocol.Withdraw,
           error: resp.data.reason,
         );
       } else {
         _log.w("Unknown response from lnurlWithdraw: $resp");
-        return LNURLWithdrawPageResult(
+        return LNURLPageResult(
+          protocol: LnUrlProtocol.Withdraw,
           error: texts.lnurl_payment_page_unknown_error,
         );
       }
     } catch (e) {
       _log.w("Error withdrawing LNURL payment", ex: e);
-      return LNURLWithdrawPageResult(error: e);
+      return LNURLPageResult(protocol: LnUrlProtocol.Withdraw, error: e);
     }
   }
 
-  void _onFinish(LNURLWithdrawPageResult? result) {
+  void _onFinish(LNURLPageResult? result) {
     if (finishCalled) {
       return;
     }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -2,7 +2,10 @@ import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
+import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
+import 'package:c_breez/widgets/transparent_page_route.dart';
+import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 
 Future<LNURLPageResult?> handleWithdrawRequest(
@@ -23,4 +26,17 @@ Future<LNURLPageResult?> handleWithdrawRequest(
   );
 
   return completer.future;
+}
+
+void handleLNURLWithdrawPageResult(BuildContext context, LNURLPageResult result) {
+  final log = FimberLog("handleLNURLWithdrawPageResult");
+  if (result.error == null) {
+    log.v("Handle LNURL withdraw page result with success");
+    Navigator.of(context).push(
+      TransparentPageRoute((ctx) => const SuccessfulPaymentRoute()),
+    );
+  } else {
+    log.v("Handle LNURL withdraw page result with error '${result.error}'");
+    throw result.error!;
+  }
 }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -1,9 +1,11 @@
 import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
 import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
+import 'package:c_breez/widgets/error_dialog.dart';
 import 'package:c_breez/widgets/transparent_page_route.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
@@ -30,13 +32,23 @@ Future<LNURLPageResult?> handleWithdrawRequest(
 
 void handleLNURLWithdrawPageResult(BuildContext context, LNURLPageResult result) {
   final log = FimberLog("handleLNURLWithdrawPageResult");
-  if (result.error == null) {
+  if (result.hasError) {
     log.v("Handle LNURL withdraw page result with success");
     Navigator.of(context).push(
       TransparentPageRoute((ctx) => const SuccessfulPaymentRoute()),
     );
   } else {
     log.v("Handle LNURL withdraw page result with error '${result.error}'");
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+    promptError(
+      context,
+      texts.invoice_receive_fail,
+      Text(
+        texts.invoice_receive_fail_message(result.errorMessage),
+        style: themeData.dialogTheme.contentTextStyle,
+      ),
+    );
     throw result.error!;
   }
 }

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -2,19 +2,19 @@ import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
-import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
+import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:flutter/material.dart';
 
-Future<LNURLWithdrawPageResult?> handleWithdrawRequest(
+Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
 ) async {
-  Completer<LNURLWithdrawPageResult?> completer = Completer();
+  Completer<LNURLPageResult?> completer = Completer();
   Navigator.of(context).push(
     MaterialPageRoute(
       builder: (_) => CreateInvoicePage(
         requestData: requestData,
-        onFinish: (LNURLWithdrawPageResult? response) {
+        onFinish: (LNURLPageResult? response) {
           completer.complete(response);
           Navigator.of(context).popUntil((route) => route.settings.name == "/");
         },

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:c_breez/routes/create_invoice/create_invoice_page.dart';
+import 'package:c_breez/routes/lnurl/withdraw/withdraw_response.dart';
+import 'package:flutter/material.dart';
+
+Future<LNURLWithdrawPageResult?> handleWithdrawRequest(
+  BuildContext context,
+  LnUrlWithdrawRequestData requestData,
+) async {
+  Completer<LNURLWithdrawPageResult?> completer = Completer();
+  Navigator.of(context).push(
+    MaterialPageRoute(
+      builder: (_) => CreateInvoicePage(
+        requestData: requestData,
+        onFinish: (LNURLWithdrawPageResult? response) {
+          completer.complete(response);
+          Navigator.of(context).popUntil((route) => route.settings.name == "/");
+        },
+      ),
+    ),
+  );
+
+  return completer.future;
+}

--- a/lib/routes/lnurl/withdraw/withdraw_response.dart
+++ b/lib/routes/lnurl/withdraw/withdraw_response.dart
@@ -1,5 +1,0 @@
-class LNURLWithdrawPageResult {
-  final Object? error;
-
-  LNURLWithdrawPageResult({this.error});
-}


### PR DESCRIPTION
This PR addresses
- https://github.com/breez/c-breez/issues/59

Users will now be able to do `register`, `login`, `link` account, `auth` actions through LNURL-auth protocol with their wallet.
- Wallet duties are implemented for [LUD-04](https://github.com/lnurl/luds/blob/luds/04.md).
- Merged all LNURL related page results under LNURLPageResult,
- Refactored LNURL and LNURL Page Result handlers,
- Error dialog is shown after LNURL-Withdraw or LNURL-Auth fails to match breez mobile behavior
- Additional refactoring