### PR TITLE
Listen to swap events to refresh refundables

### DIFF
--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -117,7 +117,7 @@ class RefundBloc extends Cubit<RefundState> {
           toAddress: toAddress,
           satPerVbyte: recommendedFee,
         );
-        final fee = await prepareRefund(req);
+        final fee = await _prepareRefund(req);
 
         return RefundFeeOption(
           processingSpeed: ProcessingSpeed.values.elementAt(index),
@@ -130,7 +130,7 @@ class RefundBloc extends Cubit<RefundState> {
     return feeOptions;
   }
 
-  Future<int> prepareRefund(PrepareRefundRequest req) async {
+  Future<int> _prepareRefund(PrepareRefundRequest req) async {
     _log.info("Refunding swap ${req.swapAddress} to ${req.toAddress} with fee ${req.satPerVbyte}");
     try {
       final resp = await _breezSDK.prepareRefund(req: req);

--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -23,6 +23,7 @@ class RefundBloc extends Cubit<RefundState> {
     late final StreamSubscription streamSubscription;
     streamSubscription = _breezSDK.nodeStateStream.where((nodeState) => nodeState != null).listen(
       (nodeState) async {
+        _log.info('Initialize RefundBloc');
         listRefundables();
         streamSubscription.cancel();
       },
@@ -45,13 +46,8 @@ class RefundBloc extends Cubit<RefundState> {
 
   _listenSwapEvents() {
     _breezSDK.swapEventsStream.listen((event) {
-      if (event is BreezEvent_SwapUpdated) {
-        _log.info('Got SwapUpdate event: $event');
-        var swapInfo = event.details;
-        if (swapInfo.status == SwapStatus.Refundable || swapInfo.status == SwapStatus.Completed) {
-          listRefundables();
-        }
-      }
+      _log.info('Got SwapUpdate event: $event');
+      listRefundables();
     }, onError: (e) {
       _log.severe('Failed to listen swapEventsStream: $e');
     });

--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -35,13 +35,10 @@ class RefundBloc extends Cubit<RefundState> {
       _log.info('Refreshing refundables');
       var refundables = await _breezSDK.listRefundables();
       _log.info('Refundables: $refundables');
-      emit(state.copyWith(refundables: refundables, refundablesError: ""));
+      emit(state.copyWith(refundables: refundables));
     } catch (e) {
       _log.severe('Failed to list refundables: $e');
-      emit(state.copyWith(
-        refundables: null,
-        refundablesError: extractExceptionMessage(e, getSystemAppLocalizations()),
-      ));
+      emit(state.copyWith(refundables: null));
       rethrow;
     }
   }
@@ -57,7 +54,6 @@ class RefundBloc extends Cubit<RefundState> {
       }
     }, onError: (e) {
       _log.severe('Failed to listen swapEventsStream: $e');
-      emit(state.copyWith(refundablesError: extractExceptionMessage(e, getSystemAppLocalizations())));
     });
   }
 
@@ -69,11 +65,11 @@ class RefundBloc extends Cubit<RefundState> {
     try {
       final refundResponse = await _breezSDK.refund(req: req);
       _log.info("Refund txId: ${refundResponse.refundTxId}");
-      emit(state.copyWith(refundTxId: refundResponse.refundTxId, refundError: ""));
+      emit(state.copyWith(refundTxId: refundResponse.refundTxId, error: ""));
       return refundResponse.refundTxId;
     } catch (e) {
       _log.severe("Failed to refund swap", e);
-      emit(state.copyWith(refundError: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(error: extractExceptionMessage(e, getSystemAppLocalizations())));
       rethrow;
     }
   }
@@ -97,7 +93,7 @@ class RefundBloc extends Cubit<RefundState> {
       );
     } catch (e) {
       _log.severe("fetchRefundFeeOptions error", e);
-      emit(state.copyWith(refundError: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(error: extractExceptionMessage(e, getSystemAppLocalizations())));
       rethrow;
     }
   }

--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -35,10 +35,13 @@ class RefundBloc extends Cubit<RefundState> {
       _log.info('Refreshing refundables');
       var refundables = await _breezSDK.listRefundables();
       _log.info('Refundables: $refundables');
-      emit(state.copyWith(refundables: refundables));
+      emit(state.copyWith(refundables: refundables, refundablesError: ""));
     } catch (e) {
       _log.severe('Failed to list refundables: $e');
-      emit(state.copyWith(refundables: null, error: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(
+        refundables: null,
+        refundablesError: extractExceptionMessage(e, getSystemAppLocalizations()),
+      ));
       rethrow;
     }
   }
@@ -54,7 +57,7 @@ class RefundBloc extends Cubit<RefundState> {
       }
     }, onError: (e) {
       _log.severe('Failed to listen swapEventsStream: $e');
-      emit(state.copyWith(error: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(refundablesError: extractExceptionMessage(e, getSystemAppLocalizations())));
     });
   }
 
@@ -66,11 +69,11 @@ class RefundBloc extends Cubit<RefundState> {
     try {
       final refundResponse = await _breezSDK.refund(req: req);
       _log.info("Refund txId: ${refundResponse.refundTxId}");
-      emit(state.copyWith(refundTxId: refundResponse.refundTxId));
+      emit(state.copyWith(refundTxId: refundResponse.refundTxId, refundError: ""));
       return refundResponse.refundTxId;
     } catch (e) {
       _log.severe("Failed to refund swap", e);
-      emit(state.copyWith(error: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(refundError: extractExceptionMessage(e, getSystemAppLocalizations())));
       rethrow;
     }
   }
@@ -94,7 +97,7 @@ class RefundBloc extends Cubit<RefundState> {
       );
     } catch (e) {
       _log.severe("fetchRefundFeeOptions error", e);
-      emit(state.copyWith(error: extractExceptionMessage(e, getSystemAppLocalizations())));
+      emit(state.copyWith(refundError: extractExceptionMessage(e, getSystemAppLocalizations())));
       rethrow;
     }
   }

--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -66,7 +66,7 @@ class RefundBloc extends Cubit<RefundState> {
     try {
       final refundResponse = await _breezSDK.refund(req: req);
       _log.info("Refund txId: ${refundResponse.refundTxId}");
-      emit(RefundState(refundTxId: refundResponse.refundTxId));
+      emit(state.copyWith(refundTxId: refundResponse.refundTxId));
       return refundResponse.refundTxId;
     } catch (e) {
       _log.severe("Failed to refund swap", e);

--- a/lib/bloc/refund/refund_state.dart
+++ b/lib/bloc/refund/refund_state.dart
@@ -15,8 +15,9 @@ class RefundState {
     String? error,
   }) {
     return RefundState(
-        refundables: refundables ?? this.refundables,
-        refundTxId: refundTxId ?? this.refundTxId,
-        error: error ?? this.error);
+      refundables: refundables ?? this.refundables,
+      refundTxId: refundTxId ?? this.refundTxId,
+      error: error ?? this.error,
+    );
   }
 }

--- a/lib/bloc/refund/refund_state.dart
+++ b/lib/bloc/refund/refund_state.dart
@@ -3,14 +3,12 @@ import 'package:breez_sdk/bridge_generated.dart';
 class RefundState {
   final List<SwapInfo>? refundables;
   final String? refundTxId;
-  final String? refundablesError;
-  final String? refundError;
+  final String? error;
 
   RefundState({
     this.refundables,
     this.refundTxId,
-    this.refundablesError = "",
-    this.refundError = "",
+    this.error = "",
   });
 
   RefundState.initial() : this();
@@ -18,14 +16,12 @@ class RefundState {
   RefundState copyWith({
     List<SwapInfo>? refundables,
     String? refundTxId,
-    String? refundablesError,
-    String? refundError,
+    String? error,
   }) {
     return RefundState(
       refundables: refundables ?? this.refundables,
       refundTxId: refundTxId ?? this.refundTxId,
-      refundablesError: refundablesError ?? this.refundablesError,
-      refundError: refundError ?? this.refundError,
+      error: error ?? this.error,
     );
   }
 }

--- a/lib/bloc/refund/refund_state.dart
+++ b/lib/bloc/refund/refund_state.dart
@@ -3,21 +3,29 @@ import 'package:breez_sdk/bridge_generated.dart';
 class RefundState {
   final List<SwapInfo>? refundables;
   final String? refundTxId;
-  final String? error;
+  final String? refundablesError;
+  final String? refundError;
 
-  RefundState({this.refundables, this.refundTxId, this.error = ""});
+  RefundState({
+    this.refundables,
+    this.refundTxId,
+    this.refundablesError = "",
+    this.refundError = "",
+  });
 
   RefundState.initial() : this();
 
   RefundState copyWith({
     List<SwapInfo>? refundables,
     String? refundTxId,
-    String? error,
+    String? refundablesError,
+    String? refundError,
   }) {
     return RefundState(
       refundables: refundables ?? this.refundables,
       refundTxId: refundTxId ?? this.refundTxId,
-      error: error ?? this.error,
+      refundablesError: refundablesError ?? this.refundablesError,
+      refundError: refundError ?? this.refundError,
     );
   }
 }

--- a/lib/routes/get-refund/get_refund_page.dart
+++ b/lib/routes/get-refund/get_refund_page.dart
@@ -35,9 +35,7 @@ class _GetRefundPageState extends State<GetRefundPage> {
         builder: (context, refundState) {
           final refundables = refundState.refundables;
           if (refundables == null || refundables.isEmpty) {
-            return Center(
-              child: Text(texts.get_refund_no_refundable_items),
-            );
+            return Center(child: Text(texts.get_refund_no_refundable_items));
           }
 
           return ListView.builder(
@@ -48,9 +46,7 @@ class _GetRefundPageState extends State<GetRefundPage> {
                 padding: const EdgeInsets.all(12.0),
                 child: Column(
                   children: [
-                    RefundItem(
-                      refundables.elementAt(index),
-                    ),
+                    RefundItem(refundables.elementAt(index)),
                     const Divider(
                       height: 0.0,
                       color: Color.fromRGBO(255, 255, 255, 0.52),


### PR DESCRIPTION
closes #834 

Refundable list is refreshed once node connects on start up and after on receiving swap events for swaps with Refundable & Completed status.

Breez SDK PR: 
- https://github.com/breez/breez-sdk/pull/876

![example workflow](https://github.com/breez/c-breez/actions/workflows/CI.yml/badge.svg?branch=swap_events_stream)