### PR TITLE
Autocomplete on restore form

### DIFF
--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -126,8 +126,11 @@ class RestoreFormPageState extends State<RestoreForm> {
 
   FutureOr<List<String>> _getSuggestions(String pattern, int itemIndex) {
     var suggestionList = WORDLIST.where((item) => item.startsWith(pattern)).toList();
-    if (pattern.length == 4 && suggestionList.isNotEmpty) {
-      _selectSuggestion(suggestionList.first, itemIndex);
+    if (suggestionList.isNotEmpty && suggestionList.length == 1) {
+      widget.textEditingControllers[itemIndex].text = suggestionList.first;
+      if (itemIndex + 1 < focusNodes.length) {
+        focusNodes[itemIndex + 1].requestFocus();
+      }
       return List.empty();
     }
     return suggestionList;


### PR DESCRIPTION
This PR addresses #505

Applies the behavior described in https://github.com/breez/c-breez/issues/505#issuecomment-1439971950:
> Autocompleting the word after typing four letters(as BIP39 words are uniquely identified by the first four letters) without the need to click on the word of autocomplete result.
> 
> For example: > qua
> 
> > quality
> > quantum
> > quarter
> 
> typing the fourth letter should fill the field with the matching value then focus on the next input field.