### PR TITLE
Fix lnurlw

### DIFF
--- a/lib/routes/lnurl/lnurl_invoice_delegate.dart
+++ b/lib/routes/lnurl/lnurl_invoice_delegate.dart
@@ -10,31 +10,33 @@ import 'package:flutter/material.dart';
 
 import 'widgets/lnurl_page_result.dart';
 
+final _log = FimberLog("handleLNURL");
+
 Future handleLNURL(
   BuildContext context,
   GlobalKey firstPaymentItemKey,
   dynamic requestData,
 ) {
-  final log = FimberLog("handleLNURL");
-  log.v("Handling lnurl requestData: $requestData");
+  _log.v("Handling lnurl requestData: $requestData");
   if (requestData is LnUrlPayRequestData) {
-    log.v("Handling payParams: $requestData");
+    _log.v("Handling payParams: $requestData");
     return handlePayRequest(context, firstPaymentItemKey, requestData);
   } else if (requestData is LnUrlWithdrawRequestData) {
-    log.v("Handling withdrawalParams: $requestData");
+    _log.v("Handling withdrawalParams: $requestData");
     return handleWithdrawRequest(context, requestData);
   } else if (requestData is LnUrlAuthRequestData) {
-    log.v("Handling lnurl auth: $requestData");
+    _log.v("Handling lnurl auth: $requestData");
     return handleAuthRequest(context, requestData);
   } else if (requestData is LnUrlErrorData) {
-    log.v("Handling lnurl error: $requestData");
+    _log.v("Handling lnurl error: $requestData");
     throw requestData.reason;
   }
-  log.w("Unsupported lnurl $requestData");
+  _log.w("Unsupported lnurl $requestData");
   throw context.texts().lnurl_error_unsupported;
 }
 
 void handleLNURLPageResult(BuildContext context, LNURLPageResult result) {
+  _log.v("handle $result");
   switch (result.protocol) {
     case LnUrlProtocol.Pay:
       handleLNURLPaymentPageResult(context, result);

--- a/lib/routes/lnurl/widgets/lnurl_page_result.dart
+++ b/lib/routes/lnurl/widgets/lnurl_page_result.dart
@@ -20,6 +20,23 @@ class LNURLPageResult {
         getSystemAppLocalizations(),
         defaultErrorMsg: getSystemAppLocalizations().lnurl_payment_page_unknown_error,
       );
+
+  @override
+  String toString() {
+    return 'LNURLPageResult{protocol: $protocol, successAction: $successAction, error: $error}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LNURLPageResult &&
+          runtimeType == other.runtimeType &&
+          protocol == other.protocol &&
+          successAction == other.successAction &&
+          error == other.error;
+
+  @override
+  int get hashCode => protocol.hashCode ^ successAction.hashCode ^ error.hashCode;
 }
 
 // Supported LNURL specs

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -10,6 +10,8 @@ import 'package:c_breez/widgets/transparent_page_route.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
 
+final _log = FimberLog("handleLNURLWithdrawPageResult");
+
 Future<LNURLPageResult?> handleWithdrawRequest(
   BuildContext context,
   LnUrlWithdrawRequestData requestData,
@@ -31,14 +33,9 @@ Future<LNURLPageResult?> handleWithdrawRequest(
 }
 
 void handleLNURLWithdrawPageResult(BuildContext context, LNURLPageResult result) {
-  final log = FimberLog("handleLNURLWithdrawPageResult");
+  _log.v("handle $result");
   if (result.hasError) {
-    log.v("Handle LNURL withdraw page result with success");
-    Navigator.of(context).push(
-      TransparentPageRoute((ctx) => const SuccessfulPaymentRoute()),
-    );
-  } else {
-    log.v("Handle LNURL withdraw page result with error '${result.error}'");
+    _log.v("Handle LNURL withdraw page result with error '${result.error}'");
     final texts = context.texts();
     final themeData = Theme.of(context);
     promptError(
@@ -50,5 +47,10 @@ void handleLNURLWithdrawPageResult(BuildContext context, LNURLPageResult result)
       ),
     );
     throw result.error!;
+  } else {
+    _log.v("Handle LNURL withdraw page result with success");
+    Navigator.of(context).push(
+      TransparentPageRoute((ctx) => const SuccessfulPaymentRoute()),
+    );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/breez/c-breez/issues/571#issuecomment-1593286917

Our `if (result.hasError) {` check was routing the success flow and the else the error flow, so the fix is just invert the if/else.
I added more log that was useful to me understand the error during the process.