### PR TITLE
bump archive package

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "0c8368c9b3f0abbc193b9d6133649a614204b528982bebc7026372d61677ce3a"
+      sha256: e0902a06f0e00414e4e3438a084580161279f137aeb862274710f29ec10cf01e
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.7"
+    version: "3.3.9"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   another_flushbar: ^1.12.30
-  archive: ^3.3.7
+  archive: ^3.3.9
   auto_size_text: ^3.0.0
   bip39: ^1.0.6
   breez_sdk:
@@ -106,7 +106,7 @@ dev_dependencies:
   test: <1.24.0 # Requires Flutter 3.10
 
 dependency_overrides:
-  archive: ^3.3.7
+  archive: ^3.3.9
   intl: ^0.18.1
   path: ^1.8.3
   test_api: <0.5.0 # Requires Flutter 3.10


### PR DESCRIPTION
Bumped the archive package to a patched version https://github.com/breez/c-breez/security/dependabot/2.