### PR TITLE
Correct the payment request info dialog alignment

### DIFF
--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -75,7 +75,7 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
         key: _dialogKey,
         width: MediaQuery.of(context).size.width,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
           mainAxisSize: MainAxisSize.min,
           children: paymentRequestDialog,
         ),
@@ -107,14 +107,9 @@ class PaymentRequestInfoDialogState extends State<PaymentRequestInfoDialog> {
           _addIfNotNull(children, _buildErrorMessage(context, currencyState));
           _addIfNotNull(children, _buildActions(context, currencyState, account));
 
-          return Container(
-            padding: const EdgeInsets.fromLTRB(8.0, 0.0, 8.0, 16.0),
-            width: MediaQuery.of(context).size.width,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              children: children,
-            ),
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Column(children: children),
           );
         },
       );


### PR DESCRIPTION
This PR addresses 
- #547

Explanation for the changes are here: https://github.com/breez/c-breez/issues/547#issuecomment-1622154949
> The UI's code is practically the same between cBreez & Breezmobile, couldn't find the root cause but noticed `Column` alignments were behaving differently. We have a lot of `_addIfNotNull` logic, perhaps this difference is due to null safety. Will get back to investigating this later.
> 
> For now, I've applied a fix to programmatically allocate the free space around equally around dialog content. There's still a slight difference 🤏 Here's the comparison between cBreez(Dark theme) and Breezmobile(Blue theme) with this fix:
> 
>  [Screen.Recording.2023-07-05.at.19.49.13.mov ](https://github.com/breez/c-breez/assets/4012752/49c78167-b1f9-4245-ae7c-71bf4cdb2627)

