### PR TITLE
Cleanup on the home drawer menu

### DIFF
--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -34,7 +34,6 @@ class Home extends StatefulWidget {
 
 class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
-  final GlobalKey<HomeDrawerState> _drawerKey = GlobalKey<HomeDrawerState>();
   final GlobalKey firstPaymentItemKey = GlobalKey();
   final ScrollController scrollController = ScrollController();
   final handlers = <Handler>[];
@@ -112,11 +111,11 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
             drawerEnableOpenDragGesture: true,
             drawerDragStartBehavior: DragStartBehavior.down,
             drawerEdgeDragWidth: mediaSize.width,
-            drawer: HomeDrawer(key: _drawerKey),
+            drawer: const HomeDrawer(),
             bottomNavigationBar: BottomActionsBar(firstPaymentItemKey),
             floatingActionButton: QrActionButton(firstPaymentItemKey),
             floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
-            body: _drawerKey.currentState?.screen() ?? AccountPage(firstPaymentItemKey, scrollController),
+            body: AccountPage(firstPaymentItemKey, scrollController),
           ),
         ),
       ),

--- a/lib/routes/home/widgets/drawer/drawer_group.dart
+++ b/lib/routes/home/widgets/drawer/drawer_group.dart
@@ -1,0 +1,17 @@
+import 'package:c_breez/routes/home/widgets/drawer/drawer_item.dart';
+
+class DrawerGroup {
+  final List<DrawerItem> items;
+  final String? groupTitle;
+  final String? groupAssetImage;
+  final bool withDivider;
+  final bool isExpanded;
+
+  const DrawerGroup({
+    this.groupTitle,
+    this.groupAssetImage,
+    this.withDivider = true,
+    this.isExpanded = true,
+    this.items = const [],
+  });
+}

--- a/lib/routes/home/widgets/drawer/drawer_header_container.dart
+++ b/lib/routes/home/widgets/drawer/drawer_header_container.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 
 const double _kBreezDrawerHeaderHeight = 160.0 + 1.0; // bottom edge
 
-class BreezDrawerHeader extends DrawerHeader {
-  const BreezDrawerHeader({
+class DrawerHeaderContainer extends DrawerHeader {
+  const DrawerHeaderContainer({
     super.key,
     super.decoration,
     super.margin = const EdgeInsets.only(bottom: 16.0),

--- a/lib/routes/home/widgets/drawer/drawer_header_content.dart
+++ b/lib/routes/home/widgets/drawer/drawer_header_content.dart
@@ -1,0 +1,55 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/user_profile/user_profile_bloc.dart';
+import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
+import 'package:c_breez/routes/home/widgets/drawer/breez_avatar_dialog.dart';
+import 'package:c_breez/routes/home/widgets/drawer/drawer_theme_switch.dart';
+import 'package:c_breez/theme/theme_extensions.dart';
+import 'package:c_breez/widgets/breez_avatar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class DrawerHeaderContent extends StatelessWidget {
+  const DrawerHeaderContent({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    return BlocBuilder<UserProfileBloc, UserProfileState>(builder: (context, userSettings) {
+      final profileSettings = userSettings.profileSettings;
+
+      return GestureDetector(
+        onTap: () {
+          showDialog<bool>(
+            useRootNavigator: false,
+            context: context,
+            barrierDismissible: false,
+            builder: (context) => BreezAvatarDialog(),
+          );
+        },
+        child: Column(children: [
+          const DrawerThemeSwitch(),
+          Row(
+            children: [
+              BreezAvatar(profileSettings.avatarURL, radius: 24.0),
+            ],
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 8.0),
+                child: AutoSizeText(
+                  profileSettings.name ?? texts.home_drawer_error_no_name,
+                  style: navigationDrawerHandleStyle,
+                ),
+              ),
+            ],
+          ),
+        ]),
+      );
+    });
+  }
+}

--- a/lib/routes/home/widgets/drawer/drawer_item.dart
+++ b/lib/routes/home/widgets/drawer/drawer_item.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class DrawerItem {
+  final GlobalKey? key;
+  final String? route;
+  final String title;
+  final String icon;
+  final bool disabled;
+  final void Function(String name)? onItemSelected;
+  final Widget? switchWidget;
+  final bool isSelected;
+
+  const DrawerItem({
+    this.route,
+    this.title = "",
+    required this.icon,
+    this.key,
+    this.onItemSelected,
+    this.disabled = false,
+    this.switchWidget,
+    this.isSelected = false,
+  });
+}

--- a/lib/routes/home/widgets/drawer/drawer_theme_switch.dart
+++ b/lib/routes/home/widgets/drawer/drawer_theme_switch.dart
@@ -1,0 +1,56 @@
+import 'package:c_breez/theme/theme_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:theme_provider/theme_provider.dart';
+
+class DrawerThemeSwitch extends StatelessWidget {
+  const DrawerThemeSwitch({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final themeData = Theme.of(context);
+    return GestureDetector(
+      onTap: () => ThemeProvider.controllerOf(context).nextTheme(),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(
+              top: 10,
+              right: 16.0,
+            ),
+            child: Container(
+              width: 64,
+              padding: const EdgeInsets.all(4),
+              decoration: const ShapeDecoration(
+                shape: StadiumBorder(),
+                color: themeSwitchBgColor,
+              ),
+              child: Row(
+                children: [
+                  Image.asset(
+                    "src/icon/ic_lightmode.png",
+                    height: 24,
+                    width: 24,
+                    color: themeData.lightThemeSwitchIconColor,
+                  ),
+                  const SizedBox(
+                    height: 20,
+                    width: 8,
+                    child: VerticalDivider(
+                      color: Colors.white30,
+                    ),
+                  ),
+                  ImageIcon(
+                    const AssetImage("src/icon/ic_darkmode.png"),
+                    color: themeData.darkThemeSwitchIconColor,
+                    size: 24.0,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -1,192 +1,92 @@
-import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
-import 'package:c_breez/bloc/lsp/lsp_state.dart';
+import 'package:c_breez/bloc/ext/block_builder_extensions.dart';
 import 'package:c_breez/bloc/refund/refund_bloc.dart';
 import 'package:c_breez/bloc/refund/refund_state.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_bloc.dart';
 import 'package:c_breez/bloc/user_profile/user_profile_state.dart';
 import 'package:c_breez/models/user_profile.dart';
+import 'package:c_breez/routes/home/widgets/drawer/breez_navigation_drawer.dart';
+import 'package:c_breez/routes/home/widgets/drawer/drawer_group.dart';
+import 'package:c_breez/routes/home/widgets/drawer/drawer_item.dart';
 import 'package:c_breez/widgets/flushbar.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 
-import 'breez_navigation_drawer.dart';
-
-const _kActiveAccountRoutes = [
-  "/connect_to_pay",
-  "/pay_invoice",
-  "/create_invoice",
-];
-
-class HomeDrawer extends StatefulWidget {
+class HomeDrawer extends StatelessWidget {
   const HomeDrawer({
     super.key,
   });
 
   @override
-  State<HomeDrawer> createState() => HomeDrawerState();
-}
-
-class HomeDrawerState extends State<HomeDrawer> {
-  final Set<String> _hiddenRoutes = {};
-  final List<DrawerItemConfig> _screens = [
-    const DrawerItemConfig("breezHome", "Breez Cloud", ""),
-  ];
-  final Map<String, Widget> _screenBuilders = {};
-
-  String _activeScreen = "breezHome";
-
-  @override
   Widget build(BuildContext context) {
-    return BlocBuilder<UserProfileBloc, UserProfileState>(
-      builder: (context, user) {
+    final texts = context.texts();
+    return BlocBuilder2<UserProfileBloc, UserProfileState, RefundBloc, RefundState>(
+      builder: (context, user, refundState) {
         final settings = user.profileSettings;
-        return BlocBuilder<LSPBloc, LspState?>(
-          builder: (context, lspState) {
-            final addOrRemove = (lspState?.lspInfo != null) ? _hiddenRoutes.remove : _hiddenRoutes.add;
-            for (var route in _kActiveAccountRoutes) {
-              addOrRemove(route);
-            }
-            return BlocBuilder<RefundBloc, RefundState>(
-              builder: (context, refundState) {
-                return _build(context, settings, refundState.refundables);
-              },
-            );
+        final refundables = refundState.refundables;
+
+        return BreezNavigationDrawer(
+          [
+            DrawerGroup(
+              items: [
+                DrawerItem(
+                  title: texts.home_drawer_item_title_balance,
+                  icon: "src/icon/balance.png",
+                  isSelected: settings.appMode == AppMode.balance,
+                ),
+              ],
+            ),
+            if (refundables != null && refundables.isNotEmpty)
+              DrawerGroup(
+                items: [
+                  DrawerItem(
+                    route: "/get_refund",
+                    title: texts.home_drawer_item_title_get_refund,
+                    icon: "src/icon/withdraw_funds.png",
+                  ),
+                ],
+              ),
+            DrawerGroup(
+              groupTitle: texts.home_drawer_item_title_preferences,
+              groupAssetImage: "",
+              isExpanded: settings.expandPreferences,
+              items: [
+                DrawerItem(
+                  route: "/fiat_currency",
+                  title: texts.home_drawer_item_title_fiat_currencies,
+                  icon: "src/icon/fiat_currencies.png",
+                ),
+                DrawerItem(
+                  route: "/network",
+                  title: texts.home_drawer_item_title_network,
+                  icon: "src/icon/network.png",
+                ),
+                DrawerItem(
+                  route: "/security",
+                  title: texts.home_drawer_item_title_security_and_backup,
+                  icon: "src/icon/security.png",
+                ),
+                DrawerItem(
+                  route: "/payment_options",
+                  title: texts.home_drawer_item_title_payment_options,
+                  icon: "src/icon/payment_options.png",
+                ),
+                DrawerItem(
+                  route: "/developers",
+                  title: texts.home_drawer_item_title_developers,
+                  icon: "src/icon/developers.png",
+                ),
+              ],
+            ),
+          ],
+          (screenName) {
+            Navigator.of(context).pushNamed(screenName).then((message) {
+              if (message != null && message is String) {
+                showFlushbar(context, message: message);
+              }
+            });
           },
         );
       },
     );
-  }
-
-  Widget _build(
-    BuildContext context,
-    UserProfileSettings settings,
-    List<SwapInfo>? refundables,
-  ) {
-    final texts = context.texts();
-
-    return BreezNavigationDrawer(
-      [
-        ..._drawerConfigAppModeItems(context, settings),
-        if (refundables != null && refundables.isNotEmpty) ...[
-          DrawerItemConfigGroup(
-            [
-              DrawerItemConfig(
-                "/get_refund",
-                texts.home_drawer_item_title_get_refund,
-                "src/icon/withdraw_funds.png",
-              ),
-            ],
-          ),
-        ],
-        DrawerItemConfigGroup(
-          _filterItems(_drawerConfigToFilter(context)),
-          groupTitle: texts.home_drawer_item_title_preferences,
-          groupAssetImage: "",
-          isExpanded: settings.expandPreferences,
-        ),
-      ],
-      (screenName) {
-        if (_screens.map((sc) => sc.name).contains(screenName)) {
-          setState(() {
-            _activeScreen = screenName;
-          });
-        } else {
-          Navigator.of(context).pushNamed(screenName).then((message) {
-            if (message != null && message is String) {
-              showFlushbar(context, message: message);
-            }
-          });
-        }
-      },
-    );
-  }
-
-  List<DrawerItemConfigGroup> _drawerConfigAppModeItems(
-    BuildContext context,
-    UserProfileSettings user,
-  ) {
-    return [
-      DrawerItemConfigGroup(
-        [
-          _drawerItemBalance(
-            context,
-            user,
-          ),
-          // App are disabled untill we support it ref:
-          // (https://github.com/breez/c-breez/issues/388#issue-1551748496)
-          //_drawerItemLightningApps(context, user),
-        ],
-      ),
-    ];
-  }
-
-  DrawerItemConfig _drawerItemBalance(
-    BuildContext context,
-    UserProfileSettings user,
-  ) {
-    final texts = context.texts();
-    return DrawerItemConfig(
-      "",
-      texts.home_drawer_item_title_balance,
-      "src/icon/balance.png",
-      isSelected: user.appMode == AppMode.balance,
-      onItemSelected: (_) {
-        // TODO add protectAdminAction
-      },
-    );
-  }
-
-  List<DrawerItemConfig> _drawerConfigToFilter(
-    BuildContext context,
-  ) {
-    final texts = context.texts();
-    return [
-      DrawerItemConfig(
-        "/fiat_currency",
-        texts.home_drawer_item_title_fiat_currencies,
-        "src/icon/fiat_currencies.png",
-      ),
-      DrawerItemConfig(
-        "/network",
-        texts.home_drawer_item_title_network,
-        "src/icon/network.png",
-      ),
-      DrawerItemConfig(
-        "/security",
-        texts.home_drawer_item_title_security_and_backup,
-        "src/icon/security.png",
-      ),
-      DrawerItemConfig(
-        "/payment_options",
-        texts.home_drawer_item_title_payment_options,
-        "src/icon/payment_options.png",
-      ),
-      ..._drawerConfigAdvancedFlavorItems(context),
-    ];
-  }
-
-  List<DrawerItemConfig> _drawerConfigAdvancedFlavorItems(
-    BuildContext context,
-  ) {
-    final texts = context.texts();
-    return [
-      DrawerItemConfig(
-        "/developers",
-        texts.home_drawer_item_title_developers,
-        "src/icon/developers.png",
-      ),
-    ];
-  }
-
-  List<DrawerItemConfig> _filterItems(
-    List<DrawerItemConfig> items,
-  ) {
-    return items.where((c) => !_hiddenRoutes.contains(c.name)).toList();
-  }
-
-  Widget? screen() {
-    return _screenBuilders[_activeScreen];
   }
 }

--- a/lib/routes/home/widgets/drawer/navigation_drawer_footer.dart
+++ b/lib/routes/home/widgets/drawer/navigation_drawer_footer.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class NavigationDrawerFooter extends StatelessWidget {
+  const NavigationDrawerFooter({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: _kBreezBottomSheetHeight + 8.0 + MediaQuery.of(context).viewPadding.bottom,
+      child: Column(
+        children: [
+          const Divider(),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Image.asset(
+                "src/images/drawer_footer.png",
+                height: 39,
+                width: 183,
+                fit: BoxFit.fitHeight,
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+const double _kBreezBottomSheetHeight = 60.0;


### PR DESCRIPTION
A minor cleanup on the home drawer menu:

- Remove unused code inherited from Breez mobile
- Remove "builders" method in favor of creating widgets in the build method directly
- Break some widgets into their own files to reduce cognitive loading when opening a file