### PR TITLE
Add device info to the log

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:breez_sdk/breez_sdk.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:git_info/git_info.dart';
 import 'package:logging/logging.dart';
@@ -64,6 +65,12 @@ class BreezLogger {
 
     GitInfo.get().then((it) {
       _log.info("Logging initialized, app build on ${it.branch} at commit ${it.hash}");
+      DeviceInfoPlugin().deviceInfo.then((deviceInfo) {
+        _log.info("Device info:");
+        deviceInfo.data.forEach((key, value) => _log.info("$key: $value"));
+      }, onError: (error) {
+        _log.severe("Failed to get device info", error);
+      });
     }, onError: (error) {
       _log.severe("Failed to get git info", error);
     });

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -305,6 +305,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.8"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: "7035152271ff67b072a211152846e9f1259cf1be41e34cd3e0b5463d2d6b8419"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.1.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   drag_and_drop_lists:
     dependency: "direct main"
     description:
@@ -1723,6 +1739,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.4"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   workmanager:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   clipboard_watcher: ^0.2.0
   csv: ^5.0.2
   connectivity_plus: ^4.0.2
+  device_info_plus: ^9.1.0
   drag_and_drop_lists: ^0.3.3
   duration: ^3.0.13
   email_validator: ^2.1.17


### PR DESCRIPTION
How the log looks like:

```
[Logger] {INFO} (2023-10-19T12:34:51.610359Z) : Logging initialized, app build on main at commit ced812d6a909f491406cbeca7c4c93400c221a54
[Logger] {INFO} (2023-10-19T12:34:51.728177Z) : Device info:
[Logger] {INFO} (2023-10-19T12:34:51.729039Z) : product: lineage_jasmine_sprout
[Logger] {INFO} (2023-10-19T12:34:51.731083Z) : supportedAbis: [arm64-v8a, armeabi-v7a, armeabi]
[Logger] {INFO} (2023-10-19T12:34:51.731554Z) : serialNumber: unknown
[Logger] {INFO} (2023-10-19T12:34:51.902439Z) : displayMetrics: {xDpi: 403.4110107421875, widthPx: 1080.0, heightPx: 2160.0, yDpi: 403.4110107421875}
[Logger] {INFO} (2023-10-19T12:34:51.903153Z) : supported32BitAbis: [armeabi-v7a, armeabi]
[Logger] {INFO} (2023-10-19T12:34:51.903489Z) : display: lineage_jasmine_sprout-userdebug 11 RQ3A.211001.001 eng.ademar.20230919.091612 test-keys
[Logger] {INFO} (2023-10-19T12:34:51.903717Z) : type: userdebug
[Logger] {INFO} (2023-10-19T12:34:51.904232Z) : isPhysicalDevice: true
[Logger] {INFO} (2023-10-19T12:34:51.904594Z) : version: {baseOS: , securityPatch: 2023-09-05, sdkInt: 30, release: 11, codename: REL, previewSdkInt: 0, incremental: eng.ademar.20230919.091612}
[Logger] {INFO} (2023-10-19T12:34:51.905720Z) : systemFeatures: [android.hardware.sensor.proximity, android.hardware.sensor.accelerometer, android.software.controls, android.hardware.faketouch, android.hardware.usb.accessory, android.hardware.telephony.cdma, android.software.backup, android.hardware.touchscreen, android.hardware.touchscreen.multitouch, android.software.print, android.hardware.consumerir, android.software.activities_on_secondary_displays, android.software.voice_recognizers, android.software.picture_in_picture, android.hardware.fingerprint, org.lineageos.performance, android.hardware.sensor.gyroscope, android.hardware.audio.low_latency, android.software.cant_save_state, android.hardware.opengles.aep, org.lineageos.livedisplay, org.lineageos.profiles, android.hardware.bluetooth, android.hardware.camera.autofocus, com.google.android.feature.GOOGLE_BUILD, android.hardware.telephony.gsm, android.hardware.telephony.ims, android.software.sip.voip, android.hardware.usb.host, android.hardware.audio.output, android.software.verified_boot, android.hardware.camera.flash, android.hardware.camera.front, android.hardware.screen.portrait, android.hardware.sensor.stepdetector, android.software.home_screen, android.hardware.microphone, android.software.autofill, org.lineageos.hardware, org.lineageos.globalactions, android.software.securely_removes_users, android.hardware.bluetooth_le, android.hardware.sensor.compass, android.hardware.touchscreen.multitouch.jazzhand, android.hardware.sensor.barometer, android.software.app_widgets, android.software.input_methods, android.hardware.sensor.light, android.hardware.vulkan.version, android.software.companion_device_setup, android.software.device_admin, android.hardware.wifi.passpoint, android.hardware.camera, org.lineageos.audio, org.lineageos.trust, android.hardware.screen.landscape, android.hardware.ram.normal, org.lineageos.android, android.software.managed_users, android.software.webview, android.hardware.sensor.stepcounter, android.hardware.camera.capability.manual_post_processing, android.hardware.camera.any, android.hardware.camera.capability.raw, android.hardware.vulkan.compute, android.software.connectionservice, android.hardware.touchscreen.multitouch.distinct, android.hardware.location.network, android.software.cts, android.software.sip, android.hardware.camera.capability.manual_sensor, android.software.app_enumeration, com.google.android.apps.dialer.SUPPORTED, android.hardware.camera.level.full, android.hardware.wifi.direct, android.software.live_wallpaper, com.google.android.feature.GOOGLE_EXPERIENCE, android.software.ipsec_tunnels, com.google.android.feature.EXCHANGE_6_2, org.lineageos.settings, android.hardware.audio.pro, android.hardware.location.gps, android.sofware.nfc.beam, android.software.midi, android.hardware.wifi, android.hardware.location, android.hardware.vulkan.level, android.software.secure_lock_screen, android.hardware.telephony, android.software.file_based_encryption]
[Logger] {INFO} (2023-10-19T12:34:51.906806Z) : manufacturer: Xiaomi
[Logger] {INFO} (2023-10-19T12:34:51.907170Z) : tags: test-keys
[Logger] {INFO} (2023-10-19T12:34:51.907590Z) : supported64BitAbis: [arm64-v8a]
[Logger] {INFO} (2023-10-19T12:34:51.907873Z) : bootloader: unknown
[Logger] {INFO} (2023-10-19T12:34:51.908112Z) : fingerprint: xiaomi/jasmine/jasmine_sprout:8.1.0/OPM1.171019.011/V9.6.17.0.ODIMIFE:user/release-keys
[Logger] {INFO} (2023-10-19T12:34:51.908349Z) : host: lineageos.customer.splobra1.pop.starlinkisp.net
[Logger] {INFO} (2023-10-19T12:34:51.908627Z) : model: Mi A2
[Logger] {INFO} (2023-10-19T12:34:51.908986Z) : id: RQ3A.211001.001
[Logger] {INFO} (2023-10-19T12:34:51.909521Z) : brand: Xiaomi
[Logger] {INFO} (2023-10-19T12:34:51.909881Z) : device: jasmine_sprout
[Logger] {INFO} (2023-10-19T12:34:51.910114Z) : board: sdm660
[Logger] {INFO} (2023-10-19T12:34:51.910314Z) : hardware: qcom
```

This log will be helpful on bug reports; e.g.: https://github.com/breez/c-breez/issues/678

No QA Needed