### PR TITLE
Revert signing config for release keeping the development (debug)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -61,18 +61,7 @@ android {
     }
 
     signingConfigs {
-        release {
-            String filePath = keystoreProperties['storeFile']
-            if (filePath != null) {
-                keyAlias keystoreProperties['keyAlias']
-                keyPassword keystoreProperties['keyPassword']
-                storeFile file(filePath)
-                storePassword keystoreProperties['storePassword']
-            } else {
-                println("No storeFile provided, release builds are not possible")
-            }
-        }
-        debug {
+        development {
             String filePath = keystoreProperties['storeFileDebug']
             if (filePath != null) {
                 keyAlias keystoreProperties['aliasDebug']
@@ -87,13 +76,15 @@ android {
 
     buildTypes {
         debug {
-            signingConfig signingConfigs.debug
+            signingConfig signingConfigs.development
             applicationIdSuffix '.debug'
             versionNameSuffix '-DEBUG'
             resValue "string", "app_name", "Breez Cloud - Debug"
         }
         release {
-            signingConfig signingConfigs.release
+            // TODO: Add your own signing config for the release build.
+            // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig signingConfigs.debug
             resValue "string", "app_name", "Breez Cloud"
         }
     }


### PR DESCRIPTION
- Reverts the sign-in config for release made on my last PR https://github.com/breez/c-breez/pull/623
  - @roeierez will be signing release builds for the store manually
  - Release builds made by CI are using the default debug config
- Keep the debug (renamed to development) config
  - This keeps the ability of the team to make debug builds with working integrations

Manually triggered https://github.com/breez/c-breez/actions/runs/6407131491 to see if everything is working