### PR TITLE
Allow payments within inbound liquidity when LSP does not support channel openings

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,8 +1,12 @@
 PODS:
-  - breez_sdk (0.1.3):
-    - breez_sdkFFI (= 0.1.3)
+  - breez_sdk (0.1.4):
+    - breez_sdk/breez_sdkFFI (= 0.1.4)
+    - breez_sdkFFI
     - Flutter
-  - breez_sdkFFI (0.1.3)
+  - breez_sdk/breez_sdkFFI (0.1.4):
+    - breez_sdkFFI
+    - Flutter
+  - breez_sdkFFI (0.1.4)
   - clipboard_watcher (0.0.1):
     - Flutter
   - connectivity_plus (0.0.1):
@@ -283,8 +287,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/workmanager/ios"
 
 SPEC CHECKSUMS:
-  breez_sdk: 02ad39b316db6d5b90e27128af8afe5219146512
-  breez_sdkFFI: 945989831ec31233461349d1e000c6044ce94687
+  breez_sdk: ef1b25b92c62ff061239b98f86784e25608a7c1f
+  breez_sdkFFI: 8ad47f4cfec4c3f26ece06a5ea60e03fa4258669
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
   Firebase: 07150e75d142fb9399f6777fa56a187b17f833a0
@@ -299,7 +303,7 @@ SPEC CHECKSUMS:
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_fimber: ec011dfb08d7cbfa16ab6bad8450b99574e6f6a4
-  flutter_inappwebview: 4fe74e5e65809c3d363febfd9e2b21aa79bb0f1c
+  flutter_inappwebview: 50b55a88f5dddadc9e741a7caf72f378116e2156
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -234,6 +234,9 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
           (amount > accState.maxInboundLiquidity && amount <= channelMinimumFee)) {
         throw PaymentBelowSetupFeesError(channelMinimumFee);
       }
+      if (amount > accState.maxInboundLiquidity) {
+        throw PaymentExceedLiquidityError(accState.maxInboundLiquidity);
+      }
       if (amount > accState.maxAllowedToReceive) {
         throw PaymentExceededLimitError(accState.maxAllowedToReceive);
       }

--- a/lib/bloc/account/payment_error.dart
+++ b/lib/bloc/account/payment_error.dart
@@ -33,3 +33,11 @@ class PaymentBelowSetupFeesError implements Exception {
     this.setupFees,
   );
 }
+
+class PaymentExceedLiquidityError implements Exception {
+  final int limitSat;
+
+  const PaymentExceedLiquidityError(
+    this.limitSat,
+  );
+}

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -235,8 +235,9 @@ class CreateInvoicePageState extends State<CreateInvoicePage> {
 
   String? validatePayment(BuildContext context, int amount) {
     final lspInfo = context.read<LSPBloc>().state?.lspInfo;
-    int? channelMinimumFee =
-        lspInfo != null ? lspInfo.openingFeeParamsList.values.first.minMsat ~/ 1000 : null;
+    int? channelMinimumFee = lspInfo != null && lspInfo.openingFeeParamsList.values.isNotEmpty
+        ? lspInfo.openingFeeParamsList.values.first.minMsat ~/ 1000
+        : null;
 
     return PaymentValidator(
       validatePayment: _validatePayment,

--- a/lib/utils/payment_validator.dart
+++ b/lib/utils/payment_validator.dart
@@ -50,6 +50,9 @@ class PaymentValidator {
       return texts.invoice_payment_validator_error_payment_below_limit(
         currency.format(e.reserveAmount),
       );
+    } on PaymentExceedLiquidityError catch (e) {
+      // TODO: Add translation
+      return "Insufficient inbound liquidity (${currency.format(e.limitSat)})";
     } on InsufficientLocalBalanceError {
       return texts.invoice_payment_validator_error_insufficient_local_balance;
     } on PaymentBelowSetupFeesError catch (e) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -520,10 +520,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      sha256: "6d6c741ddba1dba5229d63ba75767064791a7ce845196b45e31105e93d67c949"
+      sha256: fad1f2740ff4b5b7da378a639f54beeb9d787b6339c89a9de00494d92372c0bb
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0-beta.22"
+    version: "6.0.0-beta.24+1"
   flutter_inappwebview_internal_annotations:
     dependency: transitive
     description:
@@ -1026,10 +1026,10 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: "2fbc3914fe625e196c64ea8ffc4084cd36781d2be276d4d5923b11af3b5d44ff"
+      sha256: da55204e5439bc8dc058df56231a7a1d513c6ec9cbad84492f56d493382d296f
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.1"
+    version: "3.2.0"
   mockito:
     dependency: "direct main"
     description:
@@ -1591,10 +1591,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "78cb6dea3e93148615109e58e42c35d1ffbf5ef66c44add673d0ab75f12ff3af"
+      sha256: "3dd2388cc0c42912eee04434531a26a82512b9cb1827e0214430c9bcbddfe025"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.37"
+    version: "6.0.38"
   url_launcher_ios:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,7 +47,7 @@ dependencies:
     git:
       url: https://github.com/breez/flutter_fgbg.git
       ref: 976b28ff3c299836f215b6deb2003838c49a8001
-  flutter_inappwebview: 6.0.0-beta.22 # xcodebuiler fails to figure out the right destination for the 6.0.0-beta.23+ | Related issue: https://github.com/pichillilorenzo/flutter_inappwebview/issues/1648#issue-1711313231
+  flutter_inappwebview: ^6.0.0-beta.24+1
   flutter_rust_bridge: 1.75.2
   flutter_secure_storage: ^8.0.0
   flutter_svg: <2.0.6 # Requires Flutter 3.10
@@ -71,7 +71,7 @@ dependencies:
   local_auth_ios: ^1.1.3
   mockito: <5.4.1 # flutter_test requirement
   # Doesn't support: Linux Windows
-  mobile_scanner: ^3.4.1
+  mobile_scanner: <3.3.0 # Kotlin requirement
   package_info_plus: ^4.1.0
   path: ^1.8.3
   path_provider: ^2.1.0


### PR DESCRIPTION
Payments within inbound liquidity when LSP does not support channel openings are now allowed with this PR and a "Insufficient inbound liquidity $maxInboundLiquidity" error message is displayed when an invoice with an amount larger than inbound liquidity is attempted to be created.

Other changelist:
- Downgrade mobile_scanner to resolve warnings during Android build,
- Upgrade flutter_inappwebview as the issue that prevented this upgrade has been resolved

Todo:
- Add error message to Breez-Translations