### PR TITLE
Single extension instance

### DIFF
--- a/ios/Breez Notification Service Extension/BreezManager.swift
+++ b/ios/Breez Notification Service Extension/BreezManager.swift
@@ -11,30 +11,7 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-// SDK events listener
-class SDKListener: EventListener {
-    
-    var paymentListener : PaymentListener
-    
-    init(paymentListener: @escaping PaymentListener) {
-        self.paymentListener = paymentListener
-    }
-    
-    func onEvent(e: BreezEvent) {
-        switch e {
-        case .invoicePaid(details: let details):
-            log.info("Received payment. Bolt11: \(details.bolt11)\nPayment Hash:\(details.paymentHash)")
-            if details.payment != nil {
-                paymentListener(details.payment!)
-            }
-            return
-        default:
-            break
-        }
-    }
-}
-
-func connectSDK(paymentListener: @escaping PaymentListener) throws -> BlockingBreezServices? {
+func connectSDK(eventListener: EventListener) throws -> BlockingBreezServices? {
     log.trace("connectSDK()")
     
     // Create the default config
@@ -57,7 +34,7 @@ func connectSDK(paymentListener: @escaping PaymentListener) throws -> BlockingBr
         throw SdkError.Generic(message: "seed not found")
     }
     log.trace("Connecting to Breez SDK")
-    let breezSDK = try connect(config: config, seed: seed!, listener: SDKListener(paymentListener: paymentListener))
+    let breezSDK = try connect(config: config, seed: seed!, listener: eventListener)
     log.trace("Connected to Breez SDK")
     return breezSDK
 }

--- a/ios/Breez Notification Service Extension/BreezManager.swift
+++ b/ios/Breez Notification Service Extension/BreezManager.swift
@@ -11,32 +11,66 @@ fileprivate var log = Logger(
 fileprivate var log = Logger(OSLog.disabled)
 #endif
 
-func connectSDK(eventListener: EventListener) throws -> BlockingBreezServices? {
-    log.trace("connectSDK()")
+class BreezManager {
+    private static var breezSDK: BlockingBreezServices? = nil
+    fileprivate static var queue = DispatchQueue(label: "BreezManager")
+    fileprivate static var sdkListener: EventListener? = nil
     
-    // Create the default config
-    let apiKey = try Environment.glApiKey()
-    log.trace("API_KEY: .\(apiKey)")
-    var config = defaultConfig(envType: EnvironmentType.production, apiKey: apiKey,
-                               nodeConfig: NodeConfig.greenlight(
-                                config: GreenlightNodeConfig(partnerCredentials: nil, inviteCode: nil)))
-    
-    config.workingDir = FileManager
-        .default.containerURL(forSecurityApplicationGroupIdentifier: "group.F7R2LZH3W5.com.cBreez.client")!
-        .absoluteString
-    
-    // Construct the seed
-    let mnemonic = CredentialsManager.shared.restoreMnemonic() ?? ""
-    log.trace("mnemonic: .\(mnemonic)")
-    let seed = try? mnemonicToSeed(phrase: mnemonic)
-    // Connect to the Breez SDK make it ready for use
-    guard seed != nil else {
-        throw SdkError.Generic(message: "seed not found")
+    static func register(listener: EventListener) throws -> BlockingBreezServices? {
+        try BreezManager.queue.sync { [] in
+            BreezManager.sdkListener = listener
+            if BreezManager.breezSDK == nil {
+                BreezManager.breezSDK = try BreezManager.connectSDK()
+            }
+            return BreezManager.breezSDK
+        }
     }
-    log.trace("Connecting to Breez SDK")
-    let breezSDK = try connect(config: config, seed: seed!, listener: eventListener)
-    log.trace("Connected to Breez SDK")
-    return breezSDK
+    
+    static func unregister() {
+        BreezManager.queue.sync { [] in
+            BreezManager.sdkListener = nil            
+        }
+    }
+    
+    static func connectSDK() throws -> BlockingBreezServices? {
+        log.trace("connectSDK()")
+        try setLogStream(logStream: SDKLogListener(logger: NotificationService.logger))
+        
+        // Create the default config
+        let apiKey = try Environment.glApiKey()
+        log.trace("API_KEY: .\(apiKey)")
+        var config = defaultConfig(envType: EnvironmentType.production, apiKey: apiKey,
+                                   nodeConfig: NodeConfig.greenlight(
+                                    config: GreenlightNodeConfig(partnerCredentials: nil, inviteCode: nil)))
+        
+        config.workingDir = FileManager
+            .default.containerURL(forSecurityApplicationGroupIdentifier: "group.F7R2LZH3W5.com.cBreez.client")!
+            .absoluteString
+        
+        // Construct the seed
+        let mnemonic = CredentialsManager.shared.restoreMnemonic() ?? ""
+        log.trace("mnemonic: .\(mnemonic)")
+        let seed = try? mnemonicToSeed(phrase: mnemonic)
+        // Connect to the Breez SDK make it ready for use
+        guard seed != nil else {
+            throw SdkError.Generic(message: "seed not found")
+        }
+        log.trace("Connecting to Breez SDK")
+        let breezSDK = try connect(config: config, seed: seed!, listener: BreezManagerListener())
+        log.trace("Connected to Breez SDK")
+        return breezSDK
+    }
 }
 
-typealias PaymentListener = (Payment) -> Void
+class BreezManagerListener: EventListener {
+    
+    func onEvent(e: BreezEvent) {
+        BreezManager.queue.async { [] in
+            if let l = BreezManager.sdkListener {
+                l.onEvent(e: e)
+            }
+        }
+    }
+    
+    
+}

--- a/ios/Breez Notification Service Extension/BreezManager.swift
+++ b/ios/Breez Notification Service Extension/BreezManager.swift
@@ -48,15 +48,15 @@ class BreezManager {
             .absoluteString
         
         // Construct the seed
-        let mnemonic = CredentialsManager.shared.restoreMnemonic() ?? ""
-        log.trace("mnemonic: .\(mnemonic)")
-        let seed = try? mnemonicToSeed(phrase: mnemonic)
-        // Connect to the Breez SDK make it ready for use
-        guard seed != nil else {
+        guard let mnemonic = CredentialsManager.shared.restoreMnemonic() else {
+            throw SdkError.Generic(message: "mnemonic not found")
+        }        
+        guard let seed = try? mnemonicToSeed(phrase: mnemonic) else {
             throw SdkError.Generic(message: "seed not found")
         }
+        // Connect to the Breez SDK make it ready for use
         log.trace("Connecting to Breez SDK")
-        let breezSDK = try connect(config: config, seed: seed!, listener: BreezManagerListener())
+        let breezSDK = try connect(config: config, seed: seed, listener: BreezManagerListener())
         log.trace("Connected to Breez SDK")
         return breezSDK
     }
@@ -66,9 +66,7 @@ class BreezManagerListener: EventListener {
     
     func onEvent(e: BreezEvent) {
         BreezManager.queue.async { [] in
-            if let l = BreezManager.sdkListener {
-                l.onEvent(e: e)
-            }
+            BreezManager.sdkListener?.onEvent(e: e)
         }
     }
     

--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -95,11 +95,8 @@ class PaymentReceiver : SDKBackgroundTask {
     }
     
     func onShutdown() {
-        if let p =  self.receivedPayment {
-            self.displayPushNotification(title: "Received \(p.amountMsat/1000) sats")
-        } else {
-            self.displayPushNotification(title: "Receive payment failed")
-        }
+        let title = self.receivedPayment != nil ? "Received \(self.receivedPayment!.amountMsat/1000) sats" :  "Receive payment failed"
+        self.displayPushNotification(title: title)
     }
     
     func onEvent(e: BreezEvent) {

--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -42,7 +42,7 @@ class NotificationService: UNNotificationServiceExtension {
                     self.breezSDK = try BreezManager.register(listener: currentTask)
                     Self.logger.info("Breez SDK connected successfully")
                 } catch {
-                    Self.logger.info("Breez SDK connections failed \(error)")
+                    Self.logger.error("Breez SDK connection failed \(error)")
                     self.shutdown()
                 }
             }


### PR DESCRIPTION
This PR simplifies the notification extension logic and prepares it to other upcoming types of background tasks (such as lnurlpay)
For each notification type a proper task is created and being started to handle that notification end to end.
Also found out that the notification is not invoked in parallel. If there are multiple payments in parallel, the notifications are queued and invoked one after another so no need to code for the case where we can several notifications for the same instance.
I also noticed we don't need the payment hash poller, we can just wait for payment received event which seems to be reliable enough.
fixed #751 
