### PR TITLE
Environment variables workaround for Flutter 3.19

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,11 +130,10 @@ flutter {
 
 dependencies {
     /* FCM */
-    implementation 'com.google.firebase:firebase-messaging-ktx:23.4.0'
-    /* WorkManager */
     def work_version = "2.9.0"
     // Kotlin + coroutines
     implementation "androidx.work:work-runtime-ktx:$work_version"
+    implementation 'com.google.firebase:firebase-messaging:23.4.1'
     /* Logging */
     implementation 'org.tinylog:tinylog-api-kotlin:2.6.2'
     implementation 'org.tinylog:tinylog-impl:2.6.2'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -130,9 +130,6 @@ flutter {
 
 dependencies {
     /* FCM */
-    def work_version = "2.9.0"
-    // Kotlin + coroutines
-    implementation "androidx.work:work-runtime-ktx:$work_version"
     implementation 'com.google.firebase:firebase-messaging:23.4.1'
     /* Logging */
     implementation 'org.tinylog:tinylog-api-kotlin:2.6.2'

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -24,10 +24,21 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
+def dartDefines = [:];
+if (project.hasProperty('dart-defines')) {
+    // Decode dart-defines, which are comma-separated and encoded in Base64, and store them in a variable.
+    dartDefines = dartDefines + project.property('dart-defines')
+            .split(',')
+            .collectEntries { entry ->
+                def pair = new String(entry.decodeBase64(), 'UTF-8').split('=', 2)
+                [(pair.first()): pair.last()]
+            }
+}
+
 def envVariables = [
         API_KEY: project.hasProperty('API_KEY')
                 ? API_KEY
-                : '',
+                : "${dartDefines.API_KEY}",
 ];
 
 android {

--- a/ios/Breez Notification Service Extension/Info.plist
+++ b/ios/Breez Notification Service Extension/Info.plist
@@ -9,7 +9,5 @@
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).NotificationService</string>
 	</dict>
-    <key>API_KEY</key>
-    <string>$(API_KEY)</string>
 </dict>
 </plist>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>API_KEY</key>
-	<string>$(API_KEY)</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -1,6 +1,11 @@
 # Troubleshooting
 
 ## No lsp
-- make sure you have `config.json` file at the root of c-breez project
-- make sure you have `API_KEY` (upper case) with a valid key at your config.json file
-- make sure you are running flutter run with the following args `--dart-define-from-file=config.json`
+If you're using `--dart-define-from-file` & `config.json` to define environment variables:
+- Make sure you have `config.json` file at the root of c-breez project
+- Make sure you have `API_KEY` (upper case) with a valid key at your `config.json` file
+- Make sure you are running flutter run with the following args `--dart-define-from-file=config.json`
+
+If you're using `--dart-define` to define environment variables:
+- Make sure you are running flutter run with the following args `--dart-define=API_KEY=<YOUR_API_KEY> --dart-define=GL_CERT=<YOUR_GL_CERT> --dart-define=GL_KEY=<YOUR_GL_KEY> --dart-define=APP_ID_PREFIX=<IOS_APP_ID_PREFIX>`
+


### PR DESCRIPTION
`--dart-define-from-file` had the ability to get access to provided key-value pairs in gradle and plist but it was _silently_ removed with **Flutter 3.19**. It was not considered a breaking change and was not documented in release notes by Flutter team.

I was not able to catch this on my builds, perhaps due to cache issues. @dangeross encountered this issue and found the related issues on this information & a [workaround](https://github.com/flutter/flutter/issues/142976#issuecomment-1949602247).

### Changelist:
- Apply the workaround so that the dart defined variables are available from `gradle` 448d34a29bd99498e649e55c44791c26173bd372
  - The iOS counterpart isn't implemented as we're not using environment variables on our Notification Service App Extension, they are accessed through shared Keychain
- In light of this, removed previously added environment variables from iOS & removed the related step from Build iOS workflow 13eb1a388768f94102749f868435bdb5408e5178
- Update `troubleshooting.md` to include `--dart-define` examples as well faf9599839183de92f76b5c0761ccffbf028d98f

### Other Changelist:
- Depend on the main **Firebase** modules instead of the KTX modules 2d63a9007c479c564144f5bd2b6c1df39b3b8000
  - More information here: [Migrate to using the Kotlin extensions (KTX) APIs in the main modules](https://firebase.google.com/docs/android/kotlin-migration)
- Removed unused **WorkManager** `gradle` dependency fcefb4d8f6bf56605185dc8bc75b7010765c536d
