### PR TITLE
Display the correct balance we validate against on ReverseSwapPage

### DIFF
--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -177,7 +177,7 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
                                 ),
                               ),
                             ),
-                            const WithdrawFundsAvailableBtc(),
+                            WithdrawFundsAvailableBtc(maxSendableAmount: maxSendableAmount),
                             Expanded(child: Container()),
                             Padding(
                               padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),

--- a/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
@@ -11,7 +11,9 @@ import 'package:logging/logging.dart';
 final _log = Logger("WithdrawFundsAvailableBtc");
 
 class WithdrawFundsAvailableBtc extends StatelessWidget {
-  const WithdrawFundsAvailableBtc();
+  final int? maxSendableAmount;
+
+  const WithdrawFundsAvailableBtc({this.maxSendableAmount});
 
   @override
   Widget build(BuildContext context) {
@@ -25,22 +27,18 @@ class WithdrawFundsAvailableBtc extends StatelessWidget {
       padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
       child: Row(
         children: [
-          Text(
-            texts.withdraw_funds_balance,
-            style: textStyle,
-          ),
+          Text(texts.withdraw_funds_balance, style: textStyle),
           Padding(
             padding: const EdgeInsets.only(left: 3.0),
             child: BlocBuilder<AccountBloc, AccountState>(
               builder: (context, account) {
                 _log.info(
-                    "Building with wallet balance: ${account.walletBalance} balance: ${account.balance}");
+                  "Building with wallet balance: ${account.walletBalance} balance: ${account.balance} maxSendableAmount: $maxSendableAmount",
+                );
                 return BlocBuilder<CurrencyBloc, CurrencyState>(
                   builder: (context, currencyState) {
                     return Text(
-                      currencyState.bitcoinCurrency.format(
-                        account.balance,
-                      ),
+                      currencyState.bitcoinCurrency.format(maxSendableAmount ?? account.balance),
                       style: textStyle,
                     );
                   },


### PR DESCRIPTION
@ok300 encountered a bug on sending to onchain(rev swap) where he had enough wallet balance but got the error "Insufficient local balance".

After confirming `maxAllowedToPay` of their `NodeState` is well within the limits, the issue pointed towards `maxAmountSat` of `ReverseSwapOptions` when we `fetchReverseSwapOptions` on opening `ReverseSwapPage` which is used on validation.

`WithdrawFundsAvailableBtc()` now uses the `maxAmountSat` of fetched `ReverseSwapOptions` to correctly display the balance we validate against.