### PR TITLE
Fix metadata parsing

### DIFF
--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -91,29 +91,34 @@ class _PaymentMinutiaeFactory {
 
   void _parseMetadata(LnPaymentDetails detailsData) {
     final metadata = detailsData.lnurlMetadata;
-    if (metadata != null && metadata.isNotEmpty) {
-      try {
-        final parsed = json.decode(metadata);
-        if (parsed is List) {
-          for (var item in parsed) {
-            if (item is List && item.length == 2) {
-              final key = item[0];
-              final value = item[1];
-              if (key is String) {
-                _metadataMap[key] = value;
-              } else {
-                _log.w("Unknown runtime type of key $key");
-              }
-            } else {
-              _log.w("Unknown runtime type of item $item");
-            }
-          }
-        } else {
-          _log.w("Unknown runtime type of $parsed for $metadata");
-        }
-      } catch (e) {
-        _log.w("Failed to parse metadata: $metadata", ex: e);
+    if (metadata == null || metadata.isEmpty) {
+      return;
+    }
+
+    try {
+      final parsed = json.decode(metadata);
+      if (parsed is! List) {
+        _log.w("Unknown runtime type of $parsed for $metadata");
+        return;
       }
+
+      for (var item in parsed) {
+        if (item is! List || item.length != 2) {
+          _log.w("Unknown runtime type of item $item");
+          continue;
+        }
+
+        final key = item[0];
+        final value = item[1];
+        if (key is! String) {
+          _log.w("Unknown runtime type of key $key");
+          continue;
+        }
+
+        _metadataMap[key] = value;
+      }
+    } catch (e) {
+      _log.w("Failed to parse metadata: $metadata", ex: e);
     }
   }
 

--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -85,13 +85,34 @@ class _PaymentMinutiaeFactory {
   _PaymentMinutiaeFactory(this._payment, this._texts) {
     final detailsData = _payment.details.data;
     if (detailsData is LnPaymentDetails) {
-      final metadata = detailsData.lnurlMetadata;
-      if (metadata != null && metadata.isNotEmpty) {
-        try {
-          _metadataMap.addAll(json.decode(metadata));
-        } catch (e) {
-          _log.w("Failed to parse metadata: $metadata", ex: e);
+      _parseMetadata(detailsData);
+    }
+  }
+
+  void _parseMetadata(LnPaymentDetails detailsData) {
+    final metadata = detailsData.lnurlMetadata;
+    if (metadata != null && metadata.isNotEmpty) {
+      try {
+        final parsed = json.decode(metadata);
+        if (parsed is List) {
+          for (var item in parsed) {
+            if (item is List && item.length == 2) {
+              final key = item[0];
+              final value = item[1];
+              if (key is String) {
+                _metadataMap[key] = value;
+              } else {
+                _log.w("Unknown runtime type of key $key");
+              }
+            } else {
+              _log.w("Unknown runtime type of item $item");
+            }
+          }
+        } else {
+          _log.w("Unknown runtime type of $parsed for $metadata");
         }
+      } catch (e) {
+        _log.w("Failed to parse metadata: $metadata", ex: e);
       }
     }
   }

--- a/test/models/payment_minutiae_test.dart
+++ b/test/models/payment_minutiae_test.dart
@@ -180,22 +180,22 @@ void main() {
 
   group("image", () {
     test("metadata img png should be extracted", () {
-      final image = makeLnPayment(metadata: '{"image/png;base64":"$imageBase64"}').image;
+      final image = makeLnPayment(metadata: '[["image/png;base64", "$imageBase64"]]').image;
       expect(image, isNotNull);
     });
 
     test("metadata img png when it is empty should return null", () {
-      final image = makeLnPayment(metadata: '{"image/png;base64":""}').image;
+      final image = makeLnPayment(metadata: '[["image/png;base64", ""]]').image;
       expect(image, isNull);
     });
 
     test("metadata img jpeg should be extracted", () {
-      final image = makeLnPayment(metadata: '{"image/jpeg;base64":"$imageBase64"}').image;
+      final image = makeLnPayment(metadata: '[["image/jpeg;base64", "$imageBase64"]]').image;
       expect(image, isNotNull);
     });
 
     test("metadata img jpeg when it is empty should return null", () {
-      final image = makeLnPayment(metadata: '{"image/jpeg;base64":""}').image;
+      final image = makeLnPayment(metadata: '[["image/jpeg;base64", ""]]').image;
       expect(image, isNull);
     });
   });
@@ -234,7 +234,7 @@ void main() {
     });
 
     test("hasMetadata should return true when metadata is not null and not empty", () {
-      final hasMetadata = makeLnPayment(metadata: '{"key": "value"}').hasMetadata;
+      final hasMetadata = makeLnPayment(metadata: '[["key", "value"]]').hasMetadata;
       expect(hasMetadata, isTrue);
     });
 
@@ -244,7 +244,7 @@ void main() {
     });
 
     test("hasMetadata should return false when metadata is empty", () {
-      final hasMetadata = makeLnPayment(metadata: "{}").hasMetadata;
+      final hasMetadata = makeLnPayment(metadata: "[]").hasMetadata;
       expect(hasMetadata, isFalse);
     });
 


### PR DESCRIPTION
Fixes https://github.com/breez/c-breez/issues/565

For some reason, I was expecting a map instead of the pattern `"[[\"text/plain\", \"lorem ipsum blah blah\"]]"`