### PR TITLE
Use the correct payment validation for LNURL payments

### DIFF
--- a/lib/routes/lnurl/payment/lnurl_payment_page.dart
+++ b/lib/routes/lnurl/payment/lnurl_payment_page.dart
@@ -266,6 +266,6 @@ class LNURLPaymentPageState extends State<LNURLPaymentPage> {
       channelCreationPossible: lspState?.isChannelOpeningAvailable ?? false,
       channelMinimumFee: channelMinimumFee,
       texts: context.texts(),
-    ).validateIncoming(amount);
+    ).validateOutgoing(amount);
   }
 }

--- a/lib/routes/subswap/swap/widgets/deposit_widget.dart
+++ b/lib/routes/subswap/swap/widgets/deposit_widget.dart
@@ -111,7 +111,7 @@ class _DepositWidgetState extends State<DepositWidget> {
       return texts.invoice_btc_address_channel_not_needed(minFeeFormatted, maxSats);
     } else if (minFeeAboveZero && liquidityAboveZero) {
       // Send more than {minSats} and up to {maxSats} to this address. A setup fee of {setUpFee}% with a minimum of {minFee}
-      // will be applied for sending more than {liquidity}.
+      // will be applied for sending more than {liquidity}. This address can be used only once.
       return texts.invoice_btc_address_warning_with_min_fee_account_connected(
         minSats,
         maxSats,


### PR DESCRIPTION
Fixes #753

The invoice amount was considered an incoming payment during validation by mistake.