### PR TITLE
sync after offline payment receive

### DIFF
--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -106,6 +106,7 @@ class NotificationService: UNNotificationServiceExtension {
             }
         }
         self.paymentReceivers.removeAll(where: {$0.paymentHash == data.paymentHash})
+        try? NotificationService.breezSDK!.sync()
     }
 }
 

--- a/lib/routes/home/widgets/dashboard/balance_text.dart
+++ b/lib/routes/home/widgets/dashboard/balance_text.dart
@@ -1,21 +1,20 @@
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/account/account_state.dart';
+import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 
 class BalanceText extends StatefulWidget {
   final UserProfileState userProfileState;
   final CurrencyState currencyState;
-  final AccountState accountState;
   final double offsetFactor;
 
   const BalanceText({
     super.key,
     required this.userProfileState,
     required this.currencyState,
-    required this.accountState,
     required this.offsetFactor,
   });
 
@@ -31,7 +30,7 @@ class _BalanceTextState extends State<BalanceText> {
   Widget build(BuildContext context) {
     final texts = context.texts();
     final themeData = Theme.of(context);
-
+    final balance = context.watch<AccountBloc>().state.balance;
     return widget.userProfileState.profileSettings.hideBalance
         ? Text(
             texts.wallet_dashboard_balance_hide,
@@ -47,7 +46,7 @@ class _BalanceTextState extends State<BalanceText> {
                 fontSize: startSize - (startSize - endSize) * widget.offsetFactor,
               ),
               text: widget.currencyState.bitcoinCurrency.format(
-                widget.accountState.balance,
+                balance,
                 removeTrailingZeros: true,
                 includeDisplayName: false,
               ),

--- a/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
+++ b/lib/routes/home/widgets/dashboard/wallet_dashboard.dart
@@ -89,7 +89,6 @@ class _WalletDashboardState extends State<WalletDashboard> {
                                   child: BalanceText(
                                     userProfileState: userProfileState,
                                     currencyState: currencyState,
-                                    accountState: accountState,
                                     offsetFactor: widget.offsetFactor,
                                   ),
                                 )


### PR DESCRIPTION
fixes #736 for iOS

Sync after payment is received in order to let the sdk cache the latest nodestate.