### PR TITLE
Update dependencies to latest

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -7,6 +7,7 @@ PODS:
     - Flutter
   - connectivity_plus (0.0.1):
     - Flutter
+    - FlutterMacOS
     - ReachabilitySwift
   - device_info_plus (0.0.1):
     - Flutter
@@ -18,14 +19,14 @@ PODS:
   - Firebase/Messaging (10.22.0):
     - Firebase/CoreOnly
     - FirebaseMessaging (~> 10.22.0)
-  - firebase_core (2.27.0):
+  - firebase_core (2.27.1):
     - Firebase/CoreOnly (= 10.22.0)
     - Flutter
-  - firebase_dynamic_links (5.4.17):
+  - firebase_dynamic_links (5.4.18):
     - Firebase/DynamicLinks (= 10.22.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (14.7.19):
+  - firebase_messaging (14.7.20):
     - Firebase/Messaging (= 10.22.0)
     - firebase_core
     - Flutter
@@ -33,11 +34,11 @@ PODS:
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
-  - FirebaseCoreInternal (10.22.0):
+  - FirebaseCoreInternal (10.23.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
   - FirebaseDynamicLinks (10.22.0):
     - FirebaseCore (~> 10.0)
-  - FirebaseInstallations (10.22.0):
+  - FirebaseInstallations (10.23.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
@@ -124,8 +125,6 @@ PODS:
   - KeychainAccess (4.2.2)
   - local_auth_darwin (0.0.1):
     - Flutter
-  - local_auth_ios (0.0.1):
-    - Flutter
   - MLImage (1.0.0-beta4)
   - MLKitBarcodeScanning (3.0.0):
     - MLKitCommon (~> 9.0)
@@ -162,7 +161,7 @@ PODS:
     - Flutter
     - FlutterMacOS
   - PromisesObjC (2.4.0)
-  - ReachabilitySwift (5.0.0)
+  - ReachabilitySwift (5.2.1)
   - share_plus (0.0.1):
     - Flutter
   - shared_preference_app_group (1.0.0):
@@ -199,7 +198,7 @@ DEPENDENCIES:
   - app_group_directory (from `.symlinks/plugins/app_group_directory/ios`)
   - breez_sdk (from `.symlinks/plugins/breez_sdk/ios`)
   - clipboard_watcher (from `.symlinks/plugins/clipboard_watcher/ios`)
-  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
+  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/darwin`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - firebase_core (from `.symlinks/plugins/firebase_core/ios`)
   - firebase_dynamic_links (from `.symlinks/plugins/firebase_dynamic_links/ios`)
@@ -214,7 +213,6 @@ DEPENDENCIES:
   - integration_test (from `.symlinks/plugins/integration_test/ios`)
   - KeychainAccess
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
-  - local_auth_ios (from `.symlinks/plugins/local_auth_ios/ios`)
   - mobile_scanner (from `.symlinks/plugins/mobile_scanner/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
@@ -262,7 +260,7 @@ EXTERNAL SOURCES:
   clipboard_watcher:
     :path: ".symlinks/plugins/clipboard_watcher/ios"
   connectivity_plus:
-    :path: ".symlinks/plugins/connectivity_plus/ios"
+    :path: ".symlinks/plugins/connectivity_plus/darwin"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   firebase_core:
@@ -289,8 +287,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/integration_test/ios"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
-  local_auth_ios:
-    :path: ".symlinks/plugins/local_auth_ios/ios"
   mobile_scanner:
     :path: ".symlinks/plugins/mobile_scanner/ios"
   package_info_plus:
@@ -314,16 +310,16 @@ SPEC CHECKSUMS:
   app_group_directory: 7bf9f8f9819ead554de29da7c25fb7a680d6a9a0
   breez_sdk: 7db178e91142798ad861ecbbd0ccad8201d2fb85
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
-  connectivity_plus: bf0076dd84a130856aa636df1c71ccaff908fa1d
-  device_info_plus: c6fb39579d0f423935b0c9ce7ee2f44b71b9fce6
+  connectivity_plus: e2dad488011aeb593e219360e804c43cc1af5770
+  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
   Firebase: 797fd7297b7e1be954432743a0b3f90038e45a71
-  firebase_core: 100945864b4aedce3cfef0c62ab864858bf013cf
-  firebase_dynamic_links: 6149c6fc3790997eb8a392074e5ee4974840942b
-  firebase_messaging: e65050bf9b187511d80ea3a4de7cf5573d2c7543
+  firebase_core: d6dfb4cb86a9ebd92464bb8736075fe967211c97
+  firebase_dynamic_links: 9129abba70e20f931bac9c2d630ab8a68cacb591
+  firebase_messaging: f97062a3a7644703ba4892859183c0a59e08d25f
   FirebaseCore: 0326ec9b05fbed8f8716cddbf0e36894a13837f7
-  FirebaseCoreInternal: bca337352024b18424a61e478460547d46c4c753
+  FirebaseCoreInternal: 6a292e6f0bece1243a737e81556e56e5e19282e3
   FirebaseDynamicLinks: 25ed0e87b0afb4769cc0ec8e942a532219abac28
-  FirebaseInstallations: 763814908793c0da14c18b3dcffdec71e29ed55e
+  FirebaseInstallations: 42d6ead4605d6eafb3b6683674e80e18eb6f2c35
   FirebaseMessaging: 9f71037fd9db3376a4caa54e5a3949d1027b4b6e
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
@@ -341,7 +337,6 @@ SPEC CHECKSUMS:
   integration_test: 13825b8a9334a850581300559b8839134b124670
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   local_auth_darwin: c7e464000a6a89e952235699e32b329457608d98
-  local_auth_ios: 5046a18c018dd973247a0564496c8898dbb5adf9
   MLImage: 7bb7c4264164ade9bf64f679b40fb29c8f33ee9b
   MLKitBarcodeScanning: 04e264482c5f3810cb89ebc134ef6b61e67db505
   MLKitCommon: c1b791c3e667091918d91bda4bba69a91011e390
@@ -350,11 +345,11 @@ SPEC CHECKSUMS:
   nanopb: 438bc412db1928dac798aa6fd75726007be04262
   ObjcExceptionBridging: c30e00eb3700467e695faeea30e26e18bd445001
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
-  package_info_plus: 115f4ad11e0698c8c1c5d8a689390df880f47e85
+  package_info_plus: 58f0028419748fad15bf008b270aaa8e54380b1c
   path_provider_foundation: 3784922295ac71e43754bd15e0653ccfd36a147c
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  share_plus: c3fef564749587fc939ef86ffb283ceac0baf9f5
+  ReachabilitySwift: 5ae15e16814b5f9ef568963fb2c87aeb49158c66
+  share_plus: 8875f4f2500512ea181eef553c3e27dba5135aad
   shared_preference_app_group: 83d2284f9e747839c40fc281403b5b60d83e2989
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   sqlite3: 73b7fc691fdc43277614250e04d183740cb15078

--- a/lib/bloc/account/account_bloc.dart
+++ b/lib/bloc/account/account_bloc.dart
@@ -95,10 +95,11 @@ class AccountBloc extends Cubit<AccountState> with HydratedMixin {
 
     // in case we failed to start (lack of inet connection probably)
     if (state.connectionStatus == ConnectionStatus.DISCONNECTED) {
-      StreamSubscription<ConnectivityResult>? subscription;
+      StreamSubscription<List<ConnectivityResult>>? subscription;
       subscription = Connectivity().onConnectivityChanged.listen((event) async {
         // we should try fetch the selected lsp information when internet is back.
-        if (event != ConnectivityResult.none && state.connectionStatus == ConnectionStatus.DISCONNECTED) {
+        if (event.contains(ConnectivityResult.none) &&
+            state.connectionStatus == ConnectionStatus.DISCONNECTED) {
           await _startSdkOnce();
           if (state.connectionStatus == ConnectionStatus.CONNECTED) {
             subscription!.cancel();

--- a/lib/bloc/connectivity/connectivity_bloc.dart
+++ b/lib/bloc/connectivity/connectivity_bloc.dart
@@ -18,13 +18,13 @@ class ConnectivityBloc extends Cubit<ConnectivityState> {
     _watchConnectivityChanges().listen((status) => emit(ConnectivityState(lastStatus: status)));
   }
 
-  Stream<ConnectivityResult> _watchConnectivityChanges() {
+  Stream<List<ConnectivityResult>> _watchConnectivityChanges() {
     return _connectivity.onConnectivityChanged
         .asyncMap((status) async => await _updateConnectionStatus(status));
   }
 
   Future<ConnectivityState> checkConnectivity() async {
-    late ConnectivityResult result;
+    late List<ConnectivityResult> result;
     try {
       result = await _updateConnectionStatus(await _connectivity.checkConnectivity());
     } on PlatformException catch (e) {
@@ -36,15 +36,15 @@ class ConnectivityBloc extends Cubit<ConnectivityState> {
     return connectivityState;
   }
 
-  Future<ConnectivityResult> _updateConnectionStatus(ConnectivityResult connectionStatus) async {
-    _log.info("Connection status changed to: ${connectionStatus.name}");
-    if (connectionStatus != ConnectivityResult.none) {
+  Future<List<ConnectivityResult>> _updateConnectionStatus(List<ConnectivityResult> connectionResult) async {
+    _log.info("Connection status changed to: $connectionResult");
+    if (!connectionResult.contains(ConnectivityResult.none)) {
       bool isDeviceConnected = await _isConnected();
       if (!isDeviceConnected) {
-        return connectionStatus;
+        return connectionResult;
       }
     }
-    return connectionStatus;
+    return connectionResult;
   }
 
   Future<bool> _isConnected() async {

--- a/lib/bloc/connectivity/connectivity_state.dart
+++ b/lib/bloc/connectivity/connectivity_state.dart
@@ -1,7 +1,7 @@
 import 'package:connectivity_plus/connectivity_plus.dart';
 
 class ConnectivityState {
-  final ConnectivityResult? lastStatus;
+  final List<ConnectivityResult>? lastStatus;
   final bool isConnecting;
 
   ConnectivityState({this.lastStatus, this.isConnecting = false});

--- a/lib/bloc/lsp/lsp_bloc.dart
+++ b/lib/bloc/lsp/lsp_bloc.dart
@@ -23,7 +23,7 @@ class LSPBloc extends Cubit<LspState?> {
 
     Connectivity().onConnectivityChanged.listen((event) {
       // we should try fetch the selected lsp information when internet is back.
-      if (event != ConnectivityResult.none && state?.lspInfo == null && state?.selectedLspId != null) {
+      if (event.contains(ConnectivityResult.none) && state?.lspInfo == null && state?.selectedLspId != null) {
         _refreshLspInfo();
       }
     });

--- a/lib/bloc/security/security_bloc.dart
+++ b/lib/bloc/security/security_bloc.dart
@@ -8,7 +8,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:local_auth/local_auth.dart';
 import 'package:local_auth_android/local_auth_android.dart';
-import 'package:local_auth_ios/types/auth_messages_ios.dart';
+import 'package:local_auth_darwin/types/auth_messages_ios.dart';
 import 'package:logging/logging.dart';
 
 class SecurityBloc extends Cubit<SecurityState> with HydratedMixin {

--- a/lib/handlers/connectivity_handler.dart
+++ b/lib/handlers/connectivity_handler.dart
@@ -39,7 +39,8 @@ class ConnectivityHandler extends Handler {
 
   void _listen(ConnectivityState connectivityState) async {
     _log.info("Received connectivityState $connectivityState");
-    if (connectivityState.lastStatus == ConnectivityResult.none) {
+    if (connectivityState.lastStatus != null &&
+        connectivityState.lastStatus!.contains(ConnectivityResult.none)) {
       showNoInternetConnectionFlushbar();
     } else {
       dismissFlushbarIfNeed();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: "4eec93681221723a686ad580c2e7d960e1017cf1a4e0a263c2573c2c6b0bf5cd"
+      sha256: "554f148e71e9e016d9c04d4af6b103ca3f74a1ceed7d7307b70a0f41e991eb77"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.25"
+    version: "1.3.26"
   analyzer:
     dependency: transitive
     description:
@@ -237,18 +237,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: "224a77051d52a11fbad53dd57827594d3bd24f945af28bd70bab376d68d437f0"
+      sha256: e9feae83b1849f61bad9f6f33ee00646e3410d54ce0821e02f262f9901dad3c9
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.2"
+    version: "6.0.1"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: cf1d1c28f4416f8c654d7dc3cd638ec586076255d407cef3ddbdaf178272a71a
+      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.4"
+    version: "2.0.0"
   convert:
     dependency: transitive
     description:
@@ -269,10 +269,10 @@ packages:
     dependency: transitive
     description:
       name: cross_file
-      sha256: fedaadfa3a6996f75211d835aaeb8fede285dae94262485698afd832371b9a5e
+      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.3+8"
+    version: "0.3.4+1"
   crypto:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
+      sha256: "50fb435ed30c6d2525cbfaaa0f46851ea6131315f213c0d921b0e407b34e3b84"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.2"
+    version: "10.0.1"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -421,10 +421,10 @@ packages:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "53316975310c8af75a96e365f9fccb67d1c544ef0acdbf0d88bbe30eedd1c4f9"
+      sha256: "67bf0d5fd78f12f51c6b54a72f6141314136a1a90e98b1b7c45e7fac883254ed"
       url: "https://pub.dev"
     source: hosted
-    version: "2.27.0"
+    version: "2.27.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
@@ -437,50 +437,50 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: c8e1d59385eee98de63c92f961d2a7062c5d9a65e7f45bdc7f1b0b205aab2492
+      sha256: "5377eaac3b9fe8aaf22638d87f92b62784f23572e132dfc029195e84d6cb37de"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.5"
+    version: "2.12.0"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      sha256: daa5fabca10d50b3beee577995b29ab148b02b4d7845dc37c6036d5a5a40f653
+      sha256: "6f8180d1641ba274e241a690cd12d1163fdec75d807aa9daa37c27489e7ad3f7"
       url: "https://pub.dev"
     source: hosted
-    version: "5.4.17"
+    version: "5.4.18"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: e77a36ad8d2b8e0333eaa35a3a706530dfe8f46bf774fab963b5ada115c70d76
+      sha256: "8b6c1827488fa1af56e9a4834ee9e356c510e35d89d1839761064eabad951cbb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+25"
+    version: "0.2.6+26"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: e41586e0fd04fe9a40424f8b0053d0832e6d04f49e020cdaf9919209a28497e9
+      sha256: "34fac43b70d5c41dc864eeb52417128da1f68b0a48604a0c56cd3190f0f609b8"
       url: "https://pub.dev"
     source: hosted
-    version: "14.7.19"
+    version: "14.7.20"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: f7a9d74ff7fc588a924f6b2eaeaa148b0db521b13a9db55f6ad45864fa98c06e
+      sha256: "1dcf7d0d6776396bb2e488c53b0e4cc671c45a65717a73d881e52190d23aca3c"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.27"
+    version: "4.5.28"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: fc21e771166860c55b103701c5ac7cdb2eec28897b97c42e6e5703cbedf9e02e
+      sha256: ceabccf24d15d03c89dfd6c7eaef11c58fbf00b9c76ebc94028408943b8d2bfd
       url: "https://pub.dev"
     source: hosted
-    version: "3.6.8"
+    version: "3.7.0"
   fixnum:
     dependency: transitive
     description:
@@ -797,10 +797,10 @@ packages:
     dependency: "direct main"
     description:
       name: http
-      sha256: a2bbf9d017fcced29139daa8ed2bba4ece450ab222871df93ca9eec6f80c34ba
+      sha256: "761a297c042deedc1ffbb156d6e2af13886bb305c2a343a4d972504cd67dd938"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   http_client_helper:
     dependency: transitive
     description:
@@ -885,10 +885,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: e2423c53a68b579a7c37a1eda967b8ae536c3d98518e5db95ca1fe5719a730a3
+      sha256: "6a1704fdd75022272e7e7a897a9068e9c2ff3cd6a66820bf3ded810633eac954"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   image_picker_ios:
     dependency: transitive
     description:
@@ -1023,21 +1023,13 @@ packages:
     source: hosted
     version: "1.0.37"
   local_auth_darwin:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: local_auth_darwin
       sha256: "33381a15b0de2279523eca694089393bb146baebdce72a404555d03174ebc1e9"
       url: "https://pub.dev"
     source: hosted
     version: "1.2.2"
-  local_auth_ios:
-    dependency: "direct main"
-    description:
-      name: local_auth_ios
-      sha256: "6dde47dc852bc0c8343cb58e66a46efb16b62eddf389ce103d4dacb0c6c40c71"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.1.7"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -1146,10 +1138,10 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: "88bc797f44a94814f2213db1c9bd5badebafdfb8290ca9f78d4b9ee2a3db4d79"
+      sha256: cb44f49b6e690fa766f023d5b22cac6b9affe741dd792b6ac7ad4fabe0d7b097
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.1"
+    version: "6.0.0"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1330,10 +1322,10 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: "3ef39599b00059db0990ca2e30fca0a29d8b37aae924d60063f8e0184cf20900"
+      sha256: "05ec043470319bfbabe0adbc90d3a84cbff0426b9d9f3a6e2ad3e131fa5fa629"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.2"
+    version: "8.0.2"
   share_plus_platform_interface:
     dependency: transitive
     description:
@@ -1394,10 +1386,10 @@ packages:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "7b15ffb9387ea3e237bb7a66b8a23d2147663d391cafc5c8f37b2e7b4bde5d21"
+      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.2"
+    version: "2.3.0"
   shared_preferences_windows:
     dependency: transitive
     description:
@@ -1719,10 +1711,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: fff0932192afeedf63cdd50ecbb1bc825d31aed259f02bb8dba0f3b729a5e88b
+      sha256: "3692a459204a33e04bc94f5fb91158faf4f2c8903281ddd82915adecdb1a901d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1791,18 +1783,18 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "4188706108906f002b3a293509234588823c8c979dc83304e229ff400c996b05"
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.2"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      sha256: "939ab60734a4f8fa95feacb55804fa278de28bdeef38e616dc08e44a84adea23"
+      sha256: "1d8e795e2a8b3730c41b8a98a2dff2e0fb57ae6f0764a1c46ec5915387d257b2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.3"
+    version: "2.4.4"
   webdriver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,19 +28,19 @@ dependencies:
       ref: 132840f2dcee3f24584c26b10d716da3fdf1f1c8
   clipboard_watcher: ^0.2.1
   csv: ^6.0.0
-  connectivity_plus: ^5.0.2
-  device_info_plus: ^9.1.2
+  connectivity_plus: ^6.0.1
+  device_info_plus: ^10.0.1
   drag_and_drop_lists: ^0.3.3
   duration: ^3.0.13
   email_validator: ^2.1.17
   extended_image: ^8.2.0
-  ffi: ^2.1.2 # requires Dart >=3.3.0(Flutter 3.19)
+  ffi: ^2.1.2
   # Doesn't support: Linux Windows
-  firebase_core: ^2.27.0 # package_info_plus >=5.0.1 is incompatible with firebase_core >=2.27.1.
+  firebase_core: ^2.27.1
   # Doesn't support: Linux Mac Windows
-  firebase_dynamic_links: ^5.4.17 # package_info_plus >=5.0.1 is incompatible with firebase_dynamic_links >=5.4.18.
+  firebase_dynamic_links: ^5.4.18
   # Doesn't support: Linux Windows
-  firebase_messaging: ^14.7.19 # package_info_plus >=5.0.1 is incompatible with firebase_messaging >=14.7.20.
+  firebase_messaging: ^14.7.20
   flutter_bloc: ^8.1.4
   # Doesn't support: Linux Mac Windows
   flutter_fgbg:
@@ -57,7 +57,7 @@ dependencies:
       ref: a16aa4deeff1c5e96c6da46da31cb0533f838d8d
   git_info: ^1.1.2
   hex: ^0.2.0
-  http: ^1.2.0 # package_info_plus >=5.0.1 is incompatible with http >=1.2.1.
+  http: ^1.2.1
   hydrated_bloc: ^9.1.4
   image: ^4.1.7
   # Doesn't support: Linux Mac Windows
@@ -65,27 +65,27 @@ dependencies:
   # Doesn't support: Linux Mac Windows
   image_picker: ^1.0.7
   ini: ^2.1.0
-  intl: ^0.19.0 # local_auth & breez_translations depends on intl ^0.18.0
+  intl: ^0.19.0
   # Doesn't support: Linux Mac
   local_auth: ^2.2.0
   local_auth_android: ^1.0.37
-  local_auth_ios: ^1.1.7
+  local_auth_darwin: ^1.2.2
   logging: ^1.2.0
   mockito: ^5.4.4
   # Doesn't support: Linux Windows
   mobile_scanner: ^4.0.1
-  package_info_plus: ^5.0.1
+  package_info_plus: ^6.0.0
   path: ^1.9.0
   path_provider: ^2.1.2
   path_provider_platform_interface: ^2.1.2
   plugin_platform_interface: ^2.1.8
   qr_flutter: ^4.1.0
   rxdart: ^0.27.7
-  share_plus: ^7.2.2
+  share_plus: ^8.0.2
   shared_preferences: ^2.2.2
   shared_preference_app_group: ^1.0.0+1 # iOS Notification Service extension requirement to access shared preferences
   simple_animations: ^5.0.2
-  sqflite_common_ffi: ^2.3.2+1
+  sqflite_common_ffi: ^2.3.3
   sqlite3_flutter_libs: ^0.5.20
   synchronized: ^3.1.0+1
   theme_provider: ^0.6.0
@@ -106,8 +106,8 @@ dev_dependencies:
 
 dependency_overrides:
   test_api: ^0.7.0
+  intl: ^0.19.0 # intl is pinned to version 0.18.1 by flutter_localizations from the flutter SDK.
   # Comment-out to work with breez-sdk from git repository
-  intl: ^0.19.0 # local_auth & breez_translations depends on intl ^0.18.0
   breez_sdk:
     path: ../breez-sdk/libs/sdk-flutter
 


### PR DESCRIPTION
Updates dependencies to latest & resolves breaking changes introduced in:
- [connectivity_plus 6.0.1](https://pub.dev/packages/connectivity_plus/changelog#601)
  - **BREAKING FEAT**(connectivity_plus): support multiple connectivity types at the same time ([#2599](https://github.com/fluttercommunity/plus_plugins/issues/2599)). ([5b477468](https://github.com/fluttercommunity/plus_plugins/commit/5b4774683d6e186fbd69cf4208302221f52aa54d))
- [local_auth 2.2.0](https://pub.dev/packages/local_auth/changelog#220)
  - Switches endorsed iOS implementation to local_auth_darwin.
  - Clients directly importing local_auth_ios for auth strings should switch dependencies and imports to local_auth_darwin. No other change is necessary.