### PR TITLE
Set initial default shared preferences

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,11 +10,11 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		2000AD59359B91B3C7963B30 /* LnurlPayInvoice.swift in Resources */ = {isa = PBXBuildFile; fileRef = 590A05D747C4C91AE3779479 /* LnurlPayInvoice.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		2B214792005A6D185AF0B44C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FACDE338D59177DD56404E3D /* Pods_Runner.framework */; };
-		35F2EA3A2C522E5BCF3B705A /* ServiceConfig.swift in Resources */ = {isa = PBXBuildFile; fileRef = D5089940E3A84AD08707A5AE /* ServiceConfig.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		54AE10A26ED5F6BFE2132EED /* BreezSDK.swift in Resources */ = {isa = PBXBuildFile; fileRef = 5FA04B52B131437219FBC6F7 /* BreezSDK.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		64856A6CFD043906C9297779 /* TaskProtocol.swift in Resources */ = {isa = PBXBuildFile; fileRef = B9313686B0681E5B408932F1 /* TaskProtocol.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		6F2FC2C62978272800DC3B60 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 6F2FC2C52978272800DC3B60 /* GoogleService-Info.plist */; };
+		7390B36A2BA4E735008C8C2A /* ServiceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E03BDED83E932CCF7CABB0 /* ServiceConfig.swift */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		79E2E4831EE7835EDE5BA587 /* LnurlPayInfo.swift in Resources */ = {isa = PBXBuildFile; fileRef = F244930C02A323D2895417C7 /* LnurlPayInfo.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		7DC8D850CD1196E851417871 /* SDKNotificationService.swift in Resources */ = {isa = PBXBuildFile; fileRef = 43FADF1A73DF51091D5C226C /* SDKNotificationService.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
@@ -26,10 +26,10 @@
 		BE06D121223B8CF67849843E /* LnurlPay.swift in Resources */ = {isa = PBXBuildFile; fileRef = CC19F65518AB43A8E7DA80C6 /* LnurlPay.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		BE7F6037FEA6310D3CFEDB8E /* ResourceHelper.swift in Resources */ = {isa = PBXBuildFile; fileRef = 0802AE4304169AB3BB9F3B32 /* ResourceHelper.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		D7516952B1670DF4F4B2F7E0 /* Pods_Breez_Notification_Service_Extension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FADA87C19A61025FCA15775A /* Pods_Breez_Notification_Service_Extension.framework */; };
+		DA4F992DA2A2464B0BA60A52 /* ServiceConfig.swift in Resources */ = {isa = PBXBuildFile; fileRef = 50E03BDED83E932CCF7CABB0 /* ServiceConfig.swift */; settings = {ASSET_TAGS = (BreezSDK, ); }; };
 		E84A6BFD2B98E2A700C58F51 /* SdkLogListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84A6BFC2B98E2A700C58F51 /* SdkLogListener.swift */; };
 		E84C89A62B98D96700347527 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E84C89A52B98D96700347527 /* KeychainHelper.swift */; };
 		E84F35832B19599500D8302B /* breez_sdkFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E84F35822B19599500D8302B /* breez_sdkFFI.xcframework */; };
-		E850C7DF2BA25D3000C7541B /* ServiceConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5089940E3A84AD08707A5AE /* ServiceConfig.swift */; };
 		E87F5EBD2B0E24D7007FB1DF /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87F5EBC2B0E24D7007FB1DF /* NotificationService.swift */; };
 		E87F5EC12B0E24D7007FB1DF /* Breez Notification Service Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = E87F5EBA2B0E24D7007FB1DF /* Breez Notification Service Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E881B7EE2BA07BA3005B2820 /* BreezSDKConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 060A529B56DAA097F99B3909 /* BreezSDKConnector.swift */; };
@@ -93,6 +93,7 @@
 		312F74EDBC0577C24D566174 /* RedeemSwap.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RedeemSwap.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Task/RedeemSwap.swift"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
 		43FADF1A73DF51091D5C226C /* SDKNotificationService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SDKNotificationService.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/SDKNotificationService.swift"; sourceTree = "<group>"; };
+		50E03BDED83E932CCF7CABB0 /* ServiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceConfig.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/ServiceConfig.swift"; sourceTree = "<group>"; };
 		590A05D747C4C91AE3779479 /* LnurlPayInvoice.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPayInvoice.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPayInvoice.swift"; sourceTree = "<group>"; };
 		5FA04B52B131437219FBC6F7 /* BreezSDK.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BreezSDK.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDK/BreezSDK.swift"; sourceTree = "<group>"; };
 		6F2FC2C52978272800DC3B60 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -115,7 +116,6 @@
 		B9313686B0681E5B408932F1 /* TaskProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TaskProtocol.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/TaskProtocol.swift"; sourceTree = "<group>"; };
 		CC19F65518AB43A8E7DA80C6 /* LnurlPay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LnurlPay.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Task/LnurlPay.swift"; sourceTree = "<group>"; };
 		D36651BB5596204629B36F7A /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
-		D5089940E3A84AD08707A5AE /* ServiceConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ServiceConfig.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/ServiceConfig.swift"; sourceTree = "<group>"; };
 		DFD3934DE72A50CD9C7285B7 /* Constants.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Constants.swift; path = "../.symlinks/plugins/breez_sdk/ios/bindings-swift/Sources/BreezSDKNotification/Constants.swift"; sourceTree = "<group>"; };
 		E84A6BFC2B98E2A700C58F51 /* SdkLogListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SdkLogListener.swift; sourceTree = "<group>"; };
 		E84C89A52B98D96700347527 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
@@ -187,7 +187,7 @@
 				590A05D747C4C91AE3779479 /* LnurlPayInvoice.swift */,
 				AD053F37E74B37E059191A04 /* ReceivePayment.swift */,
 				312F74EDBC0577C24D566174 /* RedeemSwap.swift */,
-				D5089940E3A84AD08707A5AE /* ServiceConfig.swift */,
+				50E03BDED83E932CCF7CABB0 /* ServiceConfig.swift */,
 			);
 			name = BreezSDK;
 			sourceTree = "<group>";
@@ -382,7 +382,7 @@
 				2000AD59359B91B3C7963B30 /* LnurlPayInvoice.swift in Resources */,
 				FAD5AED09BBC79CB53D18356 /* ReceivePayment.swift in Resources */,
 				B35490FF878372F502E52A83 /* RedeemSwap.swift in Resources */,
-				35F2EA3A2C522E5BCF3B705A /* ServiceConfig.swift in Resources */,
+				DA4F992DA2A2464B0BA60A52 /* ServiceConfig.swift in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,7 +506,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E850C7DF2BA25D3000C7541B /* ServiceConfig.swift in Sources */,
+				7390B36A2BA4E735008C8C2A /* ServiceConfig.swift in Sources */,
 				E881B7EE2BA07BA3005B2820 /* BreezSDKConnector.swift in Sources */,
 				E881B7EF2BA07BA3005B2820 /* Constants.swift in Sources */,
 				E881B7F02BA07BA3005B2820 /* ResourceHelper.swift in Sources */,

--- a/lib/bloc/payment_options/payment_options_bloc.dart
+++ b/lib/bloc/payment_options/payment_options_bloc.dart
@@ -11,7 +11,11 @@ class PaymentOptionsBloc extends Cubit<PaymentOptionsState> {
   PaymentOptionsBloc(
     this._preferences,
   ) : super(const PaymentOptionsState.initial()) {
-    resetPaymentOptions(true);
+    _initializePaymentOptions();
+  }
+
+  void _initializePaymentOptions() async {
+    await _preferences.hasPaymentOptions() ? await _getPaymentOptions() : await setDefaultPaymentOptions();
   }
 
   Future<void> setProportionalFee(double proportionalFee) async {
@@ -29,29 +33,25 @@ class PaymentOptionsBloc extends Cubit<PaymentOptionsState> {
     emit(state.copyWith(channelFeeLimitMsat: channelFeeLimitMsat));
   }
 
-  Future<void> resetPaymentOptions([bool checkPaymentOptions = false]) async {
-    final hasPaymentOptions = await _preferences.hasPaymentOptions();
-    if (!checkPaymentOptions || !hasPaymentOptions) {
-      try {
-        await _preferences.setPaymentOptionsProportionalFee(kDefaultProportionalFee);
-        await _preferences.setPaymentOptionsExemptFee(kDefaultExemptFeeMsat);
-        await _preferences.setPaymentOptionsChannelSetupFeeLimit(kDefaultChannelSetupFeeLimitMsat);
-        _log.info(
-          "Reverted payment options to default values: "
-          "proportionalFee: $kDefaultProportionalFee "
-          "exemptFeeMsat: $kDefaultExemptFeeMsat "
-          "channelFeeLimitMsat: $kDefaultChannelSetupFeeLimitMsat",
-        );
-      } catch (e) {
-        _log.severe("Failed to reset payment options.");
-        rethrow;
-      }
+  Future<void> setDefaultPaymentOptions() async {
+    try {
+      await _preferences.setPaymentOptionsProportionalFee(kDefaultProportionalFee);
+      await _preferences.setPaymentOptionsExemptFee(kDefaultExemptFeeMsat);
+      await _preferences.setPaymentOptionsChannelSetupFeeLimit(kDefaultChannelSetupFeeLimitMsat);
+      emit(const PaymentOptionsState.initial());
+      _log.info(
+        "Set payment options to default values: "
+        "proportionalFee: $kDefaultProportionalFee "
+        "exemptFeeMsat: $kDefaultExemptFeeMsat "
+        "channelFeeLimitMsat: $kDefaultChannelSetupFeeLimitMsat",
+      );
+    } catch (e) {
+      _log.severe("Failed to set default payment options.");
+      rethrow;
     }
-
-    await getPaymentOptions();
   }
 
-  Future<void> getPaymentOptions() async {
+  Future<void> _getPaymentOptions() async {
     final proportionalFee = await _preferences.getPaymentOptionsProportionalFee();
     final exemptFeeMsat = await _preferences.getPaymentOptionsExemptFee();
     final channelFeeLimitMsat = await _preferences.getPaymentOptionsChannelSetupFeeLimitMsat();

--- a/lib/routes/payment_options/widget/actions_fee.dart
+++ b/lib/routes/payment_options/widget/actions_fee.dart
@@ -33,7 +33,7 @@ class ActionsFee extends StatelessWidget {
                 child: Text(texts.payment_options_fee_action_reset),
                 onPressed: () async {
                   try {
-                    await context.read<PaymentOptionsBloc>().resetPaymentOptions();
+                    await context.read<PaymentOptionsBloc>().setDefaultPaymentOptions();
                     formKey.currentState!.reset();
                     if (!context.mounted) return;
                     showFlushbar(context, message: "Reverted fee settings to default values.");

--- a/lib/utils/preferences.dart
+++ b/lib/utils/preferences.dart
@@ -20,6 +20,15 @@ final _log = Logger("Preferences");
 class Preferences {
   const Preferences();
 
+  Future<bool> hasPaymentOptions() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getKeys().containsAll([
+      _kPaymentOptionProportionalFee,
+      _kPaymentOptionExemptFee,
+      _kPaymentOptionChannelSetupFeeLimit,
+    ]);
+  }
+
   Future<String?> getMempoolSpaceUrl() async {
     final prefs = await SharedPreferences.getInstance();
     return prefs.getString(_mempoolSpaceUrlKey);


### PR DESCRIPTION
This PR changes the `PaymentOptionsBloc` to set the initial default shared preferences (in iOS also to the app group UserDefaults) if they are currently not stored. This allows the notification service extension to get the default values from shared preferences.