### PR TITLE
Upgrade Flutter requirement to latest stable(3.13.8)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
       # Setup the flutter environment.
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.12'
+          flutter-version: '3.13.8'
           channel: 'stable'
 
       - uses: actions/setup-java@v2

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -45,7 +45,7 @@ jobs:
       # Setup the flutter environment.
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.12'
+          flutter-version: '3.13.8'
           channel: 'stable'          
 
       - name: install dependencies

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -65,7 +65,7 @@ jobs:
       # Setup the flutter environment.
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.7.12'
+          flutter-version: '3.13.8'
           channel: 'stable'          
 
       - name: install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@
 /build/
 untranslated_messages.txt
 
+# fenv related
+.flutter-version
+
 # Web related
 lib/generated_plugin_registrant.dart
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -6,6 +6,8 @@ PODS:
   - connectivity_plus (0.0.1):
     - Flutter
     - ReachabilitySwift
+  - device_info_plus (0.0.1):
+    - Flutter
   - Firebase/CoreOnly (10.15.0):
     - FirebaseCore (= 10.15.0)
   - Firebase/DynamicLinks (10.15.0):
@@ -14,14 +16,14 @@ PODS:
   - Firebase/Messaging (10.15.0):
     - Firebase/CoreOnly
     - FirebaseMessaging (~> 10.15.0)
-  - firebase_core (2.17.0):
+  - firebase_core (2.19.0):
     - Firebase/CoreOnly (= 10.15.0)
     - Flutter
-  - firebase_dynamic_links (5.3.7):
+  - firebase_dynamic_links (5.4.1):
     - Firebase/DynamicLinks (= 10.15.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (14.6.9):
+  - firebase_messaging (14.7.1):
     - Firebase/Messaging (= 10.15.0)
     - firebase_core
     - Flutter
@@ -129,7 +131,7 @@ PODS:
     - GTMSessionFetcher/Core (< 3.0, >= 1.1)
     - MLImage (= 1.0.0-beta4)
     - MLKitCommon (~> 9.0)
-  - mobile_scanner (3.2.0):
+  - mobile_scanner (3.5.0):
     - Flutter
     - GoogleMLKit/BarcodeScanning (~> 4.0.0)
   - nanopb (2.30909.0):
@@ -177,6 +179,7 @@ DEPENDENCIES:
   - breez_sdk (from `.symlinks/plugins/breez_sdk/ios`)
   - clipboard_watcher (from `.symlinks/plugins/clipboard_watcher/ios`)
   - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_dynamic_links (from `.symlinks/plugins/firebase_dynamic_links/ios`)
   - firebase_messaging (from `.symlinks/plugins/firebase_messaging/ios`)
@@ -191,9 +194,9 @@ DEPENDENCIES:
   - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
+  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
-  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
   - sqlite3_flutter_libs (from `.symlinks/plugins/sqlite3_flutter_libs/ios`)
   - uni_links (from `.symlinks/plugins/uni_links/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -231,6 +234,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/clipboard_watcher/ios"
   connectivity_plus:
     :path: ".symlinks/plugins/connectivity_plus/ios"
+  device_info_plus:
+    :path: ".symlinks/plugins/device_info_plus/ios"
   firebase_core:
     :path: ".symlinks/plugins/firebase_core/ios"
   firebase_dynamic_links:
@@ -260,11 +265,11 @@ EXTERNAL SOURCES:
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/ios"
+    :path: ".symlinks/plugins/path_provider_foundation/darwin"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   shared_preferences_foundation:
-    :path: ".symlinks/plugins/shared_preferences_foundation/ios"
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
   sqlite3_flutter_libs:
     :path: ".symlinks/plugins/sqlite3_flutter_libs/ios"
   uni_links:
@@ -277,11 +282,12 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   breez_sdk: 233b05873a9e87762e4da7f12eb7a91cf2caff0b
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
-  connectivity_plus: 07c49e96d7fc92bc9920617b83238c4d178b446a
+  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
+  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
   Firebase: 66043bd4579e5b73811f96829c694c7af8d67435
-  firebase_core: 28e84c2a4fcf6a50ef83f47b145ded8c1fa331e4
-  firebase_dynamic_links: 52f5d054c676061cf17f4390f3bad9cc964cfdeb
-  firebase_messaging: 91ec967913a5d144f951b3c3ac17a57796d38735
+  firebase_core: fd674fcc642742ef7289acea60bd21a1a021bd98
+  firebase_dynamic_links: 5dfbb02d53262d43d1a0251cd567223505e31f4a
+  firebase_messaging: 4f6c9f2920785b409108c8b5f1f8cdaf89d8def2
   FirebaseCore: 2cec518b43635f96afe7ac3a9c513e47558abd2e
   FirebaseCoreInternal: 26233f705cc4531236818a07ac84d20c333e505a
   FirebaseDynamicLinks: 206d4ed3efd2b722822598017f3980d9fda89815
@@ -289,7 +295,7 @@ SPEC CHECKSUMS:
   FirebaseMessaging: 0c0ae1eb722ef0c07f7801e5ded8dccd1357d6d4
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
-  flutter_inappwebview: db0387fb3c2298997710505e7128eda00d15fc54
+  flutter_inappwebview: 166ed136c90e43c69b451f6d825da379be66c847
   flutter_keyboard_visibility: 0339d06371254c3eb25eeb90ba8d17dca8f9c069
   flutter_secure_storage: 23fc622d89d073675f2eaa109381aefbcf5a49be
   GoogleDataTransport: 54dee9d48d14580407f8f5fbf2f496e92437a2f2
@@ -300,20 +306,20 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 3a63d75eecd6aa32c2fc79f578064e1214dfdec2
   image_cropper: a3291c624a953049bc6a02e1f8c8ceb162a24b25
   image_picker_ios: 4a8aadfbb6dc30ad5141a2ce3832af9214a705b5
-  integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
+  integration_test: 13825b8a9334a850581300559b8839134b124670
   local_auth_ios: c6cf091ded637a88f24f86a8875d8b0f526e2605
   MLImage: 7bb7c4264164ade9bf64f679b40fb29c8f33ee9b
   MLKitBarcodeScanning: 04e264482c5f3810cb89ebc134ef6b61e67db505
   MLKitCommon: c1b791c3e667091918d91bda4bba69a91011e390
   MLKitVision: 8baa5f46ee3352614169b85250574fde38c36f49
-  mobile_scanner: 47056db0c04027ea5f41a716385542da28574662
+  mobile_scanner: 10f0f1e1607d78f1acd8a1f5eeba1f0e23236d44
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
-  package_info_plus: fd030dabf36271f146f1f3beacd48f564b0f17f7
+  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
   path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
   PromisesObjC: c50d2056b5253dadbd6c2bea79b0674bd5a52fa4
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
+  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
   shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
   sqlite3: e0a0623a33a20a47cb5921552aebc6e9e437dc91
   sqlite3_flutter_libs: 0d61e18fab1bed977dbd2d2fc76a726044ca00e7

--- a/lib/background/breez_message_handler.dart
+++ b/lib/background/breez_message_handler.dart
@@ -2,8 +2,8 @@ import 'dart:io';
 
 import 'package:c_breez/background/breez_service_initializer.dart';
 import 'package:c_breez/main.dart';
-import 'package:logging/logging.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:logging/logging.dart';
 import 'package:workmanager/workmanager.dart';
 
 final _log = Logger("BreezMessageHandler");

--- a/lib/bloc/account/credentials_manager.dart
+++ b/lib/bloc/account/credentials_manager.dart
@@ -1,11 +1,11 @@
 import 'dart:io';
 
 import 'package:breez_sdk/bridge_generated.dart' as sdk;
+import 'package:c_breez/config.dart';
 import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/services/keychain.dart';
 import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
-import 'package:c_breez/config.dart';
 
 class CredentialsManager {
   final _log = Logger("CredentialsManager");

--- a/lib/bloc/backup/backup_bloc.dart
+++ b/lib/bloc/backup/backup_bloc.dart
@@ -1,8 +1,8 @@
 import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:c_breez/bloc/backup/backup_state.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 class BackupBloc extends Cubit<BackupState?> {
   final _log = Logger("BackupBloc");

--- a/lib/bloc/buy_bitcoin/moonpay/moonpay_bloc.dart
+++ b/lib/bloc/buy_bitcoin/moonpay/moonpay_bloc.dart
@@ -5,8 +5,8 @@ import 'package:c_breez/bloc/buy_bitcoin/moonpay/moonpay_state.dart';
 import 'package:c_breez/config.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/utils/preferences.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("MoonPayBloc");
 

--- a/lib/bloc/connectivity/connectivity_bloc.dart
+++ b/lib/bloc/connectivity/connectivity_bloc.dart
@@ -2,9 +2,9 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 import 'connectivity_state.dart';
 

--- a/lib/bloc/csv_exporter.dart
+++ b/lib/bloc/csv_exporter.dart
@@ -7,8 +7,8 @@ import 'package:c_breez/bloc/account/payment_filters.dart';
 import 'package:c_breez/models/payment_minutiae.dart';
 import 'package:c_breez/utils/date.dart';
 import 'package:csv/csv.dart';
-import 'package:logging/logging.dart';
 import 'package:intl/intl.dart';
+import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 
 final _log = Logger("CsvExporter");

--- a/lib/bloc/ext/block_builder_extensions.dart
+++ b/lib/bloc/ext/block_builder_extensions.dart
@@ -9,9 +9,9 @@ class BlocBuilder2<Bloc1 extends BlocBase<State1>, State1, Bloc2 extends BlocBas
   final BlocWidgetBuilder2<State1, State2> builder;
 
   const BlocBuilder2({
-    Key? key,
+    super.key,
     required this.builder,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -31,9 +31,9 @@ class BlocBuilder3<Bloc1 extends BlocBase<State1>, State1, Bloc2 extends BlocBas
   final BlocWidgetBuilder3<State1, State2, State3> builder;
 
   const BlocBuilder3({
-    Key? key,
+    super.key,
     required this.builder,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/bloc/fee_options/fee_options_bloc.dart
+++ b/lib/bloc/fee_options/fee_options_bloc.dart
@@ -49,17 +49,6 @@ class FeeOptionsBloc extends Cubit<FeeOptionsState> {
     }
   }
 
-  Future<int> _retrieveUTXOS() async {
-    final nodeState = await _breezLib.nodeInfo();
-    if (nodeState == null) {
-      _log.severe("_retrieveUTXOS Failed to get node state");
-      throw Exception(getSystemAppLocalizations().node_state_error);
-    }
-    final utxos = nodeState.utxos.length;
-    _log.info("_retrieveUTXOS utxos: $utxos");
-    return utxos;
-  }
-
   Future<List<FeeOption>> _constructFeeOptionList(
     String address,
     RecommendedFees recommendedFees,

--- a/lib/bloc/fee_options/fee_options_bloc.dart
+++ b/lib/bloc/fee_options/fee_options_bloc.dart
@@ -6,8 +6,8 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/fee_options/fee_option.dart';
 import 'package:c_breez/bloc/fee_options/fee_options_state.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("FeeOptionsBloc");
 

--- a/lib/bloc/network/network_settings_bloc.dart
+++ b/lib/bloc/network/network_settings_bloc.dart
@@ -5,9 +5,9 @@ import 'package:c_breez/config.dart';
 import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/utils/blockchain_explorer_utils.dart';
 import 'package:c_breez/utils/preferences.dart';
-import 'package:logging/logging.dart';
 import 'package:http/http.dart' as http;
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 class NetworkSettingsBloc extends Cubit<NetworkSettingsState> with HydratedMixin {
   final Preferences _preferences;

--- a/lib/bloc/payment_options/payment_options_bloc.dart
+++ b/lib/bloc/payment_options/payment_options_bloc.dart
@@ -1,7 +1,7 @@
 import 'package:c_breez/bloc/payment_options/payment_options_state.dart';
 import 'package:c_breez/utils/preferences.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("PaymentOptionsBloc");
 

--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/bloc/refund/refund_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("RefundBloc");
 

--- a/lib/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart
+++ b/lib/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart
@@ -4,8 +4,8 @@ import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/rev_swap_in_progress/rev_swap_in_progress_state.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("RevSwapsInProgressBloc");
 

--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -5,8 +5,8 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/reverse_swap/reverse_swap_state.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("ReverseSwapBloc");
 

--- a/lib/bloc/security/security_bloc.dart
+++ b/lib/bloc/security/security_bloc.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:c_breez/bloc/security/security_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_fgbg/flutter_fgbg.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -10,6 +9,7 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth_android/local_auth_android.dart';
 import 'package:local_auth_ios/types/auth_messages_ios.dart';
+import 'package:logging/logging.dart';
 
 class SecurityBloc extends Cubit<SecurityState> with HydratedMixin {
   final _log = Logger("LocalAuthenticationService");

--- a/lib/bloc/swap_in_progress/swap_in_progress_bloc.dart
+++ b/lib/bloc/swap_in_progress/swap_in_progress_bloc.dart
@@ -5,8 +5,8 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/swap_in_progress/swap_in_progress_state.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SwapInProgressBloc");
 

--- a/lib/bloc/sweep/sweep_bloc.dart
+++ b/lib/bloc/sweep/sweep_bloc.dart
@@ -5,8 +5,8 @@ import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/sweep/sweep_state.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SweepBloc");
 

--- a/lib/bloc/user_profile/user_profile_bloc.dart
+++ b/lib/bloc/user_profile/user_profile_bloc.dart
@@ -7,8 +7,8 @@ import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:c_breez/models/user_profile.dart';
 import 'package:c_breez/services/breez_server.dart';
 import 'package:c_breez/services/notifications.dart';
-import 'package:logging/logging.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 
 const PROFILE_DATA_FOLDER_PATH = "profile";

--- a/lib/handlers/connectivity_handler.dart
+++ b/lib/handlers/connectivity_handler.dart
@@ -8,9 +8,9 @@ import 'package:c_breez/handlers/handler.dart';
 import 'package:c_breez/handlers/handler_context_provider.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("ConnectivityHandler");
 

--- a/lib/handlers/payment_result_handler.dart
+++ b/lib/handlers/payment_result_handler.dart
@@ -7,9 +7,9 @@ import 'package:c_breez/bloc/account/payment_result.dart';
 import 'package:c_breez/handlers/handler.dart';
 import 'package:c_breez/handlers/handler_context_provider.dart';
 import 'package:c_breez/widgets/flushbar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 final _log = Logger("PaymentResultHandler");

--- a/lib/models/payment_minutiae.dart
+++ b/lib/models/payment_minutiae.dart
@@ -4,8 +4,8 @@ import 'dart:typed_data';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/generated/breez_translations.dart';
 import 'package:c_breez/utils/extensions/breez_pos_message_extractor.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("PaymentDetails");
 

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_error.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_error.dart
@@ -8,9 +8,9 @@ class MoonpayError extends StatelessWidget {
   final String error;
 
   const MoonpayError({
-    Key? key,
+    super.key,
     required this.error,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_loading.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_loading.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 
 class MoonpayLoading extends StatelessWidget {
   const MoonpayLoading({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_page.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_page.dart
@@ -10,8 +10,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class MoonPayPage extends StatefulWidget {
   const MoonPayPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<MoonPayPage> createState() => _MoonPayPageState();

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_swap_in_progress.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_swap_in_progress.dart
@@ -10,9 +10,9 @@ class MoonpaySwapInProgress extends StatelessWidget {
   final MoonPayStateSwapInProgress state;
 
   const MoonpaySwapInProgress({
-    Key? key,
+    super.key,
     required this.state,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_webview.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_webview.dart
@@ -1,10 +1,10 @@
 import 'package:c_breez/bloc/buy_bitcoin/moonpay/moonpay_bloc.dart';
 import 'package:c_breez/bloc/buy_bitcoin/moonpay/moonpay_state.dart';
 import 'package:c_breez/routes/buy_bitcoin/moonpay/moonpay_loading.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("MoonpayWebView");
 

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_webview.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_webview.dart
@@ -12,9 +12,9 @@ class MoonpayWebView extends StatelessWidget {
   final String url;
 
   const MoonpayWebView({
-    Key? key,
+    super.key,
     required this.url,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -33,14 +33,13 @@ class CreateInvoicePage extends StatefulWidget {
   final LnUrlWithdrawRequestData? requestData;
 
   const CreateInvoicePage({
-    Key? key,
+    super.key,
     this.requestData,
     this.onFinish,
   })  : assert(
           requestData == null || (onFinish != null),
           "If you are using LNURL withdraw, you must provide an onFinish callback.",
-        ),
-        super(key: key);
+        );
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/create_invoice/create_invoice_page.dart
+++ b/lib/routes/create_invoice/create_invoice_page.dart
@@ -21,10 +21,10 @@ import 'package:c_breez/widgets/keyboard_done_action.dart';
 import 'package:c_breez/widgets/receivable_btc_box.dart';
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
 import 'package:c_breez/widgets/transparent_page_route.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("CreateInvoicePage");
 
@@ -36,7 +36,7 @@ class CreateInvoicePage extends StatefulWidget {
     super.key,
     this.requestData,
     this.onFinish,
-  })  : assert(
+  }) : assert(
           requestData == null || (onFinish != null),
           "If you are using LNURL withdraw, you must provide an onFinish callback.",
         );

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -10,9 +10,9 @@ import 'package:c_breez/routes/create_invoice/widgets/loading_or_error.dart';
 import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/flushbar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
 final _log = Logger("QrCodeDialog");

--- a/lib/routes/create_invoice/widgets/animated_background.dart
+++ b/lib/routes/create_invoice/widgets/animated_background.dart
@@ -4,8 +4,8 @@ import 'package:simple_animations/simple_animations.dart';
 
 class AnimatedBackground extends StatelessWidget {
   const AnimatedBackground({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/create_invoice/widgets/compact_qr_image.dart
+++ b/lib/routes/create_invoice/widgets/compact_qr_image.dart
@@ -48,7 +48,7 @@ class CompactQRImage extends StatelessWidget {
   final String data;
   final double? size;
 
-  const CompactQRImage({Key? key, required this.data, this.size}) : super(key: key);
+  const CompactQRImage({super.key, required this.data, this.size});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
+++ b/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
@@ -3,9 +3,9 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/theme/theme_extensions.dart';
 import 'package:c_breez/widgets/warning_box.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final log = Logger("ExpiryAndFeeMessage");
 

--- a/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
+++ b/lib/routes/create_invoice/widgets/expiry_and_fee_message.dart
@@ -13,9 +13,9 @@ class ExpiryAndFeeMessage extends StatelessWidget {
   final int? lspFees;
 
   const ExpiryAndFeeMessage({
-    Key? key,
+    super.key,
     required this.lspFees,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/create_invoice/widgets/successful_payment_message.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment_message.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 class SuccessfulPaymentMessage extends StatelessWidget {
   const SuccessfulPaymentMessage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/dev/command_line_interface.dart
+++ b/lib/routes/dev/command_line_interface.dart
@@ -4,8 +4,8 @@ import 'dart:io';
 import 'package:c_breez/routes/dev/widget/command_list.dart';
 import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 

--- a/lib/routes/dev/command_line_interface.dart
+++ b/lib/routes/dev/command_line_interface.dart
@@ -14,7 +14,7 @@ final _log = Logger("CommandsList");
 class CommandLineInterface extends StatefulWidget {
   final GlobalKey<ScaffoldState> scaffoldKey;
 
-  const CommandLineInterface({Key? key, required this.scaffoldKey}) : super(key: key);
+  const CommandLineInterface({super.key, required this.scaffoldKey});
 
   @override
   State<CommandLineInterface> createState() => _CommandLineInterfaceState();

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -34,8 +34,8 @@ class Choice {
 
 class DevelopersView extends StatelessWidget {
   const DevelopersView({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -13,7 +13,6 @@ import 'package:c_breez/widgets/route.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:path/path.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';

--- a/lib/routes/dev/widget/command.dart
+++ b/lib/routes/dev/widget/command.dart
@@ -7,8 +7,8 @@ class Command extends StatelessWidget {
   const Command(
     this.command,
     this.onTap, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/dev/widget/command_list.dart
+++ b/lib/routes/dev/widget/command_list.dart
@@ -17,8 +17,8 @@ class CommandList extends StatelessWidget {
     this.fallbackTextStyle = const TextStyle(),
     required this.inputController,
     required this.focusNode,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -15,8 +15,8 @@ const double ITEM_HEIGHT = 72.0;
 
 class FiatCurrencySettings extends StatefulWidget {
   const FiatCurrencySettings({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   FiatCurrencySettingsState createState() {

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -15,9 +15,9 @@ import 'package:c_breez/routes/home/widgets/payments_filter/payments_filter_sliv
 import 'package:c_breez/routes/home/widgets/payments_list/payments_list.dart';
 import 'package:c_breez/routes/home/widgets/status_text.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 const _kFilterMaxSize = 64.0;
 const _kPaymentListItemHeight = 72.0;

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -31,8 +31,8 @@ class AccountPage extends StatelessWidget {
   const AccountPage(
     this.firstPaymentItemKey,
     this.scrollController, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -19,8 +19,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class Home extends StatefulWidget {
   const Home({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -21,8 +21,8 @@ final _log = Logger("AccountRequiredActionsIndicator");
 
 class AccountRequiredActionsIndicator extends StatelessWidget {
   const AccountRequiredActionsIndicator({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/app_bar/home_app_bar.dart
+++ b/lib/routes/home/widgets/app_bar/home_app_bar.dart
@@ -7,11 +7,10 @@ import 'account_required_actions.dart';
 
 class HomeAppBar extends AppBar {
   HomeAppBar({
-    Key? key,
+    super.key,
     required ThemeData themeData,
     required GlobalKey<ScaffoldState> scaffoldKey,
   }) : super(
-          key: key,
           centerTitle: false,
           actions: [
             const Padding(

--- a/lib/routes/home/widgets/app_bar/warning_action.dart
+++ b/lib/routes/home/widgets/app_bar/warning_action.dart
@@ -8,9 +8,9 @@ class WarningAction extends StatefulWidget {
 
   const WarningAction(
     this.onTap, {
-    Key? key,
+    super.key,
     this.iconWidget,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item.dart
@@ -10,13 +10,13 @@ class BottomActionItem extends StatelessWidget {
   final Alignment minimizedAlignment;
 
   const BottomActionItem({
-    Key? key,
+    super.key,
     required this.text,
     required this.group,
     required this.iconAssetPath,
     required this.onPress,
     this.minimizedAlignment = Alignment.center,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_action_item_image.dart
@@ -5,10 +5,10 @@ class BottomActionItemImage extends StatelessWidget {
   final bool enabled;
 
   const BottomActionItemImage({
-    Key? key,
+    super.key,
     required this.iconAssetPath,
     this.enabled = true,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/bottom_actions_bar.dart
@@ -11,8 +11,8 @@ class BottomActionsBar extends StatelessWidget {
 
   const BottomActionsBar(
     this.firstPaymentItemKey, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -46,10 +46,10 @@ class SendOptions extends StatelessWidget {
   final AutoSizeGroup actionsGroup;
 
   const SendOptions({
-    Key? key,
+    super.key,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -78,10 +78,10 @@ class ReceiveOptions extends StatelessWidget {
   final AutoSizeGroup actionsGroup;
 
   const ReceiveOptions({
-    Key? key,
+    super.key,
     required this.firstPaymentItemKey,
     required this.actionsGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
+++ b/lib/routes/home/widgets/bottom_actions_bar/enter_payment_info_dialog.dart
@@ -5,9 +5,9 @@ import 'package:c_breez/bloc/input/input_source.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("EnterPaymentInfoDialog");
 

--- a/lib/routes/home/widgets/dashboard/balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/balance_text.dart
@@ -12,12 +12,12 @@ class BalanceText extends StatefulWidget {
   final double offsetFactor;
 
   const BalanceText({
-    Key? key,
+    super.key,
     required this.userProfileState,
     required this.currencyState,
     required this.accountState,
     required this.offsetFactor,
-  }) : super(key: key);
+  });
 
   @override
   State<BalanceText> createState() => _BalanceTextState();

--- a/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/fiat_balance_text.dart
@@ -14,11 +14,11 @@ class FiatBalanceText extends StatefulWidget {
   final double offsetFactor;
 
   const FiatBalanceText({
-    Key? key,
+    super.key,
     required this.currencyState,
     required this.accountState,
     required this.offsetFactor,
-  }) : super(key: key);
+  });
 
   @override
   State<FiatBalanceText> createState() => _FiatBalanceTextState();

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -19,10 +19,10 @@ class WalletDashboard extends StatefulWidget {
   final double offsetFactor;
 
   const WalletDashboard({
-    Key? key,
+    super.key,
     required this.height,
     required this.offsetFactor,
-  }) : super(key: key);
+  });
 
   @override
   State<WalletDashboard> createState() => _WalletDashboardState();

--- a/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
+++ b/lib/routes/home/widgets/drawer/breez_avatar_dialog.dart
@@ -153,6 +153,7 @@ class BreezAvatarDialogState extends State<BreezAvatarDialog> {
         isUploading = false;
         pickedImage = null;
       });
+      // ignore: use_build_context_synchronously
       showFlushbar(
         context,
         message: texts.breez_avatar_dialog_error_upload,
@@ -228,8 +229,8 @@ class BreezAvatarDialogState extends State<BreezAvatarDialog> {
 
 class TitleBackground extends StatelessWidget {
   const TitleBackground({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -252,7 +253,7 @@ class RandomButton extends StatelessWidget {
   final Function() onPressed;
   final AutoSizeGroup? autoSizeGroup;
 
-  const RandomButton({Key? key, required this.onPressed, this.autoSizeGroup}) : super(key: key);
+  const RandomButton({super.key, required this.onPressed, this.autoSizeGroup});
 
   @override
   Widget build(BuildContext context) {
@@ -287,11 +288,11 @@ class AvatarPreview extends StatelessWidget {
   final bool isUploading;
 
   const AvatarPreview({
-    Key? key,
+    super.key,
     required this.pickedImage,
     required this.randomAvatarPath,
     required this.isUploading,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -319,8 +320,8 @@ class AvatarPreview extends StatelessWidget {
 
 class AvatarSpinner extends StatelessWidget {
   const AvatarSpinner({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -344,7 +345,7 @@ class GalleryButton extends StatelessWidget {
   final Function() onPressed;
   final AutoSizeGroup? autoSizeGroup;
 
-  const GalleryButton({Key? key, required this.onPressed, this.autoSizeGroup}) : super(key: key);
+  const GalleryButton({super.key, required this.onPressed, this.autoSizeGroup});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/drawer/breez_drawer_header.dart
+++ b/lib/routes/home/widgets/drawer/breez_drawer_header.dart
@@ -4,14 +4,14 @@ const double _kBreezDrawerHeaderHeight = 160.0 + 1.0; // bottom edge
 
 class BreezDrawerHeader extends DrawerHeader {
   const BreezDrawerHeader({
-    Key? key,
+    super.key,
     super.decoration,
     super.margin = const EdgeInsets.only(bottom: 16.0),
     super.padding = const EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0),
     super.duration = const Duration(milliseconds: 250),
     super.curve = Curves.fastOutSlowIn,
     required super.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
+++ b/lib/routes/home/widgets/drawer/breez_navigation_drawer.dart
@@ -61,8 +61,8 @@ class BreezNavigationDrawer extends StatelessWidget {
   BreezNavigationDrawer(
     this._drawerGroupedItems,
     this._onItemSelected, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -380,13 +380,12 @@ class _ExpansionTile extends StatelessWidget {
   final bool isExpanded;
 
   const _ExpansionTile({
-    Key? key,
     required this.items,
     required this.title,
     required this.icon,
     required this.controller,
     this.isExpanded = true,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -21,8 +21,8 @@ const _kActiveAccountRoutes = [
 
 class HomeDrawer extends StatefulWidget {
   const HomeDrawer({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<HomeDrawer> createState() => HomeDrawerState();

--- a/lib/routes/home/widgets/fade_in_widget.dart
+++ b/lib/routes/home/widgets/fade_in_widget.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class FadeInWidget extends StatefulWidget {
   final Widget child;
 
-  const FadeInWidget({Key? key, required this.child}) : super(key: key);
+  const FadeInWidget({super.key, required this.child});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/no_lsp_widget.dart
+++ b/lib/routes/home/widgets/no_lsp_widget.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 class NoLSPWidget extends StatelessWidget {
   const NoLSPWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_filter/header_filter_chip.dart
+++ b/lib/routes/home/widgets/payments_filter/header_filter_chip.dart
@@ -11,9 +11,8 @@ class HeaderFilterChip extends SliverPadding {
     double maxHeight,
     DateTime startDate,
     DateTime endDate, {
-    Key? key,
+    super.key,
   }) : super(
-          key: key,
           padding: const EdgeInsets.fromLTRB(8, 0, 8, 0),
           sliver: SliverPersistentHeader(
             pinned: true,

--- a/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
+++ b/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
@@ -7,9 +7,9 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/theme/theme_provider.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:share_plus/share_plus.dart';
 
 class PaymentmentFilterExporter extends StatelessWidget {

--- a/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
+++ b/lib/routes/home/widgets/payments_filter/payment_filter_exporter.dart
@@ -18,8 +18,8 @@ class PaymentmentFilterExporter extends StatelessWidget {
 
   PaymentmentFilterExporter(
     this.filter, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -88,6 +88,7 @@ class PaymentmentFilterExporter extends StatelessWidget {
           navigator.removeRoute(loaderRoute);
         }
         _log.severe("Received error: $error");
+        // ignore: use_build_context_synchronously
         showFlushbar(
           context,
           message: texts.payments_filter_action_export_failed,

--- a/lib/routes/home/widgets/payments_filter/payments_filter.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter.dart
@@ -10,8 +10,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PaymentsFilter extends StatefulWidget {
   const PaymentsFilter({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
@@ -13,8 +13,8 @@ class PaymentsFilterCalendar extends StatelessWidget {
 
   const PaymentsFilterCalendar(
     this.filter, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_dropdown.dart
@@ -9,8 +9,8 @@ class PaymentsFilterDropdown extends StatelessWidget {
   const PaymentsFilterDropdown(
     this.filter,
     this.onFilterChanged, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_sliver.dart
@@ -9,11 +9,11 @@ class PaymentsFilterSliver extends StatefulWidget {
   final ScrollController scrollController;
 
   const PaymentsFilterSliver({
-    Key? key,
+    super.key,
     required this.maxSize,
     required this.hasFilter,
     required this.scrollController,
-  }) : super(key: key);
+  });
 
   @override
   State<PaymentsFilterSliver> createState() => _PaymentsFilterSliverState();

--- a/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
@@ -12,9 +12,9 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;
 
   const ClosedChannelPaymentDetailsWidget({
-    Key? key,
+    super.key,
     required this.paymentMinutiae,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/dialog/payment_details_closed_channel_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/payment_details_closed_channel_dialog.dart
@@ -8,9 +8,9 @@ class PaymentDetailsDialogClosedChannelDialog extends StatelessWidget {
   final PaymentMinutiae paymentMinutiae;
 
   const PaymentDetailsDialogClosedChannelDialog({
-    Key? key,
+    super.key,
     required this.paymentMinutiae,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -20,7 +20,7 @@ class ShareablePaymentRow extends StatelessWidget {
   final AutoSizeGroup? valueAutoSizeGroup;
 
   const ShareablePaymentRow({
-    Key? key,
+    super.key,
     required this.title,
     required this.sharedValue,
     this.isURL = false,
@@ -32,7 +32,7 @@ class ShareablePaymentRow extends StatelessWidget {
     this.childrenPadding,
     this.labelAutoSizeGroup,
     this.valueAutoSizeGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/tx_widget.dart
@@ -11,12 +11,12 @@ class TxWidget extends StatelessWidget {
   final EdgeInsets? padding;
 
   const TxWidget({
-    Key? key,
+    super.key,
     required this.txURL,
     required this.txID,
     this.txLabel,
     this.padding,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/flip_transition.dart
+++ b/lib/routes/home/widgets/payments_list/flip_transition.dart
@@ -12,10 +12,10 @@ class FlipTransition extends StatefulWidget {
   const FlipTransition(
     this.firstChild,
     this.secondChild, {
-    Key? key,
+    super.key,
     required this.radius,
     required this.onComplete,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
+++ b/lib/routes/home/widgets/payments_list/payment_details_dialog.dart
@@ -12,8 +12,8 @@ import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_preimage.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_success_action.dart';
 import 'package:c_breez/routes/home/widgets/payments_list/dialog/payment_details_dialog_title.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 final AutoSizeGroup _labelGroup = AutoSizeGroup();
 final AutoSizeGroup _valueGroup = AutoSizeGroup();

--- a/lib/routes/home/widgets/payments_list/payment_item.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item.dart
@@ -18,8 +18,8 @@ class PaymentItem extends StatefulWidget {
     this._paymentMinutiae,
     this._firstItem,
     this.firstPaymentItemKey, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<PaymentItem> createState() => _PaymentItemState();

--- a/lib/routes/home/widgets/payments_list/payment_item_amount.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_amount.dart
@@ -21,8 +21,8 @@ class PaymentItemAmount extends StatelessWidget {
 
   const PaymentItemAmount(
     this._paymentMinutiae, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_avatar.dart
@@ -10,8 +10,8 @@ class PaymentItemAvatar extends StatelessWidget {
   const PaymentItemAvatar(
     this.paymentMinutiae, {
     this.radius = 20.0,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/payment_item_subtitle.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_subtitle.dart
@@ -11,8 +11,8 @@ class PaymentItemSubtitle extends StatelessWidget {
 
   const PaymentItemSubtitle(
     this._paymentMinutiae, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/payment_item_title.dart
+++ b/lib/routes/home/widgets/payments_list/payment_item_title.dart
@@ -10,8 +10,8 @@ class PaymentItemTitle extends StatelessWidget {
 
   const PaymentItemTitle(
     this._paymentMinutiae, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/payments_list.dart
+++ b/lib/routes/home/widgets/payments_list/payments_list.dart
@@ -27,8 +27,8 @@ class PaymentsList extends StatelessWidget {
     this._payments,
     this._itemHeight,
     this.firstPaymentItemKey, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/payments_list/success_avatar.dart
+++ b/lib/routes/home/widgets/payments_list/success_avatar.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 class SuccessAvatar extends StatelessWidget {
   final double? radius;
 
-  const SuccessAvatar({Key? key, this.radius}) : super(key: key);
+  const SuccessAvatar({super.key, this.radius});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -5,10 +5,10 @@ import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/bloc/lsp/lsp_state.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/widgets/flushbar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("QrActionButton");
 

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -17,8 +17,8 @@ class QrActionButton extends StatelessWidget {
 
   const QrActionButton(
     this.firstPaymentItemKey, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/home/widgets/rotator.dart
+++ b/lib/routes/home/widgets/rotator.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class Rotator extends StatefulWidget {
   final Widget child;
 
-  const Rotator({Key? key, required this.child}) : super(key: key);
+  const Rotator({super.key, required this.child});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/home/widgets/status_text.dart
+++ b/lib/routes/home/widgets/status_text.dart
@@ -12,10 +12,10 @@ class StatusText extends StatelessWidget {
   final LspState? lspState;
 
   const StatusText({
-    Key? key,
+    super.key,
     required this.accountState,
     required this.lspState,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -171,6 +171,7 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
       if (isRestore) {
         _restoreNodeFromMnemonicSeed(initialWords: mnemonic.split(" "));
       }
+      // ignore: use_build_context_synchronously
       showFlushbar(context, message: extractExceptionMessage(error, texts));
       return;
     } finally {

--- a/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/mnemonics_confirmation_page.dart
@@ -55,8 +55,8 @@ class MnemonicsConfirmationPageState extends State<MnemonicsConfirmationPage> {
 
 class MnemonicsImage extends StatelessWidget {
   const MnemonicsImage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -99,10 +99,10 @@ class ConfirmationCheckbox extends StatelessWidget {
   final Function(bool value) onPressed;
 
   const ConfirmationCheckbox({
-    Key? key,
+    super.key,
     required this.onPressed,
     required this.isUnderstood,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -139,10 +139,10 @@ class ConfirmButton extends StatelessWidget {
   final String mnemonics;
 
   const ConfirmButton({
-    Key? key,
+    super.key,
     required this.isUnderstood,
     required this.mnemonics,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/initial_walkthrough/mnemonics/mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/mnemonics_page.dart
@@ -12,7 +12,7 @@ class MnemonicsPage extends StatefulWidget {
   final String mnemonics;
   final bool viewMode;
 
-  const MnemonicsPage({Key? key, required this.mnemonics, this.viewMode = false}) : super(key: key);
+  const MnemonicsPage({super.key, required this.mnemonics, this.viewMode = false});
 
   @override
   MnemonicsPageState createState() => MnemonicsPageState();

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_item.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_item.dart
@@ -10,11 +10,11 @@ class MnemonicItem extends StatelessWidget {
   final AutoSizeGroup? autoSizeGroup;
 
   const MnemonicItem({
-    Key? key,
+    super.key,
     required this.mnemonic,
     required this.index,
     this.autoSizeGroup,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_seed_list.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/mnemonic_seed_list.dart
@@ -7,9 +7,9 @@ class MnemonicSeedList extends StatelessWidget {
   final List<String> mnemonicsList;
 
   const MnemonicSeedList({
-    Key? key,
+    super.key,
     required this.mnemonicsList,
-  }) : super(key: key);
+  });
 
   get autoSizeGroup => AutoSizeGroup();
 

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -5,9 +5,9 @@ import 'package:c_breez/routes/lnurl/auth/login_text.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/widgets/error_dialog.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("HandleLNURLAuthRequest");
 

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -6,9 +6,9 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/models/currency.dart';
 import 'package:c_breez/routes/lnurl/payment/lnurl_payment_info.dart';
 import 'package:c_breez/utils/fiat_conversion.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("LNURLPaymentDialog");
 

--- a/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_dialog.dart
@@ -17,8 +17,8 @@ class LNURLPaymentDialog extends StatefulWidget {
 
   const LNURLPaymentDialog({
     required this.data,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/lnurl/payment/lnurl_payment_handler.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_handler.dart
@@ -7,9 +7,9 @@ import 'package:c_breez/routes/lnurl/payment/success_action/success_action_dialo
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/widgets/payment_dialogs/processing_payment_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("HandleLNURLPayRequest");
 

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -42,8 +42,8 @@ class LNURLPaymentPage extends StatefulWidget {
     this.identifier,
      */
 
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -12,12 +12,11 @@ import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
-import 'package:flutter/gestures.dart';
-// import 'package:email_validator/email_validator.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+// import 'package:email_validator/email_validator.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("LNURLPaymentPage");
 

--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -12,6 +12,7 @@ import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/lib/routes/lnurl/widgets/lnurl_metadata.dart
+++ b/lib/routes/lnurl/widgets/lnurl_metadata.dart
@@ -28,9 +28,9 @@ class LNURLMetadataImage extends StatelessWidget {
   final String? base64String;
 
   const LNURLMetadataImage({
-    Key? key,
+    super.key,
     this.base64String,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_dialog.dart
@@ -5,9 +5,9 @@ import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/loading_animated_text.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("LNURLWithdrawDialog");
 

--- a/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
+++ b/lib/routes/lnurl/withdraw/lnurl_withdraw_handler.dart
@@ -7,8 +7,8 @@ import 'package:c_breez/routes/create_invoice/widgets/successful_payment.dart';
 import 'package:c_breez/routes/lnurl/widgets/lnurl_page_result.dart';
 import 'package:c_breez/widgets/error_dialog.dart';
 import 'package:c_breez/widgets/transparent_page_route.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("HandleLNURLWithdrawPageResult");
 

--- a/lib/routes/lsp/select_lsp_page.dart
+++ b/lib/routes/lsp/select_lsp_page.dart
@@ -13,8 +13,8 @@ class SelectLSPPage extends StatelessWidget {
   final selectedLspController = StreamController<LspInformation?>();
 
   SelectLSPPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -67,11 +67,10 @@ class _LspActionButton extends StatelessWidget {
   final void Function() resetLsp;
 
   const _LspActionButton({
-    Key? key,
     this.selectedLsp,
     required this.error,
     required this.resetLsp,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/lsp/widgets/lsp_list.dart
+++ b/lib/routes/lsp/widgets/lsp_list.dart
@@ -10,8 +10,7 @@ class LspList extends StatefulWidget {
   final LspInformation? selectedLsp;
   final ValueChanged<LspInformation> onSelected;
 
-  const LspList({Key? key, required this.lspList, required this.selectedLsp, required this.onSelected})
-      : super(key: key);
+  const LspList({super.key, required this.lspList, required this.selectedLsp, required this.onSelected});
 
   @override
   State<LspList> createState() => _LspListState();

--- a/lib/routes/lsp/widgets/lsp_list_widget.dart
+++ b/lib/routes/lsp/widgets/lsp_list_widget.dart
@@ -3,9 +3,9 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/routes/lsp/widgets/lsp_list.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 class LspListWidget extends StatefulWidget {
   final LspInformation? selectedLsp;

--- a/lib/routes/lsp/widgets/lsp_list_widget.dart
+++ b/lib/routes/lsp/widgets/lsp_list_widget.dart
@@ -13,11 +13,11 @@ class LspListWidget extends StatefulWidget {
   final ValueChanged<Object> onError;
 
   const LspListWidget({
-    Key? key,
+    super.key,
     required this.selectedLsp,
     required this.onSelected,
     required this.onError,
-  }) : super(key: key);
+  });
 
   @override
   State<LspListWidget> createState() => _LspListWidgetState();
@@ -67,7 +67,7 @@ class _LspListWidgetState extends State<LspListWidget> {
 }
 
 class _LspErrorText extends StatelessWidget {
-  const _LspErrorText({Key? key}) : super(key: key);
+  const _LspErrorText();
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/network/network_page.dart
+++ b/lib/routes/network/network_page.dart
@@ -5,8 +5,8 @@ import 'package:flutter/material.dart';
 
 class NetworkPage extends StatelessWidget {
   const NetworkPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/network/widget/mempool_settings_widget.dart
+++ b/lib/routes/network/widget/mempool_settings_widget.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/network/network_settings_bloc.dart';
 import 'package:c_breez/bloc/network/network_settings_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("MempoolSettingsWidget");
 

--- a/lib/routes/network/widget/mempool_settings_widget.dart
+++ b/lib/routes/network/widget/mempool_settings_widget.dart
@@ -9,8 +9,8 @@ final _log = Logger("MempoolSettingsWidget");
 
 class MempoolSettingsWidget extends StatefulWidget {
   const MempoolSettingsWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<MempoolSettingsWidget> createState() => _MempoolSettingsWidgetState();

--- a/lib/routes/payment_options/payment_options_page.dart
+++ b/lib/routes/payment_options/payment_options_page.dart
@@ -11,8 +11,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class PaymentOptionsPage extends StatelessWidget {
   const PaymentOptionsPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/payment_options/widget/actions_fee.dart
+++ b/lib/routes/payment_options/widget/actions_fee.dart
@@ -2,9 +2,9 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_state.dart';
 import 'package:c_breez/routes/payment_options/widget/save_dialog.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("ActionsFee");
 

--- a/lib/routes/payment_options/widget/actions_fee.dart
+++ b/lib/routes/payment_options/widget/actions_fee.dart
@@ -10,8 +10,8 @@ final _log = Logger("ActionsFee");
 
 class ActionsFee extends StatelessWidget {
   const ActionsFee({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/payment_options/widget/exempt_fee_widget.dart
+++ b/lib/routes/payment_options/widget/exempt_fee_widget.dart
@@ -14,8 +14,8 @@ final _log = Logger("ExemptfeeMsatWidget");
 
 class ExemptfeeMsatWidget extends StatefulWidget {
   const ExemptfeeMsatWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<ExemptfeeMsatWidget> createState() => _ExemptfeeMsatState();

--- a/lib/routes/payment_options/widget/exempt_fee_widget.dart
+++ b/lib/routes/payment_options/widget/exempt_fee_widget.dart
@@ -4,10 +4,10 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/form_validator.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 final _log = Logger("ExemptfeeMsatWidget");

--- a/lib/routes/payment_options/widget/header_fee.dart
+++ b/lib/routes/payment_options/widget/header_fee.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 class HeaderFee extends StatelessWidget {
   const HeaderFee({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/payment_options/widget/override_fee.dart
+++ b/lib/routes/payment_options/widget/override_fee.dart
@@ -9,8 +9,8 @@ final _log = Logger("OverrideFee");
 
 class OverrideFee extends StatelessWidget {
   const OverrideFee({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/payment_options/widget/override_fee.dart
+++ b/lib/routes/payment_options/widget/override_fee.dart
@@ -1,9 +1,9 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("OverrideFee");
 

--- a/lib/routes/payment_options/widget/payment_option_warning.dart
+++ b/lib/routes/payment_options/widget/payment_option_warning.dart
@@ -4,8 +4,8 @@ import 'package:flutter/material.dart';
 
 class PaymentOptionWarning extends StatelessWidget {
   const PaymentOptionWarning({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/payment_options/widget/proportional_fee_widget.dart
+++ b/lib/routes/payment_options/widget/proportional_fee_widget.dart
@@ -15,8 +15,8 @@ final _log = Logger("ProportionalFeeWidget");
 
 class ProportionalFeeWidget extends StatefulWidget {
   const ProportionalFeeWidget({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<ProportionalFeeWidget> createState() => _ProportionalFeeWidgetState();

--- a/lib/routes/payment_options/widget/proportional_fee_widget.dart
+++ b/lib/routes/payment_options/widget/proportional_fee_widget.dart
@@ -4,11 +4,11 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/form_validator.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_state.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 final _log = Logger("ProportionalFeeWidget");

--- a/lib/routes/payment_options/widget/save_dialog.dart
+++ b/lib/routes/payment_options/widget/save_dialog.dart
@@ -1,8 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SaveDialog");
 

--- a/lib/routes/payment_options/widget/save_dialog.dart
+++ b/lib/routes/payment_options/widget/save_dialog.dart
@@ -8,8 +8,8 @@ final _log = Logger("SaveDialog");
 
 class SaveDialog extends StatelessWidget {
   const SaveDialog({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/qr_scan/scan_overlay.dart
+++ b/lib/routes/qr_scan/scan_overlay.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 class ScanOverlay extends StatelessWidget {
   const ScanOverlay({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/qr_scan/widgets/qr_scan.dart
+++ b/lib/routes/qr_scan/widgets/qr_scan.dart
@@ -1,10 +1,10 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/routes/qr_scan/scan_overlay.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
 import 'package:image_picker/image_picker.dart';
+import 'package:logging/logging.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 
 final _log = Logger("QRScan");

--- a/lib/routes/qr_scan/widgets/qr_scan.dart
+++ b/lib/routes/qr_scan/widgets/qr_scan.dart
@@ -100,8 +100,8 @@ class ImagePickerButton extends StatelessWidget {
 
   const ImagePickerButton(
     this.cameraController, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -149,8 +149,8 @@ class ImagePickerButton extends StatelessWidget {
 
 class QRScanCancelButton extends StatelessWidget {
   const QRScanCancelButton({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/change_pin_page.dart
+++ b/lib/routes/security/change_pin_page.dart
@@ -13,8 +13,8 @@ import 'package:path_provider/path_provider.dart';
 
 class ChangePinPage extends StatefulWidget {
   const ChangePinPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<ChangePinPage> createState() => _ChangePinPageState();

--- a/lib/routes/security/lock_screen.dart
+++ b/lib/routes/security/lock_screen.dart
@@ -17,9 +17,9 @@ class LockScreen extends StatelessWidget {
   final AuthorizedAction authorizedAction;
 
   const LockScreen({
-    Key? key,
+    super.key,
     required this.authorizedAction,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/secured_page.dart
+++ b/lib/routes/security/secured_page.dart
@@ -12,9 +12,9 @@ class SecuredPage<T> extends StatefulWidget {
   final Widget securedWidget;
 
   const SecuredPage({
-    Key? key,
+    super.key,
     required this.securedWidget,
-  }) : super(key: key);
+  });
 
   @override
   State<SecuredPage<T>> createState() => _SecuredPageState<T>();

--- a/lib/routes/security/secured_page.dart
+++ b/lib/routes/security/secured_page.dart
@@ -2,9 +2,9 @@ import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/security/security_bloc.dart';
 import 'package:c_breez/bloc/security/security_state.dart';
 import 'package:c_breez/routes/security/widget/pin_code_widget.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SecuredPage");
 

--- a/lib/routes/security/security_page.dart
+++ b/lib/routes/security/security_page.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 
 class SecurityPage extends StatelessWidget {
   const SecurityPage({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/digit_button_widget.dart
+++ b/lib/routes/security/widget/digit_button_widget.dart
@@ -8,13 +8,12 @@ class DigitButtonWidget extends StatelessWidget {
   final Function(String?)? onPressed;
 
   const DigitButtonWidget({
-    Key? key,
+    super.key,
     this.digit,
     this.icon,
     this.foregroundColor = Colors.white,
     this.onPressed,
-  })  : assert(digit != null || icon != null, "Either digit or icon must be provided"),
-        super(key: key);
+  })  : assert(digit != null || icon != null, "Either digit or icon must be provided");
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/digit_button_widget.dart
+++ b/lib/routes/security/widget/digit_button_widget.dart
@@ -13,7 +13,7 @@ class DigitButtonWidget extends StatelessWidget {
     this.icon,
     this.foregroundColor = Colors.white,
     this.onPressed,
-  })  : assert(digit != null || icon != null, "Either digit or icon must be provided");
+  }) : assert(digit != null || icon != null, "Either digit or icon must be provided");
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/digit_masked_widget.dart
+++ b/lib/routes/security/widget/digit_masked_widget.dart
@@ -10,12 +10,12 @@ class DigitMaskedWidget extends StatelessWidget {
   final Color unfilledColor;
 
   const DigitMaskedWidget({
-    Key? key,
+    super.key,
     this.size = 32,
     this.filled = false,
     this.filledColor = Colors.white,
     this.unfilledColor = Colors.transparent,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -64,8 +64,8 @@ class DigitMaskedWidget extends StatelessWidget {
 
 class DigitMaskedWidgetPreview extends StatefulWidget {
   const DigitMaskedWidgetPreview({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<DigitMaskedWidgetPreview> createState() => _DigitMaskedWidgetPreviewState();

--- a/lib/routes/security/widget/local_auth_switch.dart
+++ b/lib/routes/security/widget/local_auth_switch.dart
@@ -7,8 +7,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class LocalAuthSwitch extends StatelessWidget {
   const LocalAuthSwitch({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
+++ b/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
@@ -10,8 +10,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 
 class SecurityMnemonicsManagement extends StatelessWidget {
   const SecurityMnemonicsManagement({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/num_pad_widget.dart
+++ b/lib/routes/security/widget/num_pad_widget.dart
@@ -9,12 +9,12 @@ class NumPadWidget extends StatelessWidget {
   final Function(ActionKey) onActionKeyPressed;
 
   const NumPadWidget({
-    Key? key,
+    super.key,
     this.lhsActionKey = ActionKey.Clear,
     this.rhsActionKey = ActionKey.Backspace,
     required this.onDigitPressed,
     required this.onActionKeyPressed,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/pin_code_widget.dart
+++ b/lib/routes/security/widget/pin_code_widget.dart
@@ -17,13 +17,13 @@ class PinCodeWidget extends StatefulWidget {
   final Future<TestPinResult> Function()? testBiometricsFunction;
 
   const PinCodeWidget({
-    Key? key,
+    super.key,
     this.pinLength = 6,
     required this.label,
     required this.testPinCodeFunction,
     this.testBiometricsFunction,
     this.localAuthenticationOption = LocalAuthenticationOption.none,
-  }) : super(key: key);
+  });
 
   @override
   State<PinCodeWidget> createState() => _PinCodeWidgetState();

--- a/lib/routes/security/widget/security_pin_interval.dart
+++ b/lib/routes/security/widget/security_pin_interval.dart
@@ -11,9 +11,9 @@ class SecurityPinInterval extends StatelessWidget {
   final Duration interval;
 
   const SecurityPinInterval({
-    Key? key,
+    super.key,
     required this.interval,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/security/widget/security_pin_management.dart
+++ b/lib/routes/security/widget/security_pin_management.dart
@@ -17,8 +17,8 @@ import 'package:path_provider/path_provider.dart';
 
 class SecurityPinManagement extends StatelessWidget {
   const SecurityPinManagement({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/settings/set_admin_password.dart
+++ b/lib/routes/settings/set_admin_password.dart
@@ -10,9 +10,9 @@ class SetAdminPasswordPage extends StatefulWidget {
   final String submitAction;
 
   const SetAdminPasswordPage({
-    Key? key,
+    super.key,
     required this.submitAction,
-  }) : super(key: key);
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -30,8 +30,8 @@ class SpontaneousPaymentPage extends StatefulWidget {
   const SpontaneousPaymentPage(
     this.nodeID,
     this.firstPaymentItemKey, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
+++ b/lib/routes/spontaneous_payment/widgets/collapsible_list_item.dart
@@ -12,12 +12,12 @@ class CollapsibleListItem extends StatelessWidget {
   final TextStyle userStyle;
 
   const CollapsibleListItem({
-    Key? key,
+    super.key,
     required this.title,
     this.sharedValue,
     this.labelGroup,
     required this.userStyle,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
+++ b/lib/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart
@@ -120,8 +120,8 @@ class WaitBroadcastDialog extends StatelessWidget {
 
 class WaitingBroadcastContent extends StatelessWidget {
   const WaitingBroadcastContent({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -153,9 +153,9 @@ class BroadcastResultContent extends StatelessWidget {
   final String txId;
 
   const BroadcastResultContent({
-    Key? key,
+    super.key,
     required this.txId,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -191,9 +191,8 @@ class _TransactionDetails extends StatelessWidget {
   final String txId;
 
   const _TransactionDetails({
-    Key? key,
     required this.txId,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -222,9 +221,8 @@ class _ShareAndCopyTxID extends StatelessWidget {
   final String txId;
 
   const _ShareAndCopyTxID({
-    Key? key,
     required this.txId,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -274,9 +272,8 @@ class _TransactionID extends StatelessWidget {
   final String txId;
 
   const _TransactionID({
-    Key? key,
     required this.txId,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/get_refund/widgets/refund_item.dart
+++ b/lib/routes/subswap/swap/get_refund/widgets/refund_item.dart
@@ -10,8 +10,8 @@ class RefundItem extends StatelessWidget {
 
   const RefundItem(
     this.swapInfo, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -32,9 +32,7 @@ class _RefundItemAmount extends StatelessWidget {
   final int confirmedSats;
 
   const _RefundItemAmount(
-    this.confirmedSats, {
-    Key? key,
-  }) : super(key: key);
+    this.confirmedSats);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/get_refund/widgets/refund_item.dart
+++ b/lib/routes/subswap/swap/get_refund/widgets/refund_item.dart
@@ -31,8 +31,7 @@ class RefundItem extends StatelessWidget {
 class _RefundItemAmount extends StatelessWidget {
   final int confirmedSats;
 
-  const _RefundItemAmount(
-    this.confirmedSats);
+  const _RefundItemAmount(this.confirmedSats);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/get_refund/widgets/refund_item_action.dart
+++ b/lib/routes/subswap/swap/get_refund/widgets/refund_item_action.dart
@@ -14,8 +14,8 @@ class RefundItemAction extends StatelessWidget {
 
   const RefundItemAction(
     this.swapInfo, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/get_refund/widgets/refund_item_action.dart
+++ b/lib/routes/subswap/swap/get_refund/widgets/refund_item_action.dart
@@ -4,8 +4,8 @@ import 'package:c_breez/routes/subswap/swap/get_refund/send_onchain.dart';
 import 'package:c_breez/routes/subswap/swap/get_refund/wait_broadcast_dialog.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("RefundItemAction");
 

--- a/lib/routes/subswap/swap/get_refund/widgets/send_onchain_form.dart
+++ b/lib/routes/subswap/swap/get_refund/widgets/send_onchain_form.dart
@@ -7,10 +7,10 @@ import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/validator_holder.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/keyboard_done_action.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SendOnchainForm");
 

--- a/lib/routes/subswap/swap/widgets/address_qr_widget.dart
+++ b/lib/routes/subswap/swap/widgets/address_qr_widget.dart
@@ -11,10 +11,10 @@ class AddressQRWidget extends StatelessWidget {
   final String backupJson;
 
   const AddressQRWidget({
-    Key? key,
+    super.key,
     required this.address,
     required this.backupJson,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/widgets/address_widget.dart
+++ b/lib/routes/subswap/swap/widgets/address_widget.dart
@@ -28,9 +28,9 @@ class AddressHeaderWidget extends StatelessWidget {
   final String address;
 
   const AddressHeaderWidget({
-    Key? key,
+    super.key,
     required this.address,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -60,9 +60,8 @@ class _ShareIcon extends StatelessWidget {
   final String address;
 
   const _ShareIcon({
-    Key? key,
     required this.address,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -88,9 +87,8 @@ class _CopyIcon extends StatelessWidget {
   final String address;
 
   const _CopyIcon({
-    Key? key,
     required this.address,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/widgets/address_widget_placeholder.dart
+++ b/lib/routes/subswap/swap/widgets/address_widget_placeholder.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 class AddressWidgetPlaceholder extends StatelessWidget {
   const AddressWidgetPlaceholder({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/subswap/swap/widgets/deposit_widget.dart
+++ b/lib/routes/subswap/swap/widgets/deposit_widget.dart
@@ -14,7 +14,7 @@ import 'address_widget.dart';
 class DepositWidget extends StatefulWidget {
   final SwapInfo swap;
 
-  const DepositWidget(this.swap, {Key? key}) : super(key: key);
+  const DepositWidget(this.swap, {super.key});
 
   @override
   State<DepositWidget> createState() => _DepositWidgetState();

--- a/lib/routes/subswap/swap/widgets/subswap_dialog.dart
+++ b/lib/routes/subswap/swap/widgets/subswap_dialog.dart
@@ -7,9 +7,9 @@ class SwapDialog extends StatelessWidget {
   final String backupJson;
 
   const SwapDialog({
-    Key? key,
+    super.key,
     required this.backupJson,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/ui_test/ui_test_page.dart
+++ b/lib/routes/ui_test/ui_test_page.dart
@@ -21,7 +21,7 @@ import 'package:hex/hex.dart';
 import 'package:theme_provider/theme_provider.dart';
 
 class UITestPage extends StatelessWidget {
-  const UITestPage({Key? key}) : super(key: key);
+  const UITestPage({super.key});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
+++ b/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
@@ -14,12 +14,12 @@ class ReverseSwapConfirmationPage extends StatefulWidget {
   final int? boltzFees;
 
   const ReverseSwapConfirmationPage({
-    Key? key,
+    super.key,
     required this.amountSat,
     required this.onchainRecipientAddress,
     required this.feesHash,
     this.boltzFees,
-  }) : super(key: key);
+  });
 
   @override
   State<ReverseSwapConfirmationPage> createState() => _ReverseSwapConfirmationPageState();
@@ -101,9 +101,8 @@ class _ErrorMessage extends StatelessWidget {
   final String message;
 
   const _ErrorMessage({
-    Key? key,
     required this.message,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
+++ b/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/fee_options/fee_options_bloc.dart';
 import 'package:c_breez/bloc/fee_options/fee_option.dart';
+import 'package:c_breez/bloc/fee_options/fee_options_bloc.dart';
 import 'package:c_breez/routes/withdraw/reverse_swap/confirmation_page/widgets/reverse_swap_button.dart';
 import 'package:c_breez/routes/withdraw/widgets/fee_chooser/fee_chooser.dart';
 import 'package:c_breez/widgets/loader.dart';

--- a/lib/routes/withdraw/reverse_swap/confirmation_page/widgets/reverse_swap_button.dart
+++ b/lib/routes/withdraw/reverse_swap/confirmation_page/widgets/reverse_swap_button.dart
@@ -14,12 +14,12 @@ class ReverseSwapButton extends StatelessWidget {
   final int satPerVbyte;
 
   const ReverseSwapButton({
-    Key? key,
+    super.key,
     required this.amountSat,
     required this.onchainRecipientAddress,
     required this.feesHash,
     required this.satPerVbyte,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -48,8 +48,10 @@ class ReverseSwapButton extends StatelessWidget {
 
       navigator.pushNamedAndRemoveUntil("/", (Route<dynamic> route) => false);
     } catch (e) {
+      // ignore: use_build_context_synchronously
       final themeData = Theme.of(context);
       navigator.pop(loaderRoute);
+      // ignore: use_build_context_synchronously
       promptError(
         context,
         null,

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -18,9 +18,9 @@ import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/loader.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("ReverseSwapPage");
 

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -68,13 +68,6 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
     if (addressData.amountSat != null) {
       _setAmount(addressData.amountSat!);
     }
-
-    /// TODO: When handling BTC addresses through InputHandler, display label & message of BitcoinAddressData
-    /// The label of the address - e.g. name of the receiver.
-    /// widget.btcAddressData!.label
-    /// Message that describes the transaction to the user.
-    /// widget.btcAddressData!.message
-    /// Set amount field as readOnly if widget.btcAddressData!.amountSat is available
   }
 
   @override

--- a/lib/routes/withdraw/sweep/confirmation_page/sweep_confirmation_page.dart
+++ b/lib/routes/withdraw/sweep/confirmation_page/sweep_confirmation_page.dart
@@ -12,10 +12,10 @@ class SweepConfirmationPage extends StatefulWidget {
   final int amountSat;
 
   const SweepConfirmationPage({
-    Key? key,
+    super.key,
     required this.toAddress,
     required this.amountSat,
-  }) : super(key: key);
+  });
 
   @override
   State<SweepConfirmationPage> createState() => _SweepConfirmationPageState();
@@ -94,9 +94,8 @@ class _ErrorMessage extends StatelessWidget {
   final String message;
 
   const _ErrorMessage({
-    Key? key,
     required this.message,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/withdraw/sweep/confirmation_page/sweep_confirmation_page.dart
+++ b/lib/routes/withdraw/sweep/confirmation_page/sweep_confirmation_page.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/fee_options/fee_options_bloc.dart';
 import 'package:c_breez/bloc/fee_options/fee_option.dart';
+import 'package:c_breez/bloc/fee_options/fee_options_bloc.dart';
 import 'package:c_breez/routes/withdraw/sweep/confirmation_page/widgets/sweep_button.dart';
 import 'package:c_breez/routes/withdraw/widgets/fee_chooser/fee_chooser.dart';
 import 'package:c_breez/widgets/loader.dart';

--- a/lib/routes/withdraw/sweep/confirmation_page/widgets/sweep_button.dart
+++ b/lib/routes/withdraw/sweep/confirmation_page/widgets/sweep_button.dart
@@ -12,10 +12,10 @@ class SweepButton extends StatelessWidget {
   final int feeRateSatsPerVbyte;
 
   const SweepButton({
-    Key? key,
+    super.key,
     required this.toAddress,
     required this.feeRateSatsPerVbyte,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -41,8 +41,10 @@ class SweepButton extends StatelessWidget {
       );
       navigator.popUntil((route) => route.settings.name == "/");
     } catch (e) {
+      // ignore: use_build_context_synchronously
       final themeData = Theme.of(context);
       navigator.pop(loaderRoute);
+      // ignore: use_build_context_synchronously
       promptError(
         context,
         null,

--- a/lib/routes/withdraw/sweep/sweep_page.dart
+++ b/lib/routes/withdraw/sweep/sweep_page.dart
@@ -23,8 +23,8 @@ class SweepPage extends StatefulWidget {
 
   const SweepPage({
     required this.walletBalance,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<SweepPage> createState() => _SweepPageState();

--- a/lib/routes/withdraw/sweep/sweep_page.dart
+++ b/lib/routes/withdraw/sweep/sweep_page.dart
@@ -12,9 +12,9 @@ import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/route.dart';
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
 import 'package:c_breez/widgets/warning_box.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("SweepPage");
 

--- a/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
@@ -12,13 +12,11 @@ final _log = Logger("BitcoinAddressTextFormField");
 
 class BitcoinAddressTextFormField extends TextFormField {
   BitcoinAddressTextFormField({
-    Key? key,
+    super.key,
     required BuildContext context,
-    required TextEditingController controller,
+    required TextEditingController super.controller,
     required ValidatorHolder validatorHolder,
   }) : super(
-          key: key,
-          controller: controller,
           decoration: InputDecoration(
             labelText: context.texts().withdraw_funds_btc_address,
             suffixIcon: IconButton(

--- a/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
@@ -4,9 +4,9 @@ import 'package:c_breez/models/bitcoin_address_info.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:c_breez/utils/validator_holder.dart';
 import 'package:c_breez/widgets/flushbar.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("BitcoinAddressTextFormField");
 

--- a/lib/routes/withdraw/widgets/fee_chooser/fee_chooser.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/fee_chooser.dart
@@ -16,9 +16,9 @@ class FeeChooser extends StatefulWidget {
     required this.feeOptions,
     required this.selectedFeeIndex,
     required this.onSelect,
-    Key? key,
+    super.key,
     this.boltzFees,
-  }) : super(key: key);
+  });
 
   @override
   State<FeeChooser> createState() => _FeeChooserState();

--- a/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_breakdown.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_breakdown.dart
@@ -15,9 +15,9 @@ class FeeBreakdown extends StatelessWidget {
   const FeeBreakdown(
     this.total,
     this.fee, {
-    Key? key,
+    super.key,
     this.boltzFees,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_chooser_header.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_chooser_header.dart
@@ -14,8 +14,8 @@ class FeeChooserHeader extends StatefulWidget {
     required this.feeOptions,
     required this.selectedFeeIndex,
     required this.onSelect,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<FeeChooserHeader> createState() => _FeeChooserHeaderState();

--- a/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_option_button.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_option_button.dart
@@ -8,13 +8,13 @@ class FeeOptionButton extends StatelessWidget {
   final Function onSelect;
 
   const FeeOptionButton({
-    Key? key,
+    super.key,
     required this.index,
     required this.text,
     required this.isAffordable,
     required this.isSelected,
     required this.onSelect,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
@@ -1,7 +1,6 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/account/payment_error.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/models/currency.dart';
 import 'package:c_breez/routes/withdraw/model/withdraw_funds_model.dart';
 import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
@@ -14,18 +13,15 @@ final _log = Logger("WithdrawFundsAmountTextFormField");
 class WithdrawFundsAmountTextFormField extends AmountFormField {
   WithdrawFundsAmountTextFormField({
     super.key,
-    required BitcoinCurrency bitcoinCurrency,
-    required BuildContext context,
-    required TextEditingController controller,
+    required super.bitcoinCurrency,
+    required super.context,
+    required TextEditingController super.controller,
     required bool withdrawMaxValue,
     required WithdrawFundsPolicy policy,
     required int balance,
   }) : super(
-          controller: controller,
           texts: context.texts(),
-          context: context,
           readOnly: policy.withdrawKind == WithdrawKind.unexpected_funds || withdrawMaxValue,
-          bitcoinCurrency: bitcoinCurrency,
           validatorFn: (amount) {
             _log.info("Validator called for $amount");
             return PaymentValidator(

--- a/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
@@ -4,9 +4,9 @@ import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/routes/withdraw/model/withdraw_funds_model.dart';
 import 'package:c_breez/utils/payment_validator.dart';
 import 'package:c_breez/widgets/amount_form_field/amount_form_field.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("WithdrawFundsAmountTextFormField");
 

--- a/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
@@ -4,9 +4,9 @@ import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/theme/theme_provider.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 
 final _log = Logger("WithdrawFundsAvailableBtc");
 

--- a/lib/services/deep_links.dart
+++ b/lib/services/deep_links.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
-import 'package:logging/logging.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 class DeepLinksService {

--- a/lib/services/device.dart
+++ b/lib/services/device.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 import 'package:clipboard_watcher/clipboard_watcher.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:share_plus/share_plus.dart';

--- a/lib/services/notifications.dart
+++ b/lib/services/notifications.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:logging/logging.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
 abstract class Notifications {

--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -35,10 +35,10 @@ import 'package:c_breez/theme/breez_dark_theme.dart';
 import 'package:c_breez/theme/breez_light_theme.dart';
 import 'package:c_breez/widgets/route.dart';
 import 'package:c_breez/widgets/transparent_page_route.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
 import 'package:theme_provider/theme_provider.dart';
 
 const String THEME_ID_PREFERENCE_KEY = "themeID";

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -1,6 +1,6 @@
 import 'package:breez_translations/generated/breez_translations.dart';
-import 'package:logging/logging.dart';
 import "package:flutter_rust_bridge/flutter_rust_bridge.dart";
+import 'package:logging/logging.dart';
 
 final _log = Logger("Exceptions");
 

--- a/lib/utils/external_browser.dart
+++ b/lib/utils/external_browser.dart
@@ -1,8 +1,8 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:logging/logging.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:logging/logging.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 final _log = Logger("ExternalBrowser");

--- a/lib/widgets/amount_form_field/amount_form_field.dart
+++ b/lib/widgets/amount_form_field/amount_form_field.dart
@@ -24,22 +24,21 @@ class AmountFormField extends TextFormField {
     required BuildContext context,
     Color? iconColor,
     Function(String amount)? returnFN,
-    TextEditingController? controller,
+    super.controller,
     Key? key,
     String? initialValue,
-    FocusNode? focusNode,
+    super.focusNode,
     InputDecoration decoration = const InputDecoration(),
-    TextStyle? style,
+    super.style,
     TextAlign textAlign = TextAlign.start,
     int maxLines = 1,
     int? maxLength,
-    ValueChanged<String>? onFieldSubmitted,
-    FormFieldSetter<String>? onSaved,
-    bool? enabled,
-    ValueChanged<String>? onChanged,
+    super.onFieldSubmitted,
+    super.onSaved,
+    super.enabled,
+    super.onChanged,
     bool? readOnly,
   }) : super(
-          focusNode: focusNode,
           keyboardType: TextInputType.numberWithOptions(
             decimal: bitcoinCurrency != BitcoinCurrency.SAT,
           ),
@@ -74,9 +73,6 @@ class AmountFormField extends TextFormField {
                     ),
                   ),
           ),
-          style: style,
-          enabled: enabled,
-          controller: controller,
           inputFormatters: bitcoinCurrency != BitcoinCurrency.SAT
               ? [
                   FilteringTextInputFormatter.allow(bitcoinCurrency.whitelistedPattern),
@@ -87,9 +83,6 @@ class AmountFormField extends TextFormField {
                   ),
                 ]
               : [SatAmountFormFieldFormatter()],
-          onFieldSubmitted: onFieldSubmitted,
-          onSaved: onSaved,
-          onChanged: onChanged,
           readOnly: readOnly ?? false,
         );
 

--- a/lib/widgets/amount_form_field/breez_dropdown.dart
+++ b/lib/widgets/amount_form_field/breez_dropdown.dart
@@ -546,7 +546,7 @@ class BreezDropdownButton<T> extends StatefulWidget {
     this.iconSize = 24.0,
     this.isDense = false,
     this.isExpanded = false,
-  })  : assert(items.isEmpty ||
+  }) : assert(items.isEmpty ||
             value == null ||
             items.where((DropdownMenuItem<T> item) => item.value == value).length == 1);
 

--- a/lib/widgets/amount_form_field/breez_dropdown.dart
+++ b/lib/widgets/amount_form_field/breez_dropdown.dart
@@ -90,10 +90,10 @@ class _DropdownScrollBehavior extends ScrollBehavior {
 
 class _DropdownMenu<T> extends StatefulWidget {
   const _DropdownMenu({
-    Key? key,
+    super.key,
     required this.padding,
     required this.route,
-  }) : super(key: key);
+  });
 
   final _DropdownRoute<T> route;
   final EdgeInsets padding;
@@ -342,7 +342,7 @@ class _DropdownRoute<T> extends PopupRoute<_DropdownRouteResult<T>> {
 
 class _DropdownRoutePage<T> extends StatelessWidget {
   const _DropdownRoutePage({
-    Key? key,
+    super.key,
     required this.route,
     required this.constraints,
     required this.items,
@@ -352,7 +352,7 @@ class _DropdownRoutePage<T> extends StatelessWidget {
     this.elevation = 8,
     required this.theme,
     required this.style,
-  }) : super(key: key);
+  });
 
   final _DropdownRoute<T> route;
   final BoxConstraints constraints;
@@ -530,7 +530,7 @@ class BreezDropdownButton<T> extends StatefulWidget {
   /// defaults, so do not need to be specified). The boolean [isDense] and
   /// [isExpanded] arguments must not be null.
   BreezDropdownButton({
-    Key? key,
+    super.key,
     required this.items,
     this.selectedItemBuilder,
     required this.value,
@@ -548,8 +548,7 @@ class BreezDropdownButton<T> extends StatefulWidget {
     this.isExpanded = false,
   })  : assert(items.isEmpty ||
             value == null ||
-            items.where((DropdownMenuItem<T> item) => item.value == value).length == 1),
-        super(key: key);
+            items.where((DropdownMenuItem<T> item) => item.value == value).length == 1);
 
   /// The list of items the user can select.
   ///
@@ -855,7 +854,7 @@ class BreezDropdownButtonState<T> extends State<BreezDropdownButton<T>> with Wid
       items.add(DefaultTextStyle(
         style: _textStyle.copyWith(color: Theme.of(context).hintColor),
         child: IgnorePointer(
-          ignoringSemantics: false,
+          ignoring: false,
           child: emplacedHint,
         ),
       ));
@@ -946,15 +945,15 @@ class DropdownButtonFormField<T> extends FormField<T> {
   ///
   /// The [DropdownButton] [items] parameters must not be null.
   DropdownButtonFormField({
-    Key? key,
+    super.key,
     T? value,
     required List<DropdownMenuItem<T>> items,
     Widget? hint,
     required this.onChanged,
     this.decoration = const InputDecoration(),
-    FormFieldSetter<T>? onSaved,
-    FormFieldValidator<T>? validator,
-    AutovalidateMode autovalidateMode = AutovalidateMode.disabled,
+    super.onSaved,
+    super.validator,
+    AutovalidateMode super.autovalidateMode = AutovalidateMode.disabled,
     Widget? disabledHint,
     int? elevation = 8,
     TextStyle? style,
@@ -968,11 +967,7 @@ class DropdownButtonFormField<T> extends FormField<T> {
             value == null ||
             items.where((DropdownMenuItem<T> item) => item.value == value).length == 1),
         super(
-          key: key,
-          onSaved: onSaved,
           initialValue: value,
-          validator: validator,
-          autovalidateMode: autovalidateMode,
           builder: (FormFieldState<T> field) {
             final InputDecoration effectiveDecoration = decoration.applyDefaults(
               Theme.of(field.context).inputDecorationTheme,

--- a/lib/widgets/designsystem/switch/simple_switch.dart
+++ b/lib/widgets/designsystem/switch/simple_switch.dart
@@ -11,14 +11,14 @@ class SimpleSwitch extends StatelessWidget {
   final ValueChanged<bool>? onChanged;
 
   const SimpleSwitch({
-    Key? key,
+    super.key,
     required this.text,
     required this.switchValue,
     this.trailing,
     this.group,
     this.onTap,
     this.onChanged,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/loader.dart
+++ b/lib/widgets/loader.dart
@@ -44,14 +44,13 @@ class FullScreenLoader extends StatelessWidget {
   final Function? onClose;
 
   const FullScreenLoader(
-      {Key? key,
+      {super.key,
       this.message,
       this.opacity = 0.5,
       this.value,
       this.progressColor,
       this.bgColor = Colors.black,
-      this.onClose})
-      : super(key: key);
+      this.onClose});
 
   @override
   Widget build(BuildContext context) {
@@ -107,8 +106,7 @@ class TransparentRouteLoader extends StatefulWidget {
   final Function? onClose;
 
   const TransparentRouteLoader(
-      {Key? key, required this.message, this.opacity = 0.5, this.action, this.onClose})
-      : super(key: key);
+      {super.key, required this.message, this.opacity = 0.5, this.action, this.onClose});
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/widgets/payment_dialogs/payment_confirmation_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_confirmation_dialog.dart
@@ -17,8 +17,8 @@ class PaymentConfirmationDialog extends StatelessWidget {
     this._onCancel,
     this._onPaymentApproved,
     this.minHeight, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -25,8 +25,8 @@ class PaymentRequestDialog extends StatefulWidget {
     this.invoice,
     this.firstPaymentItemKey,
     this.scrollController, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_info_dialog.dart
@@ -31,8 +31,8 @@ class PaymentRequestInfoDialog extends StatefulWidget {
     this._onPaymentApproved,
     this._setAmountToPay,
     this.minHeight, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<StatefulWidget> createState() {

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_animated_content.dart
@@ -11,7 +11,7 @@ class ProcessingPaymentAnimatedContent extends StatelessWidget {
   final Widget child;
 
   const ProcessingPaymentAnimatedContent({
-    Key? key,
+    super.key,
     required this.color,
     required this.opacity,
     required this.moment,
@@ -19,7 +19,7 @@ class ProcessingPaymentAnimatedContent extends StatelessWidget {
     required this.startHeight,
     required this.transitionAnimation,
     required this.child,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_content.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_content.dart
@@ -9,10 +9,10 @@ class ProcessingPaymentContent extends StatelessWidget {
   final Color color;
 
   const ProcessingPaymentContent({
-    Key? key,
+    super.key,
     this.dialogKey,
     this.color = Colors.transparent,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/payment_dialogs/processing_payment/processing_payment_title.dart
+++ b/lib/widgets/payment_dialogs/processing_payment/processing_payment_title.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 
 class ProcessingPaymentTitle extends StatelessWidget {
   const ProcessingPaymentTitle({
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -26,8 +26,8 @@ class ProcessingPaymentDialog extends StatefulWidget {
     this.isLnurlPayment = false,
     required this.paymentFunc,
     this.onStateChange,
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   ProcessingPaymentDialogState createState() {

--- a/lib/widgets/preview/fill_view_port_column_scroll_view.dart
+++ b/lib/widgets/preview/fill_view_port_column_scroll_view.dart
@@ -4,9 +4,9 @@ class FillViewPortColumnScrollView extends StatelessWidget {
   final List<Widget> children;
 
   const FillViewPortColumnScrollView({
-    Key? key,
+    super.key,
     required this.children,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/lib/widgets/preview/preview.dart
+++ b/lib/widgets/preview/preview.dart
@@ -7,8 +7,8 @@ class Preview extends StatefulWidget {
 
   const Preview(
     this.children, {
-    Key? key,
-  }) : super(key: key);
+    super.key,
+  });
 
   @override
   State<Preview> createState() => _PreviewState();

--- a/lib/widgets/route.dart
+++ b/lib/widgets/route.dart
@@ -1,8 +1,7 @@
 import 'package:flutter/cupertino.dart';
 
 class FadeInRoute<T> extends CupertinoPageRoute<T> {
-  FadeInRoute({required WidgetBuilder builder, RouteSettings? settings})
-      : super(builder: builder, settings: settings);
+  FadeInRoute({required super.builder, super.settings});
 
   @override
   Widget buildTransitions(
@@ -18,8 +17,7 @@ class FadeInRoute<T> extends CupertinoPageRoute<T> {
 }
 
 class NoTransitionRoute<T> extends CupertinoPageRoute<T> {
-  NoTransitionRoute({required WidgetBuilder builder, RouteSettings? settings})
-      : super(builder: builder, settings: settings);
+  NoTransitionRoute({required super.builder, super.settings});
 
   @override
   Widget buildTransitions(

--- a/lib/widgets/warning_box.dart
+++ b/lib/widgets/warning_box.dart
@@ -9,7 +9,7 @@ class WarningBox extends StatelessWidget {
   final Color? borderColor;
 
   const WarningBox({
-    Key? key,
+    super.key,
     required this.child,
     this.boxPadding = const EdgeInsets.symmetric(
       vertical: 16,
@@ -21,7 +21,7 @@ class WarningBox extends StatelessWidget {
     ),
     this.backgroundColor,
     this.borderColor,
-  }) : super(key: key);
+  });
 
   @override
   Widget build(BuildContext context) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: d84d98f1992976775f83083523a34c5d22fea191eec3abb2bd09537fb623c2e0
+      sha256: "76c15c4167f820b74abcd8c6fc5e393e1ed5e1207a34e9b22953603e03b3ba6a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.7"
+    version: "1.3.9"
   analyzer:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: archive
-      sha256: "20071638cbe4e5964a427cfa0e86dce55d060bc7d82d56f3554095d7239a8765"
+      sha256: "7e0d52067d05f2e0324268097ba723b71cb41ac8a6a2b24d1edf9c536b987b03"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.4.6"
   args:
     dependency: transitive
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -95,7 +95,7 @@ packages:
       path: "../breez-sdk/libs/sdk-flutter"
       relative: true
     source: path
-    version: "0.2.5"
+    version: "0.2.8"
   breez_translations:
     dependency: "direct main"
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: build
-      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.1"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -133,34 +133,34 @@ packages:
     dependency: transitive
     description:
       name: build_daemon
-      sha256: "757153e5d9cd88253cb13f28c2fb55a537dc31fefd98137549895b5beb7c6169"
+      sha256: "5f02d73eb2ba16483e693f80bee4f088563a820e47d1027d4cdfe62b5bb43e65"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      sha256: "0713a05b0386bd97f9e63e78108805a4feca5898a4b821d6610857f10c91e975"
+      sha256: "64e12b0521812d1684b1917bc80945625391cb9bdd4312536b1d69dcb6133ed8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.4.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      sha256: "10c6bcdbf9d049a0b666702cf1cee4ddfdc38f02a19d35ae392863b47519848b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.3"
+    version: "2.4.6"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: "0671ad4162ed510b70d0eb4ad6354c249f8429cab4ae7a4cec86bbc2886eb76e"
+      sha256: c9e32d21dd6626b5c163d48b037ce906bbe428bc23ab77bcd77bb21e593b6185
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.7+1"
+    version: "7.2.11"
   built_collection:
     dependency: transitive
     description:
@@ -181,10 +181,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -221,26 +221,18 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
-  colorize:
-    dependency: transitive
-    description:
-      name: colorize
-      sha256: "584746cd6ba1cba0633b6720f494fe6f9601c4170f0666c1579d2aa2a61071ba"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.0"
+    version: "1.17.2"
   connectivity_plus:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "77a180d6938f78ca7d2382d2240eb626c0f6a735d0bfdce227d8ffb80f95c48b"
+      sha256: b502a681ba415272ecc41400bd04fe543ed1a62632137dc84d25a91e7746f55f
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.2"
+    version: "5.0.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -269,26 +261,26 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fd832b5384d0d6da4f6df60b854d33accaaeb63aa9e10e736a87381f08dee2cb
+      sha256: "445db18de832dba8d851e287aff8ccf169bed30d2e94243cb54c7d2f1ed2142c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+5"
+    version: "0.3.3+6"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      sha256: ff625774173754681d66daaf4a448684fb04b78f902da9cb3d308c19cc5e8bab
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   csv:
     dependency: "direct main"
     description:
       name: csv
-      sha256: "016b31a51a913744a0a1655c74ff13c9379e1200e246a03d96c81c5d9ed297b5"
+      sha256: "142bdf2b24f4a49e35a0fc4398f21d861c4c0f9015e8054dcacd0bb8e23ee27d"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "5.1.0"
   dart_style:
     dependency: transitive
     description:
@@ -349,18 +341,18 @@ packages:
     dependency: "direct main"
     description:
       name: extended_image
-      sha256: "75e4b0ad0f8f63eed7935ff2506c809a670f5e6dd0f61304525879d53fc41a17"
+      sha256: b4d72a27851751cfadaf048936d42939db7cd66c08fdcfe651eeaa1179714ee6
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.2"
+    version: "8.1.1"
   extended_image_library:
     dependency: transitive
     description:
       name: extended_image_library
-      sha256: "550743b43ab093aed35ef234500fcc7a304cbac1eca47b0cc991e07e88750758"
+      sha256: "8bf87c0b14dcb59200c923a9a3952304e4732a0901e40811428834ef39018ee1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.2"
+    version: "3.6.0"
   fake_async:
     dependency: transitive
     description:
@@ -373,10 +365,10 @@ packages:
     dependency: "direct main"
     description:
       name: ffi
-      sha256: ed5337a5660c506388a9f012be0288fb38b49020ce2b45fe1f8b8323fe429f99
+      sha256: "7bf0adc28a23d395f19f3f1eb21dd7cfd1dd9f8e1c50051c069122e6853bc878"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.2"
+    version: "2.1.0"
   file:
     dependency: transitive
     description:
@@ -421,66 +413,66 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "95580fa07c8ca3072a2bb1fecd792616a33f8683477d25b7d29d3a6a399e6ece"
+      sha256: "57bba167105d2315d243a4524939406df688f38a5b6d7a4159382bbbe43cdd00"
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.0"
+    version: "2.19.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: b63e3be6c96ef5c33bdec1aab23c91eb00696f6452f0519401d640938c94cba2
+      sha256: c437ae5d17e6b5cc7981cf6fd458a5db4d12979905f9aafd1fea930428a9fe63
       url: "https://pub.dev"
     source: hosted
-    version: "4.8.0"
+    version: "5.0.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: e8c408923cd3a25bd342c576a114f2126769cd1a57106a4edeaa67ea4a84e962
+      sha256: "0631a2ec971dbc540275e2fa00c3a8a2676f0a7adbc3c197d6fba569db689d97"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.0"
+    version: "2.8.1"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      sha256: c37784a4b663b9351894c921a991647e9fb7d6c7b1c0cbd0d8a28f8abe0dfb38
+      sha256: "957fae6b560dc5f9c0d8e433ddbd6720890492e84d413a367b5d178753a527ea"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.7"
+    version: "5.4.1"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: "8f445e4c8f4ca7e463f4a75e777c8d72431103dd79e26f71393d66bc21dcd2df"
+      sha256: aa0a3427c900e137afda17b585f38a2e10ffdf98e1e74d3c5b3b80410b7aaeaa
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+7"
+    version: "0.2.6+9"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "67f9d7c87457e71ad78ee81e332f232b8a24f7d5e338f8c958fa7d6e9e0e3636"
+      sha256: "01320eab9b3f91a6351d873923190a965e5155db942187aa600f85f78b9de501"
       url: "https://pub.dev"
     source: hosted
-    version: "14.6.9"
+    version: "14.7.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "8c7ced3201886ad7ba37f344c1468ccfc08abb3023922e0e5a016eaf38abb96c"
+      sha256: "952df577e7fb3a4550483f86bb568f19ce5da2a91f1597eeefdca0607de82562"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.8"
+    version: "4.5.10"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: b601322bdb44e2fefe4cc7b85ef0dbb7a2479d4a7653a51340821cf8d60696b5
+      sha256: dcc901226c33b4819992c4add900ed5dae79b0db70097a795d7932c85b18cda1
       url: "https://pub.dev"
     source: hosted
-    version: "3.5.8"
+    version: "3.5.10"
   fixnum:
     dependency: transitive
     description:
@@ -520,10 +512,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_inappwebview
-      sha256: "6d6c741ddba1dba5229d63ba75767064791a7ce845196b45e31105e93d67c949"
+      sha256: "786b124c944f4914670868c9775c90600a4d4674497f617190c0d676019e337b"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0-beta.22"
+    version: "6.0.0-beta.25"
   flutter_inappwebview_internal_annotations:
     dependency: transitive
     description:
@@ -584,10 +576,10 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      sha256: ad76540d21c066228ee3f9d1dad64a9f7e46530e8bb7c85011a88bc1fd874bc5
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -605,18 +597,18 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_rust_bridge
-      sha256: "8dcfeff9dcf0db9c76578c8805a337c0e5e21b4d96887eb1007b6fe141e15ea9"
+      sha256: ff90d5ddd0cda6d94ed048cc9c4a4d993d1a4bb11605d60a1282fc1bbf173c77
       url: "https://pub.dev"
     source: hosted
-    version: "1.75.2"
+    version: "1.80.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
       name: flutter_secure_storage
-      sha256: "22dbf16f23a4bcf9d35e51be1c84ad5bb6f627750565edd70dab70f3ff5fff8f"
+      sha256: ffdbb60130e4665d2af814a0267c481bcf522c41ae2e43caf69fa0146876d685
       url: "https://pub.dev"
     source: hosted
-    version: "8.1.0"
+    version: "9.0.0"
   flutter_secure_storage_linux:
     dependency: transitive
     description:
@@ -653,18 +645,18 @@ packages:
     dependency: transitive
     description:
       name: flutter_secure_storage_windows
-      sha256: "38f9501c7cb6f38961ef0e1eacacee2b2d4715c63cc83fe56449c4d3d0b47255"
+      sha256: "5809c66f9dd3b4b93b0a6e2e8561539405322ee767ac2f64d084e2ab5429d108"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "3.0.0"
   flutter_svg:
     dependency: "direct main"
     description:
       name: flutter_svg
-      sha256: f991fdb1533c3caeee0cdc14b04f50f0c3916f0dbcbc05237ccbe4e3c6b93f3f
+      sha256: "8c5d68a82add3ca76d792f058b186a0599414f279f00ece4830b9b231b570338"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.7"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -688,10 +680,10 @@ packages:
     dependency: transitive
     description:
       name: freezed
-      sha256: "2df89855fe181baae3b6d714dc3c4317acf4fccd495a6f36e5e00f24144c6c3b"
+      sha256: "21bf2825311de65501d22e563e3d7605dff57fb5e6da982db785ae5372ff018a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.5"
   freezed_annotation:
     dependency: transitive
     description:
@@ -717,10 +709,10 @@ packages:
     dependency: transitive
     description:
       name: get_it
-      sha256: "529de303c739fca98cd7ece5fca500d8ff89649f1bb4b4e94fb20954abcd7468"
+      sha256: f79870884de16d689cf9a7d15eedf31ed61d750e813c538a6efb92660fea83c3
       url: "https://pub.dev"
     source: hosted
-    version: "7.6.0"
+    version: "7.6.4"
   git_info:
     dependency: "direct main"
     description:
@@ -765,18 +757,18 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: "5895291c13fa8a3bd82e76d5627f69e0d85ca6a30dcac95c4ea19a5d555879c2"
+      sha256: "759d1a329847dd0f39226c688d3e06a6b8679668e350e2891a6474f8b4bb8525"
       url: "https://pub.dev"
     source: hosted
-    version: "0.13.6"
+    version: "1.1.0"
   http_client_helper:
     dependency: transitive
     description:
       name: http_client_helper
-      sha256: "14c6e756644339f561321dab021215475ba4779aa962466f59ccb3ecf66b36c3"
+      sha256: "8a9127650734da86b5c73760de2b404494c968a3fd55602045ffec789dac3cb1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.4"
+    version: "3.0.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -813,26 +805,26 @@ packages:
     dependency: "direct main"
     description:
       name: image_cropper
-      sha256: "542c3453109d16bcc388e43ae2276044d2cd6a6d20c68bdcff2c94ab9363ea15"
+      sha256: "19340e50a8c09124ef2196884e9eb79d219d84cb819cfbf52141221216e30515"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "5.0.0"
   image_cropper_for_web:
     dependency: transitive
     description:
       name: image_cropper_for_web
-      sha256: "89c936aa772a35b69ca67b78049ae9fa163a4fb8da2f6dee3893db8883fb49d2"
+      sha256: "865d798b5c9d826f1185b32e5d0018c4183ddb77b7b82a931e1a06aa3b74974e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   image_cropper_platform_interface:
     dependency: transitive
     description:
       name: image_cropper_platform_interface
-      sha256: b232175c132b2f7ede3e1f101652bcd635cb4079a77c6dded8e6d32e6578d685
+      sha256: ee160d686422272aa306125f3b6fb1c1894d9b87a5e20ed33fa008e7285da11e
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -930,10 +922,10 @@ packages:
     dependency: transitive
     description:
       name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.7"
   json_annotation:
     dependency: transitive
     description:
@@ -946,34 +938,34 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      sha256: cbf8d4b858bb0134ef3ef87841abdf8d63bfc255c266b7bf6b39daa1085c4290
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   local_auth:
     dependency: "direct main"
     description:
       name: local_auth
-      sha256: "0cf238be2bfa51a6c9e7e9cfc11c05ea39f2a3a4d3e5bb255d0ebc917da24401"
+      sha256: "7e6c63082e399b61e4af71266b012e767a5d4525dd6e9ba41e174fd42d76e115"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.7"
   local_auth_android:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: "523dd636ce061ddb296cbc3db410cb8f21efb7d8798f7b9532c8038ce2f8bad5"
+      sha256: df4ccb3193525b8a60c78a5ca7bf188a47705bcf77bcc837a6b2cf6da64ae0e2
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.31"
+    version: "1.0.35"
   local_auth_ios:
     dependency: "direct main"
     description:
       name: local_auth_ios
-      sha256: edc2977c5145492f3451db9507a2f2f284ee4f408950b3e16670838726761940
+      sha256: "26a8d1ad0b4ef6f861d29921be8383000fda952e323a5b6752cf82ca9cf9a7a9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -986,10 +978,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: "19323b75ab781d5362dbb15dcb7e0916d2431c7a6dbdda016ec9708689877f73"
+      sha256: "505ba3367ca781efb1c50d3132e44a2446bccc4163427bc203b9b4d8994d97ea"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.10"
   logging:
     dependency: "direct main"
     description:
@@ -1002,26 +994,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   mime:
     dependency: transitive
     description:
@@ -1034,18 +1026,18 @@ packages:
     dependency: "direct main"
     description:
       name: mobile_scanner
-      sha256: da55204e5439bc8dc058df56231a7a1d513c6ec9cbad84492f56d493382d296f
+      sha256: d1ce638a53b3d751a6cdbd61ed2705d20d38aa30ed26b6fb2526c34c934afe54
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.5.0"
   mockito:
     dependency: "direct main"
     description:
       name: mockito
-      sha256: dd61809f04da1838a680926de50a9e87385c1de91c6579629c3d1723946e8059
+      sha256: "7d5b53bcd556c1bc7ffbe4e4d5a19c3e112b7e925e9e172dd7c6ad0630812616"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.0"
+    version: "5.4.2"
   nested:
     dependency: transitive
     description:
@@ -1082,10 +1074,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "6ff267fcd9d48cb61c8df74a82680e8b82e940231bb5f68356672fde0397334a"
+      sha256: "7e76fad405b3e4016cd39d08f455a4eb5199723cf594cd1b8916d47140d93017"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.0"
+    version: "4.2.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1162,10 +1154,10 @@ packages:
     dependency: transitive
     description:
       name: petitparser
-      sha256: "49392a45ced973e8d94a85fdb21293fbb40ba805fc49f2965101ae748a3683b4"
+      sha256: cb3798bef7fc021ac45b308f4b51208a152792445cce0448c9a4ba5879dd8750
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.4.0"
   platform:
     dependency: transitive
     description:
@@ -1234,10 +1226,10 @@ packages:
     dependency: transitive
     description:
       name: puppeteer
-      sha256: dd49117259867d0ce0de33ddd95628fb70cff94581a6432c08272447b8dd1d27
+      sha256: "59e723cc5b69537159a7c34efd645dc08a6a1ac4647d7d7823606802c0f93cdb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.24.0"
+    version: "3.2.0"
   qr:
     dependency: transitive
     description:
@@ -1266,26 +1258,26 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "6cec740fa0943a826951223e76218df002804adb588235a8910dc3d6b0654e11"
+      sha256: f74fc3f1cbd99f39760182e176802f693fa0ec9625c045561cfad54681ea93dd
       url: "https://pub.dev"
     source: hosted
-    version: "7.1.0"
+    version: "7.2.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "357412af4178d8e11d14f41723f80f12caea54cf0d5cd29af9dcdab85d58aea7"
+      sha256: df08bc3a07d01f5ea47b45d03ffcba1fa9cd5370fb44b3f38c70e42cced0f956
       url: "https://pub.dev"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.1"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: b7f41bad7e521d205998772545de63ff4e6c97714775902c199353f8bf1511ac
+      sha256: "81429e4481e1ccfb51ede496e916348668fd0921627779233bd24cc3ff6abd02"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.2"
   shared_preferences_android:
     dependency: transitive
     description:
@@ -1306,10 +1298,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: c2eb5bf57a2fe9ad6988121609e47d3e07bb3bdca5b6f8444e4cf302428a128a
+      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -1330,10 +1322,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: f763a101313bd3be87edffe0560037500967de9c394a714cd598d945517f694f
+      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   shelf:
     dependency: transitive
     description:
@@ -1383,10 +1375,10 @@ packages:
     dependency: transitive
     description:
       name: source_gen
-      sha256: "373f96cf5a8744bc9816c1ff41cf5391bbdbe3d7a96fe98c622b6738a8a7bd33"
+      sha256: fc0da689e5302edb6177fdd964efcb7f58912f43c28c2047a808f5bfff643d16
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.4.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -1407,34 +1399,34 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
-      sha256: "8f7603f3f8f126740bc55c4ca2d1027aab4b74a1267a3e31ce51fe40e3b65b8f"
+      sha256: "1b92f368f44b0dee2425bb861cfa17b6f6cf3961f762ff6f941d20b33355660a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.5+1"
+    version: "2.5.0"
   sqflite_common_ffi:
     dependency: "direct main"
     description:
       name: sqflite_common_ffi
-      sha256: f86de82d37403af491b21920a696b19f01465b596f545d1acd4d29a0a72418ad
+      sha256: "0d5cc1be2eb18400ac6701c31211d44164393aa75886093002ecdd947be04f93"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.5"
+    version: "2.3.0+2"
   sqlite3:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "281b672749af2edf259fc801f0fcba092257425bcd32a0ce1c8237130bc934c7"
+      sha256: db65233e6b99e99b2548932f55a987961bc06d82a31a0665451fa0b4fff4c3fb
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.2"
+    version: "2.1.0"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1503,26 +1495,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "5301f54eb6fe945daa99bc8df6ece3f88b5ceaa6f996f250efdaaf63e22886be"
+      sha256: d983a57c33dde6d44b1fb8635f67c91f4b41d26cf227c147963affa97d63563d
       url: "https://pub.dev"
     source: hosted
-    version: "1.23.1"
+    version: "1.24.8"
   test_api:
     dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.18"
+    version: "0.6.1"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: d2e9240594b409565524802b84b7b39341da36dd6fd8e1660b53ad928ec3e9af
+      sha256: "2f866bf4b20c11327ac166ee6036bddafb7fe9e35505ff8324f788e66913f967"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.24"
+    version: "0.5.8"
   theme_provider:
     dependency: "direct main"
     description:
@@ -1559,10 +1551,10 @@ packages:
     dependency: transitive
     description:
       name: typed_data
-      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      sha256: facc8d6582f16042dd49f2463ff1bd6e2c9ef9f3d5da3d9b087e244a7b564b3c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   uni_links:
     dependency: "direct main"
     description:
@@ -1591,10 +1583,10 @@ packages:
     dependency: "direct main"
     description:
       name: url_launcher
-      sha256: eb1e00ab44303d50dd487aab67ebc575456c146c6af44422f9c13889984c00f3
+      sha256: "47e208a6711459d813ba18af120d9663c20bdf6985d6ad39fe165d2538378d27"
       url: "https://pub.dev"
     source: hosted
-    version: "6.1.11"
+    version: "6.1.14"
   url_launcher_android:
     dependency: transitive
     description:
@@ -1639,10 +1631,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: ba140138558fcc3eead51a1c42e92a9fb074a1b1149ed3c73e66035b2ccd94f2
+      sha256: "043a0d5b83bb7a6f4f0040763dd7b23e75c8e1979cc1109a545054b6dcf56d17"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.19"
+    version: "2.1.0"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1663,26 +1655,26 @@ packages:
     dependency: transitive
     description:
       name: vector_graphics
-      sha256: ea8d3fc7b2e0f35de38a7465063ecfcf03d8217f7962aa2a6717132cb5d43a79
+      sha256: b16dadf7eb610e20da044c141b4a0199a5e8082ca21daba68322756f953ce714
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.9"
   vector_graphics_codec:
     dependency: transitive
     description:
       name: vector_graphics_codec
-      sha256: a5eaa5d19e123ad4f61c3718ca1ed921c4e6254238d9145f82aa214955d9aced
+      sha256: a4b01403d5c613db115e30e71eca33f7e9e09f2d3c52c3fb84e16333ecddc539
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.9"
   vector_graphics_compiler:
     dependency: transitive
     description:
       name: vector_graphics_compiler
-      sha256: "15edc42f7eaa478ce854eaf1fbb9062a899c0e4e56e775dd73b7f4709c97c4ca"
+      sha256: d26c0e2f237476426523eb25512e4c09fa27c6d33ed659a0e69d79e20b5dc47f
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.5"
+    version: "1.1.9"
   vector_math:
     dependency: "direct main"
     description:
@@ -1695,18 +1687,26 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      sha256: c620a6f783fa22436da68e42db7ebbf18b8c44b9a46ab911f666ff09ffd9153f
       url: "https://pub.dev"
     source: hosted
-    version: "9.4.0"
+    version: "11.7.1"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      sha256: "3d2ad6751b3c16cf07c7fca317a1413b3f26530319181b37e3b9039b84fc01d8"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1719,34 +1719,34 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      sha256: "87d3f2333bb240704cd3f1c6b5b7acd8a10e7f0bc28c28dcf14e782014f4a572"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   win32:
     dependency: transitive
     description:
       name: win32
-      sha256: "5a751eddf9db89b3e5f9d50c20ab8612296e4e8db69009788d6c8b060a84191c"
+      sha256: "350a11abd2d1d97e0cc7a28a81b781c08002aa2864d9e3f192ca0ffa18b06ed3"
       url: "https://pub.dev"
     source: hosted
-    version: "4.1.4"
+    version: "5.0.9"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "1c52f994bdccb77103a6231ad4ea331a244dbcef5d1f37d8462f713143b0bfae"
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.2"
   workmanager:
     dependency: "direct main"
     description:
@@ -1768,10 +1768,10 @@ packages:
     dependency: transitive
     description:
       name: xml
-      sha256: "979ee37d622dec6365e2efa4d906c37470995871fe9ae080d967e192d88286b5"
+      sha256: "5bc72e1e45e941d825fd7468b9b4cc3b9327942649aeb6fc5cdbf135f0a86e84"
       url: "https://pub.dev"
     source: hosted
-    version: "6.2.2"
+    version: "6.3.0"
   yaml:
     dependency: transitive
     description:
@@ -1781,5 +1781,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=2.19.6 <3.0.0"
-  flutter: ">=3.7.12"
+  dart: ">=3.1.0 <4.0.0"
+  flutter: ">=3.13.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: c_breez
 description: A new Flutter project.
 publish_to: "none"
-version: 1.0.0+4
+version: 1.1.0
 
 environment:
-  sdk: ">=2.19.6 <3.0.0"
-  flutter: ">=3.7.12"
+  sdk: '>=3.0.0 <4.0.0'
+  flutter: ">=3.10.0"
 
 dependencies:
   flutter:
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   another_flushbar: ^1.12.30
-  archive: ^3.3.9
+  archive: ^3.4.6
   auto_size_text: ^3.0.0
   bip39: ^1.0.6
   breez_sdk:
@@ -25,71 +25,71 @@ dependencies:
       url: https://github.com/breez/Breez-Translations
       ref: 782e52c6f272a4901ff85ecb76981085b355acd1
   clipboard_watcher: ^0.2.0
-  csv: ^5.0.2
-  connectivity_plus: ^4.0.2
+  csv: ^5.1.0
+  connectivity_plus: ^5.0.1
   device_info_plus: ^9.1.0
   drag_and_drop_lists: ^0.3.3
   duration: ^3.0.13
   email_validator: ^2.1.17
-  extended_image: <8.0.0 # Requires Flutter 3.10
-  ffi: <2.1.0 # Requires Flutter 3.10
+  extended_image: ^8.1.1
+  ffi: ^2.1.0
   # Doesn't support: Linux Windows
-  firebase_core: ^2.15.0
+  firebase_core: ^2.19.0
   # Doesn't support: Linux Mac Windows
-  firebase_dynamic_links: ^5.3.4
+  firebase_dynamic_links: ^5.4.1
   # Doesn't support: Linux Windows
-  firebase_messaging: ^14.6.5
+  firebase_messaging: ^14.7.1
   flutter_bloc: ^8.1.3
   # Doesn't support: Linux Mac Windows
   flutter_fgbg:
     git:
       url: https://github.com/breez/flutter_fgbg.git
       ref: 976b28ff3c299836f215b6deb2003838c49a8001
-  flutter_inappwebview: 6.0.0-beta.22 # xcodebuiler fails to figure out the right destination for the 6.0.0-beta.23+ | Related issue: https://github.com/pichillilorenzo/flutter_inappwebview/issues/1648#issue-1711313231
-  flutter_rust_bridge: 1.75.2
-  flutter_secure_storage: ^8.0.0
-  flutter_svg: <2.0.6 # Requires Flutter 3.10
+  flutter_inappwebview: ^6.0.0-beta.25
+  flutter_rust_bridge: 1.80.1
+  flutter_secure_storage: ^9.0.0
+  flutter_svg: ^2.0.7
   flutter_typeahead:
     git:
       url: https://github.com/breez/flutter_typeahead.git
       ref: a16aa4deeff1c5e96c6da46da31cb0533f838d8d
   git_info: ^1.1.2
   hex: ^0.2.0
-  http: <1.0.0 # Requires Flutter 3.10
+  http: ^1.1.0
   hydrated_bloc: ^9.1.2
-  image: ^4.0.17
+  image: ^4.1.3
   # Doesn't support: Linux Mac Windows
-  image_cropper: <5.0.0 # Requires Flutter 3.10
+  image_cropper: ^5.0.0
   # Doesn't support: Linux Mac Windows
-  image_picker: ^1.0.2
+  image_picker: ^1.0.4
   ini: ^2.1.0
   intl: ^0.18.1
   # Doesn't support: Linux Mac
-  local_auth: ^2.1.6
-  local_auth_android: <1.0.32 # Requires Flutter 3.10
-  local_auth_ios: ^1.1.3
+  local_auth: ^2.1.7
+  local_auth_android: ^1.0.35
+  local_auth_ios: ^1.1.4
   logging: ^1.2.0
-  mockito: <5.4.1 # flutter_test requirement
+  mockito: ^5.4.2
   # Doesn't support: Linux Windows
-  mobile_scanner: <3.3.0 # Kotlin requirement
-  package_info_plus: ^4.1.0
+  mobile_scanner: ^3.5.0
+  package_info_plus: ^4.2.0
   path: ^1.8.3
-  path_provider: ^2.1.0
-  path_provider_platform_interface: ^2.1.0
-  plugin_platform_interface: ^2.1.5
+  path_provider: ^2.1.1
+  path_provider_platform_interface: ^2.1.1
+  plugin_platform_interface: ^2.1.6
   qr_flutter: ^4.1.0
   rxdart: ^0.27.7
-  share_plus: ^7.1.0
-  shared_preferences: ^2.2.0
+  share_plus: ^7.2.1
+  shared_preferences: ^2.2.2
   simple_animations: ^5.0.2
-  sqflite_common_ffi: <2.3.0 # Requires Flutter 3.10
-  sqlite3_flutter_libs: ^0.5.15
+  sqflite_common_ffi: ^2.3.0+2
+  sqlite3_flutter_libs: ^0.5.17
   synchronized: ^3.1.0
   theme_provider: ^0.6.0
   timeago: ^3.5.0
   # Doesn't support: Linux Mac Windows
   uni_links: ^0.5.1
-  url_launcher: <6.1.12 # Requires Flutter 3.10
+  url_launcher: ^6.1.14
   vector_math: ^2.1.4
   workmanager:
     git:
@@ -100,15 +100,15 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  build_runner: <2.4.0 # Requires Flutter 3.10
-  flutter_lints: ^2.0.2
-  test: <1.24.0 # Requires Flutter 3.10
+  build_runner: ^2.4.6
+  flutter_lints: ^3.0.0
+  test: ^1.24.8
 
 dependency_overrides:
-  archive: ^3.3.9
+  archive: ^3.4.6
   intl: ^0.18.1
   path: ^1.8.3
-  test_api: <0.5.0 # Requires Flutter 3.10
+  test_api: ^0.6.1
   # Comment-out to work with breez-sdk from git repository
   breez_sdk:
     path: ../breez-sdk/libs/sdk-flutter

--- a/test/utils/sqflite_handler.dart
+++ b/test/utils/sqflite_handler.dart
@@ -4,7 +4,7 @@ import 'package:sqflite_common_ffi/src/mixin/handler_mixin.dart';
 
 void sqfliteFfiInitAsMockMethodCallHandler() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final binding = TestDefaultBinaryMessengerBinding.instance!;
+  final binding = TestDefaultBinaryMessengerBinding.instance;
   binding.defaultBinaryMessenger.setMockMethodCallHandler(
     const MethodChannel('com.tekartik.sqflite'),
     (methodCall) async {


### PR DESCRIPTION
### Changelist:
- Upgrade Flutter to 3.13.8
  -  Bump Dart range to  '>=3.0.0 <4.0.0'
  -  Bump Flutter range to  '>=3.10.0'
- Update dependencies to latest
- Bump c-breez version to 1.1.0
- Fix linter issues
  - Convert 'key' to a super parameter. (use_super_parameters) - This makes up the bulk of the changes
  - Ignore errors for https://github.com/dart-lang/linter/issues/3028 on catch blocks
- Remove obsolete TODO comments