### PR TITLE
Fix build context crashes by improving how we make our handlers

### DIFF
--- a/lib/handlers/connectivity_handler.dart
+++ b/lib/handlers/connectivity_handler.dart
@@ -1,41 +1,74 @@
+import 'dart:async';
+
 import 'package:another_flushbar/flushbar.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/connectivity/connectivity_bloc.dart';
 import 'package:c_breez/bloc/connectivity/connectivity_state.dart';
+import 'package:c_breez/handlers/handler.dart';
+import 'package:c_breez/handlers/handler_context_provider.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
-class ConnectivityHandler {
-  final BuildContext context;
-  final ConnectivityBloc connectivityBloc;
-  late Flushbar flushbar;
+final _log = FimberLog("ConnectivityHandler");
 
-  ConnectivityHandler(this.context, this.connectivityBloc) {
-    flushbar = _getNoConnectionFlushbar();
-    connectivityBloc.stream
+class ConnectivityHandler extends Handler {
+  StreamSubscription<ConnectivityState>? _subscription;
+  Flushbar? _flushbar;
+
+  @override
+  void init(HandlerContextProvider<StatefulWidget> contextProvider) {
+    super.init(contextProvider);
+    _subscription = contextProvider
+        .getBuildContext()!
+        .read<ConnectivityBloc>()
+        .stream
         .distinct((previous, next) => previous.lastStatus == next.lastStatus)
-        .listen((connectionStatus) {
-      if (connectionStatus.lastStatus == ConnectivityResult.none) {
-        showNoInternetConnectionFlushbar();
-      } else if (flushbar.isShowing() || flushbar.isAppearing()) {
-        flushbar.dismiss(true);
-      }
-    });
+        .listen(_listen);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _subscription?.cancel();
+    _subscription = null;
+    _flushbar = null;
+  }
+
+  void _listen(ConnectivityState connectivityState) async {
+    _log.v("Received connectivityState $connectivityState");
+    if (connectivityState.lastStatus == ConnectivityResult.none) {
+      showNoInternetConnectionFlushbar();
+    } else {
+      dismissFlushbarIfNeed();
+    }
   }
 
   void showNoInternetConnectionFlushbar() {
+    dismissFlushbarIfNeed();
+    final context = contextProvider?.getBuildContext();
+    if (context == null) {
+      _log.v("Skipping connection flushbar as context is null");
+      return;
+    }
+    _flushbar = _getNoConnectionFlushbar(context);
+    _flushbar?.show(context);
+  }
+
+  void dismissFlushbarIfNeed() {
+    final flushbar = _flushbar;
+    if (flushbar == null) return;
+
     if (flushbar.isShowing() || flushbar.isAppearing()) {
       flushbar.dismiss(true);
     }
-    flushbar.show(context);
+    _flushbar = null;
   }
 
-  Flushbar _getNoConnectionFlushbar() {
-    final texts = context.texts();
-
-    Flushbar? noConnectionFlushbar;
-    noConnectionFlushbar = Flushbar(
+  Flushbar? _getNoConnectionFlushbar(BuildContext context) {
+    return Flushbar(
       isDismissible: false,
       flushbarPosition: FlushbarPosition.TOP,
       icon: Icon(
@@ -44,52 +77,52 @@ class ConnectivityHandler {
         color: Theme.of(context).colorScheme.error,
       ),
       messageText: Text(
-        texts.no_connection_flushbar_title,
+        context.texts().no_connection_flushbar_title,
         style: theme.snackBarStyle,
         textAlign: TextAlign.center,
       ),
       mainButton: SizedBox(
         width: 64,
         child: StreamBuilder<ConnectivityState>(
-            stream: connectivityBloc.stream,
-            builder: (context, snapshot) {
-              if (snapshot.hasData && snapshot.data?.isConnecting == true) {
-                return Center(
-                  child: SizedBox(
-                    height: 24.0,
-                    width: 24.0,
-                    child: CircularProgressIndicator(
-                      color: Theme.of(context).colorScheme.error,
-                    ),
-                  ),
-                );
-              }
-              return TextButton(
-                onPressed: () {
-                  connectivityBloc.setIsConnecting(true);
-                  Future.delayed(
-                    const Duration(seconds: 1),
-                    () => connectivityBloc
-                        .checkConnectivity()
-                        .whenComplete(() => connectivityBloc.setIsConnecting(false))
-                        .onError((error, stackTrace) {
-                      connectivityBloc.setIsConnecting(false);
-                      throw error.toString();
-                    }),
-                  );
-                },
-                child: Text(
-                  texts.no_connection_flushbar_action_retry,
-                  style: theme.snackBarStyle.copyWith(
+          stream: context.read<ConnectivityBloc>().stream,
+          builder: (context, snapshot) {
+            if (snapshot.hasData && snapshot.data?.isConnecting == true) {
+              return Center(
+                child: SizedBox(
+                  height: 24.0,
+                  width: 24.0,
+                  child: CircularProgressIndicator(
                     color: Theme.of(context).colorScheme.error,
                   ),
                 ),
               );
-            }),
+            }
+            return TextButton(
+              onPressed: () {
+                context.read<ConnectivityBloc>().setIsConnecting(true);
+                Future.delayed(
+                  const Duration(seconds: 1),
+                  () => context
+                      .read<ConnectivityBloc>()
+                      .checkConnectivity()
+                      .whenComplete(() => context.read<ConnectivityBloc>().setIsConnecting(false))
+                      .onError((error, stackTrace) {
+                    context.read<ConnectivityBloc>().setIsConnecting(false);
+                    throw error.toString();
+                  }),
+                );
+              },
+              child: Text(
+                context.texts().no_connection_flushbar_action_retry,
+                style: theme.snackBarStyle.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            );
+          },
+        ),
       ),
       backgroundColor: theme.snackBarBackgroundColor,
     );
-
-    return noConnectionFlushbar;
   }
 }

--- a/lib/handlers/handler.dart
+++ b/lib/handlers/handler.dart
@@ -1,0 +1,13 @@
+import 'handler_context_provider.dart';
+
+abstract class Handler {
+  HandlerContextProvider? contextProvider;
+
+  void init(HandlerContextProvider contextProvider) {
+    this.contextProvider = contextProvider;
+  }
+
+  void dispose() {
+    contextProvider = null;
+  }
+}

--- a/lib/handlers/handler_context_provider.dart
+++ b/lib/handlers/handler_context_provider.dart
@@ -1,0 +1,7 @@
+import 'package:flutter/widgets.dart';
+
+mixin HandlerContextProvider<T extends StatefulWidget> on State<T> {
+  BuildContext? getBuildContext() {
+    return context;
+  }
+}

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -1,42 +1,67 @@
+import 'dart:async';
+
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/bloc/account/payment_result.dart';
+import 'package:c_breez/handlers/handler.dart';
+import 'package:c_breez/handlers/handler_context_provider.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:rxdart/rxdart.dart';
 
-class PaymentResultHandler {
-  final _log = FimberLog("PaymentResultHandler");
+final _log = FimberLog("PaymentResultHandler");
 
-  final BuildContext context;
-  final AccountBloc accountBloc;
+class PaymentResultHandler extends Handler {
+  StreamSubscription<PaymentResult>? _subscription;
 
-  PaymentResultHandler(this.context, this.accountBloc) {
-    _log.v("PaymentResultHandler created");
-    accountBloc.paymentResultStream.delay(const Duration(seconds: 1)).listen(
-      (paymentResult) async {
-        _log.v("Received paymentResult: $paymentResult");
-        if (paymentResult.paymentInfo != null) {
-          final texts = context.texts();
-          showFlushbar(
-            context,
-            messageWidget: SingleChildScrollView(
-              child: Text(
-                paymentResult.paymentInfo!.paymentType == PaymentType.Received
-                    ? texts.successful_payment_received
-                    : texts.home_payment_sent,
-              ),
-            ),
-          );
-        } else if (paymentResult.error != null) {
-          _log.v("paymentResult error: ${paymentResult.error}");
-          showFlushbar(
-            context,
-            message: paymentResult.errorMessage(),
-          );
-        }
-      },
-    );
+  @override
+  void init(HandlerContextProvider contextProvider) {
+    super.init(contextProvider);
+    _log.v("PaymentResultHandler inited");
+    _subscription = contextProvider
+        .getBuildContext()!
+        .read<AccountBloc>()
+        .paymentResultStream
+        .delay(const Duration(seconds: 1))
+        .listen(_listen);
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _subscription?.cancel();
+    _subscription = null;
+  }
+
+  void _listen(PaymentResult paymentResult) async {
+    _log.v("Received paymentResult: $paymentResult");
+    final context = contextProvider?.getBuildContext();
+    if (context == null) {
+      _log.w("Failed to proceed because context is null");
+      return;
+    }
+
+    if (paymentResult.paymentInfo != null) {
+      final texts = context.texts();
+      showFlushbar(
+        context,
+        messageWidget: SingleChildScrollView(
+          child: Text(
+            paymentResult.paymentInfo!.paymentType == PaymentType.Received
+                ? texts.successful_payment_received
+                : texts.home_payment_sent,
+          ),
+        ),
+      );
+    } else if (paymentResult.error != null) {
+      _log.v("paymentResult error: ${paymentResult.error}");
+      showFlushbar(
+        context,
+        message: paymentResult.errorMessage(),
+      );
+    }
   }
 }


### PR DESCRIPTION
I have been catching several crashes originating from our handlers. The major cause is the `BuildContext` being hold by the handlers.

Here I'm fixing most of these crashes by using a `Handler` structure with an init/dispose structure and getting the context when needed and checking for its nullability.