### PR TITLE
Handle parsed BTC addresses 

### DIFF
--- a/lib/bloc/input/input_bloc.dart
+++ b/lib/bloc/input/input_bloc.dart
@@ -91,7 +91,8 @@ class InputBloc extends Cubit<InputState> {
         parsedInput is InputType_LnUrlWithdraw ||
         parsedInput is InputType_LnUrlAuth ||
         parsedInput is InputType_LnUrlError ||
-        parsedInput is InputType_NodeId) {
+        parsedInput is InputType_NodeId ||
+        parsedInput is InputType_BitcoinAddress) {
       return InputState(inputData: parsedInput);
     } else {
       return InputState(isLoading: false);
@@ -145,6 +146,15 @@ class InputBloc extends Cubit<InputState> {
       _log.i("nodeId: ${parsedInput.nodeId}");
     } else if (parsedInput is InputType_Url) {
       _log.i("url: ${parsedInput.url}");
+    } else if (parsedInput is InputType_BitcoinAddress) {
+      final btcAddressData = parsedInput.address;
+      _log.i(
+        "address: ${btcAddressData.address}\n"
+        "network: ${btcAddressData.network}\n"
+        "amountSat: ${btcAddressData.amountSat}\n"
+        "label: ${btcAddressData.label}\n"
+        "message: ${btcAddressData.message}",
+      );
     }
   }
 

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -10,6 +10,7 @@ import 'package:c_breez/models/invoice.dart';
 import 'package:c_breez/routes/lnurl/lnurl_invoice_delegate.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/routes/spontaneous_payment/spontaneous_payment_page.dart';
+import 'package:c_breez/routes/withdraw/reverse_swap/reverse_swap_page.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/loader.dart';
@@ -114,6 +115,8 @@ class InputHandler extends Handler {
       return handleLNURL(context, firstPaymentItemKey, parsedInput.btcAddressData);
     } else if (parsedInput is InputType_NodeId) {
       return handleNodeID(context, parsedInput.nodeId);
+    } else if (parsedInput is InputType_BitcoinAddress) {
+      return handleBTCAddress(context, parsedInput.address);
     }
   }
 
@@ -138,6 +141,17 @@ class InputHandler extends Handler {
         builder: (_) => SpontaneousPaymentPage(
           nodeID,
           firstPaymentItemKey,
+        ),
+      ),
+    );
+  }
+
+  Future handleBTCAddress(BuildContext context, BitcoinAddressData btcAddressData) async {
+    _log.v("handle btc address ${btcAddressData.address}");
+    return await Navigator.of(context).push(
+      FadeInRoute(
+        builder: (_) => ReverseSwapPage(
+          btcAddressData: btcAddressData,
         ),
       ),
     );

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -26,6 +26,7 @@ final _log = FimberLog("ReverseSwapPage");
 
 class ReverseSwapPage extends StatefulWidget {
   final BitcoinAddressData? btcAddressData;
+
   const ReverseSwapPage({super.key, required this.btcAddressData});
 
   @override
@@ -74,7 +75,6 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
     /// widget.btcAddressData!.label
     /// Message that describes the transaction to the user.
     /// widget.btcAddressData!.message
-    /// Set amount field as readOnly if widget.btcAddressData!.amountSat is available
   }
 
   @override


### PR DESCRIPTION
This PR addresses second part of 
- #148 

BTC addresses are now parsed and handled on InputBloc & InputHandler respectively.
Users will be redirected to Send to BTC Address page and address field will be automatically filled, as well as amount field if it's available.

### TODO:
- [ ] Ignore users own funding address
- [ ] Display label & message information if necessary. Explanation below:

@kingonly Parsed BTCAddressData can have label & message fields on Breez SDK. This is not the case on Breezmobile and this requires a product decision. Do we want to display these information on Send to BTC Address page?

Label is the label of the address - e.g. name of the receiver. Message is usually used to describe the transaction to the user, it's reasoning or a simple comment.