### PR TITLE
Immediately listen inputs and move the wait for node state after event

### DIFF
--- a/test/bloc/input/input_bloc_test.dart
+++ b/test/bloc/input/input_bloc_test.dart
@@ -7,6 +7,7 @@ import 'package:c_breez/services/injector.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
+import '../../mock/breez_bridge_mock.dart';
 import '../../mock/injector_mock.dart';
 import '../../unit_logger.dart';
 import '../../utils/fake_path_provider_platform.dart';

--- a/test/bloc/input/input_bloc_test.dart
+++ b/test/bloc/input/input_bloc_test.dart
@@ -7,7 +7,6 @@ import 'package:c_breez/services/injector.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 
-import '../../mock/breez_bridge_mock.dart';
 import '../../mock/injector_mock.dart';
 import '../../unit_logger.dart';
 import '../../utils/fake_path_provider_platform.dart';

--- a/test/mock/breez_bridge_mock.dart
+++ b/test/mock/breez_bridge_mock.dart
@@ -117,7 +117,7 @@ class BreezSDKMock extends Mock implements BreezSDK {
   Stream<InvoicePaidDetails> get invoicePaidStream => invoicePaidController.stream;
 
   @override
-  final nodeStateController = StreamController<NodeState?>.broadcast();
+  final nodeStateController = BehaviorSubject<NodeState?>();
 
   @override
   Stream<NodeState?> get nodeStateStream => nodeStateController.stream;

--- a/test/unit_logger.dart
+++ b/test/unit_logger.dart
@@ -8,7 +8,7 @@ void setUpLogger() {
     Logger.root.onRecord.listen((record) {
       // Dart analyzer doesn't understand that here we are in debug mode so we have to use kDebugMode again
       if (kDebugMode) {
-        print("[${record.loggerName}] {${record.level.name}} (${record.time}) : ${record.message}");
+        debugPrint("[${record.loggerName}] {${record.level.name}} (${record.time}) : ${record.message}");
       }
     });
   }


### PR DESCRIPTION
Currently, we are waiting for a node state before starting to listen to the clipboard, it can happen that a device emits the clipboard earlier than others and we end in a state where we miss such an event.

I'm changing the logic of the InputBloc initialization to start watching inputs immediately and wait for a node state once it receives an event, so we don't lose any events.

As the node stream is controlled by a behavior subject, we get the state immediately once the first item is emitted so there is no difference in behavior to what we have today; on the other hand, I believe this change will solve the issue https://github.com/breez/c-breez/issues/678 

# How to test
- Copy a lnurl to your clipboard
- Goes to c-breez app
- It should be handled
- Test with the app open and closed