### PR TITLE
Make route logging logs just the route name to avoid logging sensitive data shared through route arguments

### DIFF
--- a/lib/user_app.dart
+++ b/lib/user_app.dart
@@ -101,7 +101,7 @@ class UserApp extends StatelessWidget {
                 },
                 initialRoute: securityState.pinStatus == PinStatus.enabled ? "lockscreen" : "splash",
                 onGenerateRoute: (RouteSettings settings) {
-                  _log.info("New route: $settings");
+                  _log.info("New route: ${settings.name}");
                   switch (settings.name) {
                     case '/intro':
                       return FadeInRoute(
@@ -137,7 +137,7 @@ class UserApp extends StatelessWidget {
                             initialRoute: "/",
                             key: _homeNavigatorKey,
                             onGenerateRoute: (RouteSettings settings) {
-                              _log.info("New inner route: $settings");
+                              _log.info("New inner route: ${settings.name}");
                               switch (settings.name) {
                                 case '/':
                                   return FadeInRoute(


### PR DESCRIPTION
We have been passing sensitive data through `RouteSettings` which was being logged.
This PR removes these data and keeps only the route name.

No QA is Needed.

P.S. Thanks @ubbabeck for noticing the problem.