### PR TITLE
Add dev command: stop

### DIFF
--- a/lib/routes/dev/command_line_interface.dart
+++ b/lib/routes/dev/command_line_interface.dart
@@ -178,6 +178,7 @@ class _CommandLineInterfaceState extends State<CommandLineInterface> {
           case 'listPayments':
           case 'listInvoices':
           case 'closeAllChannels':
+          case 'stop':
             final command = commandArgs[0].toLowerCase();
             _log.info("executing command: $command");
             final answer = await _breezLib.executeCommand(command: command);

--- a/lib/routes/dev/widget/command_list.dart
+++ b/lib/routes/dev/widget/command_list.dart
@@ -70,6 +70,10 @@ class CommandList extends StatelessWidget {
                   "closeAllChannels",
                   (c) => _onCommand(context, c),
                 ),
+                Command(
+                  "stop",
+                  (c) => _onCommand(context, c),
+                ),
               ],
             ),
           ],


### PR DESCRIPTION
Added the `stop` dev command.

Note: as the command will stop the remote note before it will be able to respond to the gRPC call, it will throw an error. See https://github.com/breez/breez-sdk/blob/89af9b4e1fb66ebb06294c709d218bf5568fab57/libs/sdk-core/src/greenlight/node_api.rs#L1362-L1368