### PR TITLE
swap page emit state when closed

### DIFF
--- a/lib/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart
+++ b/lib/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart
@@ -34,10 +34,15 @@ class RevSwapsInProgressBloc extends Cubit<RevSwapsInProgressState> {
           "Reverse Swap ${revSwapInfo.id} to ${revSwapInfo.claimPubkey} for ${revSwapInfo.onchainAmountSat} sats status:${revSwapInfo.status.name}",
         );
       }
-      emit(RevSwapsInProgressState(reverseSwapsInProgress: reverseSwapsInProgress));
+      if (!isClosed) {
+        emit(RevSwapsInProgressState(reverseSwapsInProgress: reverseSwapsInProgress));
+      }
     } catch (e) {
       final errorMessage = extractExceptionMessage(e, texts);
-      emit(RevSwapsInProgressState(error: errorMessage));
+      if (!isClosed) {
+        emit(RevSwapsInProgressState(error: errorMessage));
+      }
+
       timer.cancel();
       _log.info("reverse swaps in progress polling finished due to error");
     }

--- a/lib/bloc/swap_in_progress/swap_in_progress_bloc.dart
+++ b/lib/bloc/swap_in_progress/swap_in_progress_bloc.dart
@@ -38,12 +38,17 @@ class SwapInProgressBloc extends Cubit<SwapInProgressState> {
         swapUnused = (await _breezLib.receiveOnchain(req: const ReceiveOnchainRequest()));
       }
       _log.info("swapInProgress: $swapInProgress, swapUnused: $swapUnused");
-      emit(SwapInProgressState(swapInProgress, swapUnused));
+      if (!isClosed) {
+        emit(SwapInProgressState(swapInProgress, swapUnused));
+      }
     } catch (e) {
       final errorMessage = extractExceptionMessage(e, texts);
-      emit(SwapInProgressState(null, null, error: errorMessage));
       timer.cancel();
+      if (!isClosed) {
+        emit(SwapInProgressState(null, null, error: errorMessage));
+      }
       _log.info("swap in address polling finished due to error");
+      rethrow;
     }
   }
 

--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -1,4 +1,3 @@
-import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/swap_in_progress/swap_in_progress_bloc.dart';
@@ -7,7 +6,6 @@ import 'package:c_breez/routes/subswap/swap/widgets/address_widget_placeholder.d
 import 'package:c_breez/routes/subswap/swap/widgets/deposit_widget.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/inprogress_swap.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/swap_error_message.dart';
-import 'package:c_breez/services/injector.dart';
 import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
@@ -24,7 +22,6 @@ class SwapPage extends StatefulWidget {
 }
 
 class SwapPageState extends State<SwapPage> {
-  final BreezSDK breezLib = ServiceInjector().breezSDK;
   SwapInfo? swapInProgress;
   SwapInfo? swapUnused;
   String? bitcoinAddress;


### PR DESCRIPTION
When we are creating a swap and we're polling the swap address it refreshes the address every 5 seconds to see if it has been used. We emit a new state every 5 seconds. 

This works when we're in the swap page, but when the we go back to the home page close() is called, but the method might still be running and thus causing a bad state. 

To avoid this behaviour I suggest that we add a check if the bloc is closed before attempting to emit new states.