### PR TITLE
error message to restore node flow

### DIFF
--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -57,6 +57,9 @@ String _localizedExceptionMessage(
       if (originalMessage.contains("dns error") || originalMessage.contains("os error 104")) {
         return texts.generic_network_error;
       }
+      if (originalMessage.contains("Recovery failed:")) {
+        return texts.enter_backup_phrase_error;
+      }
       return originalMessage;
   }
 }


### PR DESCRIPTION
# About pr

Fixes #533 

Displays readable error message when the user insert an invalid recovery phrase.
![Screenshot 2023-06-19 at 13 23 06](https://github.com/breez/c-breez/assets/36157890/31f567e7-b9fc-4a18-bed7-9658f51e3d83)
