### PR TITLE
remove pasting handling

### DIFF
--- a/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart
@@ -1,16 +1,12 @@
-import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
-import 'package:c_breez/bloc/input/input_bloc.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart';
 import 'package:c_breez/routes/withdraw_funds/withdraw_funds_address_page.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
-import 'package:c_breez/widgets/loader.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 final _log = FimberLog("SendOptionsBottomSheet");


### PR DESCRIPTION
This pr removes the pasting logic of the [send_options_bottom_sheet.dart](https://github.com/breez/c-breez/compare/609-multiple-pasting?expand=1#diff-2e65547a4868cf3300a6a65a4fba5576d1ffabfbde9d4295925e68fdd6f61c9f) to mimic the behaviour of breezmobile. 

I believe this can be removed since the inputhandler handles the data if the user has something in their clipboard and in my opinion the UX is also better now. The user might want to manually write in an lighting address while having an invoice in the clipboard.