### PR TITLE
Correct fee affordability calculations for swaps

### DIFF
--- a/lib/models/fee_options/fee_option.dart
+++ b/lib/models/fee_options/fee_option.dart
@@ -32,9 +32,7 @@ abstract class FeeOption {
     }
   }
 
-  bool isAffordable({required int balance, required int amountSat}) {
-    return (amountSat + txFeeSat) < balance;
-  }
+  bool isAffordable({int? balance, int? walletBalance, required int amountSat});
 }
 
 class ReverseSwapFeeOption extends FeeOption {
@@ -48,8 +46,10 @@ class ReverseSwapFeeOption extends FeeOption {
   });
 
   @override
-  bool isAffordable({required int balance, required int amountSat}) {
-    return balance >= pairInfo.senderAmountSat;
+  bool isAffordable({int? balance, int? walletBalance, required int amountSat}) {
+    assert(balance != null);
+
+    return balance! >= pairInfo.senderAmountSat;
   }
 }
 
@@ -59,6 +59,11 @@ class RefundFeeOption extends FeeOption {
     required super.processingSpeed,
     required super.satPerVbyte,
   });
+
+  @override
+  bool isAffordable({int? balance, int? walletBalance, required int amountSat}) {
+    return (amountSat >= txFeeSat);
+  }
 }
 
 class RedeemOnchainFeeOption extends FeeOption {
@@ -67,4 +72,11 @@ class RedeemOnchainFeeOption extends FeeOption {
     required super.processingSpeed,
     required super.satPerVbyte,
   });
+
+  @override
+  bool isAffordable({int? balance, int? walletBalance, required int amountSat}) {
+    assert(walletBalance != null);
+
+    return (walletBalance! >= amountSat);
+  }
 }

--- a/lib/routes/get-refund/refund_confirmation_page.dart
+++ b/lib/routes/get-refund/refund_confirmation_page.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/refund/refund_bloc.dart';
 import 'package:c_breez/models/fee_options/fee_option.dart';
 import 'package:c_breez/routes/get-refund/widgets/refund_button.dart';
@@ -108,10 +107,7 @@ class RefundConfirmationState extends State<RefundConfirmationPage> {
     );
     _fetchFeeOptionsFuture.then((feeOptions) {
       setState(() {
-        final account = context.read<AccountBloc>().state;
-        affordableFees = feeOptions
-            .where((f) => f.isAffordable(balance: account.balance, amountSat: widget.amountSat))
-            .toList();
+        affordableFees = feeOptions.where((f) => f.isAffordable(amountSat: widget.amountSat)).toList();
         selectedFeeIndex = (affordableFees.length / 2).floor();
       });
     });

--- a/lib/routes/withdraw/redeem_onchain_funds/confirmation_page/redeem_onchain_funds_confirmation.dart
+++ b/lib/routes/withdraw/redeem_onchain_funds/confirmation_page/redeem_onchain_funds_confirmation.dart
@@ -91,7 +91,7 @@ class _RedeemOnchainConfirmationPageState extends State<RedeemOnchainConfirmatio
       final account = context.read<AccountBloc>().state;
       setState(() {
         affordableFees = feeOptions
-            .where((f) => f.isAffordable(balance: account.walletBalance, amountSat: widget.amountSat))
+            .where((f) => f.isAffordable(walletBalance: account.walletBalance, amountSat: widget.amountSat))
             .toList();
         selectedFeeIndex = (affordableFees.length / 2).floor();
       });

--- a/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_chooser_header.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_chooser_header.dart
@@ -44,7 +44,8 @@ class _FeeChooserHeaderState extends State<FeeChooserHeader> {
                 index: index,
                 text: feeOption.getDisplayName(texts),
                 isAffordable: feeOption.isAffordable(
-                  balance: (feeOption is ReverseSwapFeeOption) ? account.balance : account.walletBalance,
+                  balance: account.balance,
+                  walletBalance: account.walletBalance,
                   amountSat: widget.amountSat,
                 ),
                 isSelected: widget.selectedFeeIndex == index,


### PR DESCRIPTION
Corrects the fee affordability calculations for refund & redeem onchain.
- Checks if refund amount is greater or equal to tx fees,
- Checks if onchain balance is greater or equal to redeem onchain amount.

I'm not satisfied with the shared Fee widgets & models on swap/reverse swap and plan to go over them to make them more robust at a later date.