### PR TITLE
fix handling request reflects state

### DIFF
--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -62,8 +62,9 @@ class InputHandler extends Handler {
       return;
     }
 
+    inputState.isLoading ? _handlingRequest = true : _handlingRequest = false;
     _setLoading(inputState.isLoading);
-    _handlingRequest = true;
+
     handleInputData(inputState.inputData)
         .then((result) {
           handleResult(result);


### PR DESCRIPTION
fixes #550 

The `_handlingRequest` did not reflect the the state after first scan since the value were not updated accordingly.

## Tests
- [x]  LNURL/ Lighting address
- [x] LnInvoice
- [x] nodeID