### PR TITLE
Reduce default log level from `CONFIG` to `INFO`

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -28,7 +28,7 @@ void shareLog() async {
 
 class BreezLogger {
   BreezLogger() {
-    Logger.root.level = Level.CONFIG;
+    Logger.root.level = Level.INFO;
 
     if (kDebugMode) {
       Logger.root.onRecord.listen((record) {


### PR DESCRIPTION
The `CONFIG` level resulted in logging the sending and receiving of gRPC data frames, which is spamming the logs:

```
[BreezSdk] {CONFIG} (2024-03-13T09:51:00.634293Z) : send frame=Data { stream_id: StreamId(1) }
[BreezSdk] {CONFIG} (2024-03-13T09:51:00.735160Z) : send frame=Data { stream_id: StreamId(1), flags: (0x1: END_STREAM) }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.103566Z) : received frame=Settings { flags: (0x1: ACK) }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.117228Z) : received settings ACK; applying Settings { flags: (0x0), enable_push: 0, initial_window_size: 2097152, max_frame_size: 16384 }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.157191Z) : received frame=WindowUpdate { stream_id: StreamId(0), size_increment: 73 }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.222232Z) : received frame=Headers { stream_id: StreamId(1), flags: (0x4: END_HEADERS) }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.271599Z) : received frame=Data { stream_id: StreamId(1) }
[BreezSdk] {CONFIG} (2024-03-13T09:51:01.346240Z) : received frame=Headers { stream_id: StreamId(1), flags: (0x5: END_HEADERS  | END_STREAM) }
```

These logs appear to be emitted by the lower-level networking calls in flutter. I found no way to specifically target this networking module with a higher log level. @erdemyerebasmaz @ademar111190 if you see a better solution, please let me know.