### PR TITLE
LNURL-Payment: Channel setup fee limit

### DIFF
--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -5,6 +5,8 @@ let accessGroup = "group.F7R2LZH3W5.com.cBreez.client"
 
 class NotificationService: SDKNotificationService {
     fileprivate let TAG = "NotificationService"
+    
+    private let kChannelSetupFeeLimit: String =  "payment_options_channel_setup_fee_limit"
     private let accountMnemonic: String = "account_mnemonic"
     private let accountApiKey: String = "account_api_key"
     
@@ -58,5 +60,11 @@ class NotificationService: SDKNotificationService {
             return nil
         }
         return ConnectRequest(config: config, seed: seed)
+    }
+    
+    override func getServiceConfig() -> ServiceConfig? {
+        let channelFeeLimitMsat = UserDefaults.standard.integer(forKey: kChannelSetupFeeLimit)
+        logger.log(tag: TAG, line: "Setting channelFeeLimitMsat to \(UInt64(channelFeeLimitMsat))", level: "DEBUG")
+        return ServiceConfig.init(channelFeeLimitMsat: UInt64(channelFeeLimitMsat))
     }
 }

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2000AD59359B91B3C7963B30 /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 590A05D747C4C91AE3779479 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		2B214792005A6D185AF0B44C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FACDE338D59177DD56404E3D /* Pods_Runner.framework */; };
+		35F2EA3A2C522E5BCF3B705A /* ServiceConfig.swift in Resources */ = {isa = PBXBuildFile; fileRef = D5089940E3A84AD08707A5AE /* ServiceConfig.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		54AE10A26ED5F6BFE2132EED /* BreezSDK.swift in Resources */ = {isa = PBXBuildFile; fileRef = 5FA04B52B131437219FBC6F7 /* BreezSDK.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		64856A6CFD043906C9297779 /* TaskProtocol.swift in Resources */ = {isa = PBXBuildFile; fileRef = B9313686B0681E5B408932F1 /* TaskProtocol.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
@@ -28,6 +29,7 @@
 		E84A6BFD2B98E2A700C58F51 /* SdkLogListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84A6BFC2B98E2A700C58F51 /* SdkLogListener.swift */; };
 		E84C89A62B98D96700347527 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84C89A52B98D96700347527 /* KeychainHelper.swift */; };
 		E84F35832B19599500D8302B /* breez_sdkFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E84F35822B19599500D8302B /* breez_sdkFFI.xcframework */; };
+		E850C7DF2BA25D3000C7541B /* ServiceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5089940E3A84AD08707A5AE /* ServiceConfig.swift */; };
 		E87F5EBD2B0E24D7007FB1DF /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87F5EBC2B0E24D7007FB1DF /* NotificationService.swift */; };
 		E87F5EC12B0E24D7007FB1DF /* Breez Notification Service Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E87F5EBA2B0E24D7007FB1DF /* Breez Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E881B7EE2BA07BA3005B2820 /* BreezSDKConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060A529B56DAA097F99B3909 /* BreezSDKConnector.swift */; };
@@ -113,6 +115,7 @@
 		B9313686B0681E5B408932F1 /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/TaskProtocol.swift"; sourceTree = "<group>"; };
 		CC19F65518AB43A8E7DA80C6 /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift"; sourceTree = "<group>"; };
 		D36651BB5596204629B36F7A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		D5089940E3A84AD08707A5AE /* ServiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceConfig.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/ServiceConfig.swift"; sourceTree = "<group>"; };
 		DFD3934DE72A50CD9C7285B7 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Constants.swift"; sourceTree = "<group>"; };
 		E84A6BFC2B98E2A700C58F51 /* SdkLogListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkLogListener.swift; sourceTree = "<group>"; };
 		E84C89A52B98D96700347527 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
@@ -184,6 +187,7 @@
 				590A05D747C4C91AE3779479 /* LnurlPayInvoice.swift */,
 				AD053F37E74B37E059191A04 /* ReceivePayment.swift */,
 				312F74EDBC0577C24D566174 /* RedeemSwap.swift */,
+				D5089940E3A84AD08707A5AE /* ServiceConfig.swift */,
 			);
 			name = BreezSDK;
 			sourceTree = "<group>";
@@ -343,8 +347,8 @@
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
 			packageReferences = (
-				E89C2CD52B0EA0CD0084A5BF /* XCRemoteSwiftPackageReference "KeychainAccess.git" */,
-				6F1E36C22B24C0E800480FB9 /* XCRemoteSwiftPackageReference "XCGLogger.git" */,
+				E89C2CD52B0EA0CD0084A5BF /* XCRemoteSwiftPackageReference "KeychainAccess" */,
+				6F1E36C22B24C0E800480FB9 /* XCRemoteSwiftPackageReference "XCGLogger" */,
 			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
@@ -378,6 +382,7 @@
 				2000AD59359B91B3C7963B30 /* LnurlPayInvoice.swift in Resources */,
 				FAD5AED09BBC79CB53D18356 /* ReceivePayment.swift in Resources */,
 				B35490FF878372F502E52A83 /* RedeemSwap.swift in Resources */,
+				35F2EA3A2C522E5BCF3B705A /* ServiceConfig.swift in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -501,6 +506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E850C7DF2BA25D3000C7541B /* ServiceConfig.swift in Sources */,
 				E881B7EE2BA07BA3005B2820 /* BreezSDKConnector.swift in Sources */,
 				E881B7EF2BA07BA3005B2820 /* Constants.swift in Sources */,
 				E881B7F02BA07BA3005B2820 /* ResourceHelper.swift in Sources */,
@@ -964,7 +970,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		6F1E36C22B24C0E800480FB9 /* XCRemoteSwiftPackageReference "XCGLogger.git" */ = {
+		6F1E36C22B24C0E800480FB9 /* XCRemoteSwiftPackageReference "XCGLogger" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/DaveWoodCom/XCGLogger.git";
 			requirement = {
@@ -972,7 +978,7 @@
 				minimumVersion = 7.0.0;
 			};
 		};
-		E89C2CD52B0EA0CD0084A5BF /* XCRemoteSwiftPackageReference "KeychainAccess.git" */ = {
+		E89C2CD52B0EA0CD0084A5BF /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kishikawakatsumi/KeychainAccess.git";
 			requirement = {

--- a/lib/bloc/payment_options/form_validator.dart
+++ b/lib/bloc/payment_options/form_validator.dart
@@ -41,3 +41,24 @@ String? proportionalFeeValidator(
   }
   return null;
 }
+
+String? channelSetupFeeLimitValidator(
+  String? value,
+) {
+  final texts = getSystemAppLocalizations();
+  if (value == null) {
+    return texts.payment_options_auto_channel_setup_fee_limit_label;
+  }
+  if (value.isEmpty) {
+    return texts.payment_options_auto_channel_setup_fee_limit_label;
+  }
+  try {
+    final newChannelFee = int.parse(value);
+    if (newChannelFee < 0) {
+      return texts.payment_options_auto_channel_setup_fee_limit_label;
+    }
+  } catch (e) {
+    return texts.payment_options_auto_channel_setup_fee_limit_label;
+  }
+  return null;
+}

--- a/lib/bloc/payment_options/payment_options_bloc.dart
+++ b/lib/bloc/payment_options/payment_options_bloc.dart
@@ -15,17 +15,15 @@ class PaymentOptionsBloc extends Cubit<PaymentOptionsState> {
   }
 
   Future<void> setProportionalFee(double proportionalFee) async {
-    emit(state.copyWith(
-      proportionalFee: proportionalFee,
-      saveEnabled: true,
-    ));
+    emit(state.copyWith(proportionalFee: proportionalFee, saveEnabled: true));
   }
 
-  Future<void> setExemptfeeMsat(int exemptfeeMsat) async {
-    emit(state.copyWith(
-      exemptFeeMsat: exemptfeeMsat,
-      saveEnabled: true,
-    ));
+  Future<void> setExemptfeeMsat(int exemptFeeMsat) async {
+    emit(state.copyWith(exemptFeeMsat: exemptFeeMsat, saveEnabled: true));
+  }
+
+  Future<void> setChannelSetupFeeLimitMsat(int channelFeeLimitMsat) async {
+    emit(state.copyWith(channelFeeLimitMsat: channelFeeLimitMsat, saveEnabled: true));
   }
 
   Future<void> resetFees() async {
@@ -33,17 +31,21 @@ class PaymentOptionsBloc extends Cubit<PaymentOptionsState> {
         "proportional: $kDefaultProportionalFee");
     await _preferences.setPaymentOptionsProportionalFee(kDefaultProportionalFee);
     await _preferences.setPaymentOptionsExemptFee(kDefaultExemptFeeMsat);
+    await _preferences.setPaymentOptionsChannelSetupFeeLimit(kDefaultChannelSetupFeeLimitMsat);
     emit(const PaymentOptionsState.initial());
   }
 
   Future<void> saveFees() async {
     final state = this.state;
-    _log.info("Saving payments override settings: enabled:"
-        "proportional: ${state.proportionalFee}"
-        "saved enabled. ${state.saveEnabled}"
-        "Exemptfee: ${state.exemptFeeMsat}");
+    _log.info(
+      "Saving payments override settings: proportionalFee: ${state.proportionalFee} "
+      "exemptFeeMsat: ${state.exemptFeeMsat} "
+      "channelFeeLimitMsat: ${state.channelFeeLimitMsat} "
+      "saveEnabled: ${state.saveEnabled}",
+    );
     await _preferences.setPaymentOptionsProportionalFee(state.proportionalFee);
     await _preferences.setPaymentOptionsExemptFee(state.exemptFeeMsat);
+    await _preferences.setPaymentOptionsChannelSetupFeeLimit(state.channelFeeLimitMsat);
     emit(state.copyWith(saveEnabled: false));
   }
 
@@ -56,13 +58,21 @@ class PaymentOptionsBloc extends Cubit<PaymentOptionsState> {
 
   Future<void> _fetchPaymentsOverrideSettings() async {
     _log.info("Fetching payments override settings");
-    final proportional = await _preferences.getPaymentOptionsProportionalFee();
+    final proportionalFee = await _preferences.getPaymentOptionsProportionalFee();
     final exemptFeeMsat = await _preferences.getPaymentOptionsExemptFee();
-    _log.info("Payments override fetched: proportional: $proportional, exemptFeeMsat: $exemptFeeMsat");
-    emit(PaymentOptionsState(
-      proportionalFee: proportional,
-      exemptFeeMsat: exemptFeeMsat,
-      saveEnabled: false,
-    ));
+    final channelFeeLimitMsat = await _preferences.getPaymentOptionsChannelSetupFeeLimitMsat();
+    _log.info(
+      "Payments override fetched: proportionalFee: $proportionalFee "
+      "exemptFeeMsat: $exemptFeeMsat "
+      "channelFeeLimitMsat: $channelFeeLimitMsat",
+    );
+    emit(
+      PaymentOptionsState(
+        proportionalFee: proportionalFee,
+        exemptFeeMsat: exemptFeeMsat,
+        channelFeeLimitMsat: channelFeeLimitMsat,
+        saveEnabled: false,
+      ),
+    );
   }
 }

--- a/lib/bloc/payment_options/payment_options_state.dart
+++ b/lib/bloc/payment_options/payment_options_state.dart
@@ -3,11 +3,13 @@ import 'package:c_breez/utils/preferences.dart';
 class PaymentOptionsState {
   final double proportionalFee;
   final int exemptFeeMsat;
+  final int channelFeeLimitMsat;
   final bool saveEnabled;
 
   const PaymentOptionsState({
     this.proportionalFee = kDefaultProportionalFee,
     this.exemptFeeMsat = kDefaultExemptFeeMsat,
+    this.channelFeeLimitMsat = kDefaultChannelSetupFeeLimitMsat,
     this.saveEnabled = false,
   });
 
@@ -16,11 +18,13 @@ class PaymentOptionsState {
   PaymentOptionsState copyWith({
     double? proportionalFee,
     int? exemptFeeMsat,
+    int? channelFeeLimitMsat,
     bool? saveEnabled,
   }) {
     return PaymentOptionsState(
       proportionalFee: proportionalFee ?? this.proportionalFee,
       exemptFeeMsat: exemptFeeMsat ?? this.exemptFeeMsat,
+      channelFeeLimitMsat: channelFeeLimitMsat ?? this.channelFeeLimitMsat,
       saveEnabled: saveEnabled ?? this.saveEnabled,
     );
   }

--- a/lib/routes/payment_options/payment_options_page.dart
+++ b/lib/routes/payment_options/payment_options_page.dart
@@ -1,6 +1,7 @@
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
 import 'package:c_breez/routes/payment_options/widget/actions_fee.dart';
+import 'package:c_breez/routes/payment_options/widget/channel_setup_fee_limit.dart';
 import 'package:c_breez/routes/payment_options/widget/exempt_fee_widget.dart';
 import 'package:c_breez/routes/payment_options/widget/header_fee.dart';
 import 'package:c_breez/routes/payment_options/widget/proportional_fee_widget.dart';
@@ -38,8 +39,9 @@ class PaymentOptionsPage extends StatelessWidget {
         body: ListView(
           children: const [
             HeaderFee(),
-            ExemptfeeMsatWidget(),
+            ExemptFeeMsatWidget(),
             ProportionalFeeWidget(),
+            ChannelSetupFeeLimit(),
             ActionsFee(),
           ],
         ),

--- a/lib/routes/payment_options/widget/channel_setup_fee_limit.dart
+++ b/lib/routes/payment_options/widget/channel_setup_fee_limit.dart
@@ -10,19 +10,19 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 import 'package:rxdart/rxdart.dart';
 
-final _log = Logger("ExemptfeeMsatWidget");
+final _log = Logger("ChannelCreationFeeLimit");
 
-class ExemptFeeMsatWidget extends StatefulWidget {
-  const ExemptFeeMsatWidget({
+class ChannelSetupFeeLimit extends StatefulWidget {
+  const ChannelSetupFeeLimit({
     super.key,
   });
 
   @override
-  State<ExemptFeeMsatWidget> createState() => _ExemptfeeMsatState();
+  State<ChannelSetupFeeLimit> createState() => _ChannelSetupFeeLimitState();
 }
 
-class _ExemptfeeMsatState extends State<ExemptFeeMsatWidget> {
-  final _exemptFeeController = TextEditingController();
+class _ChannelSetupFeeLimitState extends State<ChannelSetupFeeLimit> {
+  final _channelSetupFeeLimitController = TextEditingController();
 
   StreamSubscription<PaymentOptionsState>? _subscription;
 
@@ -52,22 +52,23 @@ class _ExemptfeeMsatState extends State<ExemptFeeMsatWidget> {
                 builder: (context, state) {
                   return TextFormField(
                     keyboardType: const TextInputType.numberWithOptions(),
-                    controller: _exemptFeeController,
+                    controller: _channelSetupFeeLimitController,
                     decoration: InputDecoration(
-                      labelText: texts.payment_options_exemptfee_label,
+                      labelText: texts.payment_options_auto_channel_setup_fee_limit_label,
                       border: const UnderlineInputBorder(),
                     ),
-                    validator: exemptFeeValidator,
+                    validator: channelSetupFeeLimitValidator,
                     onChanged: (value) {
                       _log.info("onChanged: $value");
-                      int exemptFeeSat;
+                      int channelCreationFeeLimitSat;
                       try {
-                        exemptFeeSat = int.parse(value);
+                        channelCreationFeeLimitSat = int.parse(value);
                       } catch (_) {
                         _log.info("Failed to parse $value as int");
                         return;
                       }
-                      context.read<PaymentOptionsBloc>().setExemptfeeMsat(exemptFeeSat * 1000);
+                      final bloc = context.read<PaymentOptionsBloc>();
+                      bloc.setChannelSetupFeeLimitMsat(channelCreationFeeLimitSat * 1000);
                     },
                   );
                 },
@@ -83,12 +84,12 @@ class _ExemptfeeMsatState extends State<ExemptFeeMsatWidget> {
     final bloc = context.read<PaymentOptionsBloc>();
     _subscription = bloc.stream.startWith(bloc.state).distinct().listen((state) {
       if (!state.saveEnabled) {
-        final exemptFeeSat = (state.exemptFeeMsat ~/ 1000).toString();
+        final channelFeeLimitMsat = (state.channelFeeLimitMsat ~/ 1000).toString();
 
-        if (_exemptFeeController.text != exemptFeeSat) {
-          _log.info("Setting exemptFee to $exemptFeeSat");
+        if (_channelSetupFeeLimitController.text != channelFeeLimitMsat) {
+          _log.info("Setting channelFeeLimitMsat to $channelFeeLimitMsat");
           setState(() {
-            _exemptFeeController.text = exemptFeeSat;
+            _channelSetupFeeLimitController.text = channelFeeLimitMsat;
           });
         }
       }

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -5,10 +5,12 @@ import 'package:shared_preferences/shared_preferences.dart';
 const kDefaultOverrideFee = false;
 const kDefaultProportionalFee = 1.0;
 const kDefaultExemptFeeMsat = 20000;
+const kDefaultChannelSetupFeeLimitMsat = 5000000;
 
 const _mempoolSpaceUrlKey = "mempool_space_url";
 const _kPaymentOptionProportionalFee = "payment_options_proportional_fee";
 const _kPaymentOptionExemptFee = "payment_options_exempt_fee";
+const _kPaymentOptionChannelSetupFeeLimit = "payment_options_channel_setup_fee_limit";
 const _kReportPrefKey = "report_preference_key";
 
 final _log = Logger("Preferences");
@@ -48,10 +50,21 @@ class Preferences {
     return prefs.getInt(_kPaymentOptionExemptFee) ?? kDefaultExemptFeeMsat;
   }
 
-  Future<void> setPaymentOptionsExemptFee(int exemptfeeMsat) async {
-    _log.info("set payment options exempt fee : $exemptfeeMsat");
+  Future<void> setPaymentOptionsExemptFee(int exemptFeeMsat) async {
+    _log.info("set payment options exempt fee : $exemptFeeMsat");
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(_kPaymentOptionExemptFee, exemptfeeMsat);
+    await prefs.setInt(_kPaymentOptionExemptFee, exemptFeeMsat);
+  }
+
+  Future<int> getPaymentOptionsChannelSetupFeeLimitMsat() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getInt(_kPaymentOptionChannelSetupFeeLimit) ?? kDefaultChannelSetupFeeLimitMsat;
+  }
+
+  Future<void> setPaymentOptionsChannelSetupFeeLimit(int channelFeeLimitMsat) async {
+    _log.info("set payment options channel setup limit fee : $channelFeeLimitMsat");
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setInt(_kPaymentOptionChannelSetupFeeLimit, channelFeeLimitMsat);
   }
 
   Future<BugReportBehavior> getBugReportBehavior() async {

--- a/test/bloc/payment_options/payment_options_bloc_test.dart
+++ b/test/bloc/payment_options/payment_options_bloc_test.dart
@@ -77,6 +77,23 @@ void main() {
     expect(injector.preferencesMock.setPaymentOptionsExemptFeeCalled, 1);
   });
 
+  test('should emit new state when automatic channel setup fee limit changed', () async {
+    final bloc = make();
+    expectLater(
+      bloc.stream,
+      emitsInOrder([
+        const PaymentOptionsState.initial(),
+        const PaymentOptionsState(channelFeeLimitMsat: 5000 * 1000, saveEnabled: true),
+        const PaymentOptionsState(channelFeeLimitMsat: 5000 * 1000),
+      ]),
+    );
+    // Delay to allow the bloc to initialize
+    await Future.delayed(const Duration(milliseconds: 1));
+    await bloc.setChannelSetupFeeLimitMsat(5000 * 1000);
+    await bloc.saveFees();
+    expect(injector.preferencesMock.setPaymentOptionsChannelSetupFeeLimitCalled, 1);
+  });
+
   test('should emit new state when reset fees', () async {
     final bloc = make();
     expectLater(
@@ -99,10 +116,12 @@ void main() {
     await Future.delayed(const Duration(milliseconds: 1));
     await bloc.setProportionalFee(0.01);
     await bloc.setExemptfeeMsat(20000);
+    await bloc.setChannelSetupFeeLimitMsat(5000000);
     await bloc.saveFees();
     await bloc.resetFees();
     expect(injector.preferencesMock.setPaymentOptionsProportionalFeeCalled, 2);
     expect(injector.preferencesMock.setPaymentOptionsExemptFeeCalled, 2);
+    expect(injector.preferencesMock.setPaymentOptionsChannelSetupFeeLimitCalled, 2);
   });
 
   test('cancel editing should clear the unsaved state', () async {
@@ -123,10 +142,12 @@ void main() {
     await Future.delayed(const Duration(milliseconds: 1));
     await bloc.setProportionalFee(0.01);
     await bloc.setExemptfeeMsat(20000);
+    await bloc.setChannelSetupFeeLimitMsat(5000000);
     await bloc.cancelEditing();
     // Delay to allow the fetch to complete
     await Future.delayed(const Duration(milliseconds: 1));
     expect(injector.preferencesMock.setPaymentOptionsProportionalFeeCalled, 0);
     expect(injector.preferencesMock.setPaymentOptionsExemptFeeCalled, 0);
+    expect(injector.preferencesMock.setPaymentOptionsChannelSetupFeeLimitCalled, 0);
   });
 }

--- a/test/mock/preferences_mock.dart
+++ b/test/mock/preferences_mock.dart
@@ -48,4 +48,18 @@ class PreferencesMock extends Mock implements Preferences {
 
   @override
   Future<int> getPaymentOptionsExemptFee() => Future<int>.value(paymentOptionsExemptfee);
+
+  int setPaymentOptionsChannelSetupFeeLimitCalled = 0;
+
+  @override
+  Future<void> setPaymentOptionsChannelSetupFeeLimit(int channelFeeLimitMsat) {
+    setPaymentOptionsChannelSetupFeeLimitCalled++;
+    return Future<void>.value();
+  }
+
+  int paymentOptionsChannelSetupFeeLimit = kDefaultChannelSetupFeeLimitMsat;
+
+  @override
+  Future<int> getPaymentOptionsChannelSetupFeeLimitMsat() =>
+      Future<int>.value(paymentOptionsChannelSetupFeeLimit);
 }


### PR DESCRIPTION
Closes #777

This PR allows users to set a "`Automatic channel setup fee limit"` through **Lightning Fees** page to be able to receive LNURL payments that require a channel setup where the fees fall within that limit. 
On C-Breez, this feature is **enabled** & set to **5000 sats** by default.

Breez SDK PR:
- https://github.com/breez/breez-sdk/pull/833

### Todo:
- If the invoice can not be created due to not enough fees to cover the channel respond with error.

@dangeross @roeierez
Currently, on the extensions we're getting the value from shared preferences but this approach is not directly compatible with extension plugin. To be able to make this compatible with extension plugin, I think a good approach would be:
- Make this part of SDK `Config`
  - Should be disabled and set to 0 by default imo, I'm not sure if this is a decision we should make on behalf of the SDK users
- Use the _automatic channel setup fee limit_ from `Config` that was used on `connect` when setting `maxSendable`
  - This value needs to be accessible internally