### PR TITLE
defer account state checking

### DIFF
--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -1,11 +1,8 @@
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/account/account_bloc.dart';
-import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart';
 import 'package:c_breez/routes/home/widgets/bottom_actions_bar/send_options_bottom_sheet.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'bottom_action_item.dart';
 
@@ -21,29 +18,26 @@ class BottomActionsBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final actionsGroup = AutoSizeGroup();
 
-    return BlocBuilder<AccountBloc, AccountState>(builder: (context, account) {
-      return BottomAppBar(
-        child: SizedBox(
-          height: 60,
-          child: Row(
-            mainAxisSize: MainAxisSize.max,
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              SendOptions(
-                firstPaymentItemKey: firstPaymentItemKey,
-                actionsGroup: actionsGroup,
-              ),
-              Container(width: 64),
-              ReceiveOptions(
-                account: account,
-                firstPaymentItemKey: firstPaymentItemKey,
-                actionsGroup: actionsGroup,
-              )
-            ],
-          ),
+    return BottomAppBar(
+      child: SizedBox(
+        height: 60,
+        child: Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: [
+            SendOptions(
+              firstPaymentItemKey: firstPaymentItemKey,
+              actionsGroup: actionsGroup,
+            ),
+            Container(width: 64),
+            ReceiveOptions(
+              firstPaymentItemKey: firstPaymentItemKey,
+              actionsGroup: actionsGroup,
+            )
+          ],
         ),
-      );
-    });
+      ),
+    );
   }
 }
 
@@ -80,13 +74,11 @@ class SendOptions extends StatelessWidget {
 }
 
 class ReceiveOptions extends StatelessWidget {
-  final AccountState account;
   final GlobalKey<State<StatefulWidget>> firstPaymentItemKey;
   final AutoSizeGroup actionsGroup;
 
   const ReceiveOptions({
     Key? key,
-    required this.account,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
   }) : super(key: key);
@@ -100,7 +92,6 @@ class ReceiveOptions extends StatelessWidget {
         builder: (context) {
           return SafeArea(
             child: ReceiveOptionsBottomSheet(
-              account: account,
               firstPaymentItemKey: firstPaymentItemKey,
             ),
           );

--- a/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/receive_options_bottom_sheet.dart
@@ -1,76 +1,66 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/account/account_state.dart';
-import 'package:c_breez/bloc/currency/currency_bloc.dart';
-import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'bottom_action_item_image.dart';
 
 class ReceiveOptionsBottomSheet extends StatelessWidget {
-  final AccountState account;
   final GlobalKey firstPaymentItemKey;
 
   const ReceiveOptionsBottomSheet({
     super.key,
     required this.firstPaymentItemKey,
-    required this.account,
   });
 
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
 
-    return BlocBuilder<CurrencyBloc, CurrencyState>(
-      builder: (context, currencyState) {
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const SizedBox(height: 8.0),
-            ListTile(
-              leading: const BottomActionItemImage(
-                iconAssetPath: "src/icon/paste.png",
-              ),
-              title: Text(
-                texts.bottom_action_bar_receive_invoice,
-                style: theme.bottomSheetTextStyle,
-              ),
-              onTap: () => _push(context, "/create_invoice"),
-            ),
-            Divider(
-              height: 0.0,
-              color: Colors.white.withOpacity(0.2),
-              indent: 72.0,
-            ),
-            ListTile(
-              leading: const BottomActionItemImage(
-                iconAssetPath: "src/icon/bitcoin.png",
-              ),
-              title: Text(
-                texts.bottom_action_bar_receive_btc_address,
-                style: theme.bottomSheetTextStyle,
-              ),
-              onTap: () => _push(context, '/swap'),
-            ),
-            Divider(
-              height: 0.0,
-              color: Colors.white.withOpacity(0.2),
-              indent: 72.0,
-            ),
-            ListTile(
-              leading: const BottomActionItemImage(
-                iconAssetPath: "src/icon/credit_card.png",
-              ),
-              title: Text(
-                texts.bottom_action_bar_buy_bitcoin,
-                style: theme.bottomSheetTextStyle,
-              ),
-              onTap: () => _push(context, "/buy_bitcoin"),
-            ),
-          ],
-        );
-      },
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        const SizedBox(height: 8.0),
+        ListTile(
+          leading: const BottomActionItemImage(
+            iconAssetPath: "src/icon/paste.png",
+          ),
+          title: Text(
+            texts.bottom_action_bar_receive_invoice,
+            style: theme.bottomSheetTextStyle,
+          ),
+          onTap: () => _push(context, "/create_invoice"),
+        ),
+        Divider(
+          height: 0.0,
+          color: Colors.white.withOpacity(0.2),
+          indent: 72.0,
+        ),
+        ListTile(
+          leading: const BottomActionItemImage(
+            iconAssetPath: "src/icon/bitcoin.png",
+          ),
+          title: Text(
+            texts.bottom_action_bar_receive_btc_address,
+            style: theme.bottomSheetTextStyle,
+          ),
+          onTap: () => _push(context, '/swap'),
+        ),
+        Divider(
+          height: 0.0,
+          color: Colors.white.withOpacity(0.2),
+          indent: 72.0,
+        ),
+        ListTile(
+          leading: const BottomActionItemImage(
+            iconAssetPath: "src/icon/credit_card.png",
+          ),
+          title: Text(
+            texts.bottom_action_bar_buy_bitcoin,
+            style: theme.bottomSheetTextStyle,
+          ),
+          onTap: () => _push(context, "/buy_bitcoin"),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
Fixes #642 

In order to make the UX for receiving and sending a bit smoother we can defer waiting for account state until the validation of the payment and not when initialing the payment. This should make it better for users if the internet speed is slow.