### PR TITLE
Fix moonpay buy flow (adding query for opening links on Android 11+)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -143,5 +143,10 @@
         <intent>
             <action android:name="android.support.customtabs.action.CustomTabsService" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" />
+        </intent>
     </queries>
 </manifest>


### PR DESCRIPTION
How to test:

- Test on:
  - Android prior to 11
  - Android 11 and/or higher
- Go to Receiver
- Buy Bitcoin
- A buy bitcoin flow should start using the Moonpay web app
- Buy some sats
- Wait a few minutes (block mining time) 
- The sats should be available at your LN wallet