### PR TITLE
Use `rust-cache` on workflows that build **Breez SDK**

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -62,6 +62,10 @@ jobs:
           cd ../sdk-core
           make init
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: breez-sdk/libs
+          
       - name: 🔨 Build Breez SDK
         env:
           SSH_PRIVATE_KEY: ${{secrets.REPO_SSH_KEY}}

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -77,6 +77,10 @@ jobs:
           cd ../sdk-core
           make init
 
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: breez-sdk/libs
+          
       - name: build sdk
         env:
           SSH_PRIVATE_KEY: ${{secrets.REPO_SSH_KEY}}


### PR DESCRIPTION
This PR addresses
- #732 