### PR TITLE
add funding and closing transaction to paymentMinutiae

### DIFF
--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -30,6 +30,8 @@ class PaymentMinutiae {
   final bool hasMetadata;
   final bool isKeySend;
   final PaymentStatus status;
+  final String? fundingTxid;
+  final String? closingTxid;
 
   const PaymentMinutiae({
     required this.id,
@@ -50,6 +52,8 @@ class PaymentMinutiae {
     required this.hasMetadata,
     required this.isKeySend,
     required this.status,
+    required this.fundingTxid,
+    required this.closingTxid,
   });
 
   factory PaymentMinutiae.fromPayment(Payment payment, BreezTranslations texts) {
@@ -73,6 +77,8 @@ class PaymentMinutiae {
       hasMetadata: factory._hasMetadata(),
       isKeySend: factory._isKeySend(),
       status: payment.status,
+      fundingTxid: factory._fundingTx(),
+      closingTxid: factory._closedTx(),
     );
   }
 }
@@ -285,5 +291,21 @@ class _PaymentMinutiaeFactory {
   bool _isKeySend() {
     final details = _payment.details.data;
     return (details is LnPaymentDetails) ? details.keysend : false;
+  }
+
+  String? _fundingTx() {
+    final details = _payment.details.data;
+    if (details is ClosedChannelPaymentDetails) {
+      return details.fundingTxid;
+    }
+    return null;
+  }
+
+  String? _closedTx() {
+    final details = _payment.details.data;
+    if (details is ClosedChannelPaymentDetails) {
+      return details.closingTxid;
+    }
+    return null;
   }
 }

--- a/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
@@ -1,7 +1,9 @@
-import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/config.dart';
 import 'package:c_breez/models/payment_minutiae.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/tx_widget.dart';
+import 'package:c_breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 
 class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
@@ -16,62 +18,61 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
     final texts = context.texts();
+    return FutureBuilder<Config>(
+      future: Config.instance(),
+      builder: (BuildContext context, AsyncSnapshot<Config> snapshot) {
+        if (snapshot.hasData) {
+          final blockExplorer = snapshot.data!.defaultMempoolUrl;
+          if (paymentMinutiae.status == sdk.PaymentStatus.Complete) {
+            return Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                RichText(
+                  text: TextSpan(
+                    style: themeData.dialogTheme.contentTextStyle,
+                    text: texts.payment_details_dialog_closed_channel_local_wallet,
+                  ),
+                ),
+                if (paymentMinutiae.paymentType == sdk.PaymentType.ClosedChannel &&
+                    paymentMinutiae.closingTxid != null) ...[
+                  TxWidget(
+                    txURL: "$blockExplorer/tx/${paymentMinutiae.closingTxid!}",
+                    txID: paymentMinutiae.closingTxid!,
+                  ),
+                ],
+              ],
+            );
+          }
 
-    if (paymentMinutiae.status == PaymentStatus.Complete) {
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          RichText(
-            text: TextSpan(
-              style: themeData.dialogTheme.contentTextStyle,
-              text: texts.payment_details_dialog_closed_channel_local_wallet,
-            ),
-          ),
-          // TODO waiting for closeChannelTxUrl and closeChannelTx
-          const TxWidget(
-            txURL: "",
-            txID: "",
-          ),
-        ],
-      );
-    }
+          String estimation = texts.payment_details_dialog_closed_channel_transfer_no_estimation;
 
-    int lockHeight = 0; // TODO pendingExpirationHeight
-    double hoursToUnlock = 0.0; // TODO hoursToExpire
-
-    int roundedHoursToUnlock = hoursToUnlock.round();
-    String hoursToUnlockStr = roundedHoursToUnlock > 1
-        ? texts.payment_details_dialog_closed_channel_about_hours(
-            roundedHoursToUnlock.toString(),
-          )
-        : texts.payment_details_dialog_closed_channel_about_hour;
-    String estimation = lockHeight > 0 && hoursToUnlock > 0
-        ? texts.payment_details_dialog_closed_channel_transfer_estimation(
-            lockHeight,
-            hoursToUnlockStr,
-          )
-        : texts.payment_details_dialog_closed_channel_transfer_no_estimation;
-
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        RichText(
-          text: TextSpan(
-            style: themeData.dialogTheme.contentTextStyle,
-            text: estimation,
-          ),
-        ),
-        // TODO waiting for closeChannelTxUrl and closeChannelTx
-        const TxWidget(
-          txURL: "",
-          txID: "",
-        ),
-        // TODO waiting for remoteCloseChannelTxUrl and remoteCloseChannelTx
-        const TxWidget(
-          txURL: "",
-          txID: "",
-        ),
-      ],
+          return Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              RichText(
+                text: TextSpan(
+                  style: themeData.dialogTheme.contentTextStyle,
+                  text: estimation,
+                ),
+              ),
+              if (paymentMinutiae.fundingTxid != null) ...[
+                TxWidget(
+                  txURL: "$blockExplorer/tx/${paymentMinutiae.fundingTxid!}",
+                  txID: paymentMinutiae.fundingTxid!,
+                ),
+              ],
+              if (paymentMinutiae.closingTxid != null) ...[
+                TxWidget(
+                  txURL: "$blockExplorer/tx/${paymentMinutiae.closingTxid!}",
+                  txID: paymentMinutiae.closingTxid!,
+                ),
+              ]
+            ],
+          );
+        } else {
+          return const Loader();
+        }
+      },
     );
   }
 }

--- a/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
@@ -43,7 +43,8 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
               ],
             );
           }
-
+          // TODO pendingExpirationHeight
+          // TODO hoursToExpire
           String estimation = texts.payment_details_dialog_closed_channel_transfer_no_estimation;
 
           return Column(


### PR DESCRIPTION
fixes #536 

## What is done

Add funding and closing txid to paymentMinutiae if available.

Remove the displaying of remote and local commitment transactions for pending closes until later.

Use blockexplorer specified in config.

