### PR TITLE
Allow two lines for shareable payment row

### DIFF
--- a/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/shareable_payment_row.dart
@@ -52,7 +52,7 @@ class ShareablePaymentRow extends StatelessWidget {
         title: AutoSizeText(
           title,
           style: titleTextStyle ?? themeData.primaryTextTheme.headlineMedium,
-          maxLines: 1,
+          maxLines: 2,
           group: labelAutoSizeGroup,
         ),
         children: [


### PR DESCRIPTION
Pull changes from https://github.com/breez/breezmobile/pull/1242