### PR TITLE
Deprecate SwapStatus.Expired

### DIFF
--- a/lib/bloc/buy_bitcoin/moonpay/moonpay_bloc.dart
+++ b/lib/bloc/buy_bitcoin/moonpay/moonpay_bloc.dart
@@ -28,7 +28,9 @@ class MoonPayBloc extends Cubit<MoonPayState> {
       if (swapInProgress != null) {
         _log.info("fetchMoonpayUrl swapInfo: $swapInProgress");
         emit(MoonPayState.swapInProgress(
-            swapInProgress.bitcoinAddress, swapInProgress.status == sdk.SwapStatus.Expired));
+          swapInProgress.bitcoinAddress,
+          swapInProgress.status == sdk.SwapStatus.Refundable,
+        ));
         return;
       }
 


### PR DESCRIPTION
This PR addresses breaking changes from swap events.
Breez SDK PR:
- https://github.com/breez/breez-sdk/pull/811