### PR TITLE
Handle node related connectivity issues

### DIFF
--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -139,6 +139,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     } catch (e) {
       _log.warning("failed to connect to breez lib", e);
       emit(state.copyWith(connectionStatus: ConnectionStatus.DISCONNECTED));
+      rethrow;
     }
   }
 

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -79,6 +79,7 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
     bool restored = false,
   }) async {
     _log.info("connect new mnemonic: ${mnemonic != null}, restored: $restored");
+    emit(state.copyWith(connectionStatus: ConnectionStatus.CONNECTING));
     if (mnemonic != null) {
       await _credentialsManager.storeMnemonic(mnemonic: mnemonic);
       emit(state.copyWith(

--- a/lib/handlers/node_connectivity_handler.dart
+++ b/lib/handlers/node_connectivity_handler.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:another_flushbar/flushbar.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/account/account_bloc.dart';
+import 'package:c_breez/bloc/account/account_state.dart';
+import 'package:c_breez/handlers/handler.dart';
+import 'package:c_breez/handlers/handler_context_provider.dart';
+import 'package:c_breez/theme/theme_provider.dart' as theme;
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger("NodeConnectivityHandler");
+
+class NodeConnectivityHandler extends Handler {
+  StreamSubscription<AccountState>? _subscription;
+  Flushbar? _flushbar;
+
+  @override
+  void init(HandlerContextProvider<StatefulWidget> contextProvider) {
+    super.init(contextProvider);
+    _subscription = contextProvider
+        .getBuildContext()!
+        .read<AccountBloc>()
+        .stream
+        .distinct((previous, next) =>
+            previous.connectionStatus == next.connectionStatus ||
+            next.connectionStatus == ConnectionStatus.CONNECTING)
+        .listen((a) => _listen(a.connectionStatus));
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _subscription?.cancel();
+    _subscription = null;
+    _flushbar = null;
+  }
+
+  void _listen(ConnectionStatus? connectionStatus) async {
+    _log.info("Received accountState $connectionStatus");
+    if (connectionStatus == ConnectionStatus.DISCONNECTED) {
+      showDisconnectedFlushbar();
+    } else if (connectionStatus == ConnectionStatus.CONNECTED) {
+      dismissFlushbarIfNeed();
+    }
+  }
+
+  void showDisconnectedFlushbar() {
+    dismissFlushbarIfNeed();
+    final context = contextProvider?.getBuildContext();
+    if (context == null) {
+      _log.info("Skipping connection flushbar as context is null");
+      return;
+    }
+    _flushbar = _getDisconnectedFlushbar(context);
+    _flushbar?.show(context);
+  }
+
+  void dismissFlushbarIfNeed() {
+    final flushbar = _flushbar;
+    if (flushbar == null) return;
+
+    if (flushbar.isShowing() || flushbar.isAppearing()) {
+      flushbar.dismiss(true);
+    }
+    _flushbar = null;
+  }
+
+  Flushbar? _getDisconnectedFlushbar(BuildContext context) {
+    return Flushbar(
+      isDismissible: false,
+      flushbarPosition: FlushbarPosition.TOP,
+      icon: Icon(
+        Icons.warning_amber_outlined,
+        size: 28.0,
+        color: Theme.of(context).colorScheme.error,
+      ),
+      messageText: Text(
+        context.texts().handler_channel_connection_message,
+        style: theme.snackBarStyle,
+        textAlign: TextAlign.center,
+      ),
+      mainButton: SizedBox(
+        width: 64,
+        child: StreamBuilder<AccountState>(
+          stream: context.read<AccountBloc>().stream,
+          builder: (context, snapshot) {
+            if (snapshot.hasData && snapshot.data?.connectionStatus == ConnectionStatus.CONNECTING) {
+              return Center(
+                child: SizedBox(
+                  height: 24.0,
+                  width: 24.0,
+                  child: CircularProgressIndicator(
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                ),
+              );
+            }
+            return TextButton(
+              onPressed: () {
+                final accountBloc = context.read<AccountBloc>();
+                Future.delayed(const Duration(milliseconds: 500), () async {
+                  try {
+                    await accountBloc.connect(restored: true);
+                  } catch (error) {
+                    _log.severe("Failed to reconnect");
+                    rethrow;
+                  }
+                });
+              },
+              child: Text(
+                context.texts().no_connection_flushbar_action_retry,
+                style: theme.snackBarStyle.copyWith(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+      backgroundColor: theme.snackBarBackgroundColor,
+    );
+  }
+}

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -7,6 +7,7 @@ import 'package:c_breez/handlers/handler.dart';
 import 'package:c_breez/handlers/handler_context_provider.dart';
 import 'package:c_breez/handlers/health_check_handler.dart';
 import 'package:c_breez/handlers/input_handler.dart';
+import 'package:c_breez/handlers/node_connectivity_handler.dart';
 import 'package:c_breez/handlers/payment_result_handler.dart';
 import 'package:c_breez/routes/home/account_page.dart';
 import 'package:c_breez/routes/home/widgets/app_bar/home_app_bar.dart';
@@ -49,6 +50,7 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
           _scaffoldKey,
         ),
         ConnectivityHandler(),
+        NodeConnectivityHandler(),
         PaymentResultHandler(),
         HealthCheckHandler(),
       ]);

--- a/lib/routes/initial_walkthrough/initial_walkthrough.dart
+++ b/lib/routes/initial_walkthrough/initial_walkthrough.dart
@@ -174,8 +174,10 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
         mnemonic: mnemonic ?? bip39.generateMnemonic(strength: 128),
         restored: isRestore,
       );
+      themeProvider.setTheme('dark');
+      navigator.pushReplacementNamed('/');
     } catch (error) {
-      _log.info("Failed to ${isRestore ? "restore" : "registe"} node", error);
+      _log.info("Failed to ${isRestore ? "restore" : "register"} node", error);
       if (isRestore) {
         _restoreNodeFromMnemonicSeed(initialWords: mnemonic.split(" "));
       }
@@ -185,9 +187,6 @@ class InitialWalkthroughPageState extends State<InitialWalkthroughPage>
     } finally {
       navigator.removeRoute(loaderRoute);
     }
-
-    themeProvider.setTheme('dark');
-    navigator.pushReplacementNamed('/');
   }
 
   void _restoreNodeFromMnemonicSeed({


### PR DESCRIPTION
This PR introduces bug fixes & improvements to node connection failures.

##### Changelist:
- Do not navigate to home page if registration fails 83536a2381d1117ba00ce671de7435caf35aacdf
  - Throw errors during connecting to SDK
- Create NodeConnectivityHandler to notify the user when their node is disconnected 831f80669f77b40de2bce3b0b6f59270df6c3ce3 
    - Display a flushbar on top with a manual retry option*
- Change `ConnectionStatus` immediately on calling connect 91bf6604d31877134776cd95ffa3787e64b3ca43
  - Connection status changes will reflect without delay on reconnect attempts

##### UI:
<img width="50%" alt="image" src="https://github.com/breez/c-breez/assets/4012752/cbe81361-cf1f-4bf6-bc0c-25ee14ffdd80">