### PR TITLE
Reduce default log level from `DEBUG` to `INFO` on notification service extensions

### DIFF
--- a/android/app/src/main/resources/tinylog.properties
+++ b/android/app/src/main/resources/tinylog.properties
@@ -1,10 +1,10 @@
 writer          = file
-writer.level    = debug
+writer.level    = info
 writer.format   = [{class}] {opening-curly-bracket}{level}{closing-curly-bracket} ({date: yyyy-MM-dd HH:mm:ss.SSS}) : {message|indent=2}
 writer.file     = #{tinylog.directory}/#{tinylog.timestamp}.android-extension.log
 writer.charset  = UTF-8
 
 #writer2         = logcat
-#writer2.level   = debug
+#writer2.level   = info
 #writer2.format  = [{class}] {opening-curly-bracket}{level}{closing-curly-bracket} ({date: yyyy-MM-dd HH:mm:ss.SSS}) : {message|indent=2}
 #writer2.tagname = {tag}

--- a/android/app/src/main/resources/tinylog.properties
+++ b/android/app/src/main/resources/tinylog.properties
@@ -1,0 +1,10 @@
+writer          = file
+writer.level    = debug
+writer.format   = [{class}] {opening-curly-bracket}{level}{closing-curly-bracket} ({date: yyyy-MM-dd HH:mm:ss.SSS}) : {message|indent=2}
+writer.file     = #{tinylog.directory}/#{tinylog.timestamp}.android-extension.log
+writer.charset  = UTF-8
+
+#writer2         = logcat
+#writer2.level   = debug
+#writer2.format  = [{class}] {opening-curly-bracket}{level}{closing-curly-bracket} ({date: yyyy-MM-dd HH:mm:ss.SSS}) : {message|indent=2}
+#writer2.tagname = {tag}

--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -20,7 +20,7 @@ class NotificationService: SDKNotificationService {
         
         xcgLogger = {
             let log = XCGLogger.default
-            log.setup(level: .debug, showThreadName: true, showLevel: true, showFileNames: true, showLineNumbers: true, writeToFile: extensionLogFile.path)
+            log.setup(level: .info, showThreadName: true, showLevel: true, showFileNames: true, showLineNumbers: true, writeToFile: extensionLogFile.path)
             return log
             
         }()


### PR DESCRIPTION
This PR is a continuation of #817 and re-adds `tinylog.properties` which was overlooked when logging library choices got abstracted from notification service extensions.