### PR TITLE
Doesn't show the fiat amount when the sats balance is zero

### DIFF
--- a/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
@@ -52,14 +52,16 @@ class _FiatBalanceTextState extends State<FiatBalanceText> {
               );
         }
       },
-      child: Text(
-        widget.currencyState.fiatConversion()?.format(widget.accountState.balance) ?? "",
-        style: theme.balanceFiatConversionTextStyle.copyWith(
-          color: themeData.colorScheme.onSecondary.withOpacity(
-            pow(1.00 - widget.offsetFactor, 2).toDouble(),
-          ),
-        ),
-      ),
+      child: widget.accountState.balance > 0
+          ? Text(
+              widget.currencyState.fiatConversion()?.format(widget.accountState.balance) ?? "",
+              style: theme.balanceFiatConversionTextStyle.copyWith(
+                color: themeData.colorScheme.onSecondary.withOpacity(
+                  pow(1.00 - widget.offsetFactor, 2).toDouble(),
+                ),
+              ),
+            )
+          : Container(),
     );
   }
 


### PR DESCRIPTION
Hide the fiat amount showed at home page if the sats amount is zero

<details>
<summary>Screenshots</summary>

|Before|After|
|---|---|
|![Screenshot_20231011_101904-min](https://github.com/breez/c-breez/assets/1225438/a695425d-3957-413a-89b8-547dd7098335)|![Screenshot_20231011_102656-min](https://github.com/breez/c-breez/assets/1225438/36b1bd9f-e51d-4d33-bd04-1ffc7f1222f8)|

</details>

# How to test
- Create a new wallet or get wallet without any sats
  - It should not show the fiat value
- Using a wallet that has sats
  - It should show the fiat value