### PR TITLE
Filter out node logs below Info level

### DIFF
--- a/android/app/src/main/kotlin/com/cBreez/client/BreezForegroundService.kt
+++ b/android/app/src/main/kotlin/com/cBreez/client/BreezForegroundService.kt
@@ -4,6 +4,7 @@ import android.content.SharedPreferences
 import breez_sdk.ConnectRequest
 import breez_sdk.EnvironmentType
 import breez_sdk.GreenlightNodeConfig
+import breez_sdk.LevelFilter
 import breez_sdk.LogEntry
 import breez_sdk.NodeConfig
 import breez_sdk.defaultConfig
@@ -33,7 +34,7 @@ class BreezForegroundService : ForegroundService() {
         super.onCreate()
         Logger.tag(TAG).debug { "Creating Breez foreground service..." }
         registerNotificationChannels(applicationContext, DEFAULT_CLICK_ACTION)
-        val sdkLogListener = SdkLogInitializer.initializeNodeLogStream()
+        val sdkLogListener = SdkLogInitializer.initializeNodeLogStream(LevelFilter.DEBUG)
         sdkLogListener.subscribe(serviceScope) { l: LogEntry ->
             when (l.level) {
                 "ERROR" -> Logger.tag(TAG).error { l.line }

--- a/ios/Breez Notification Service Extension/NotificationService.swift
+++ b/ios/Breez Notification Service Extension/NotificationService.swift
@@ -31,7 +31,7 @@ class NotificationService: SDKNotificationService {
         setLogger(logger: logger)
         // Use the same SdkLogListener(:LogStream) to listen in on BreezSDK node logs
         do {
-            try setLogStream(logStream: logger)
+            try setLogStream(logStream: logger, filterLevel: LevelFilter.debug)
         } catch let e {
             self.logger.log(tag: TAG, line:"Failed to set log stream: \(e)", level: "ERROR")
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/credentials_manager.dart';
 import 'package:c_breez/bloc/backup/backup_bloc.dart';
@@ -53,7 +54,7 @@ void main() async {
     var breezLogger = injector.breezLogger;
     final breezSDK = injector.breezSDK;
     if (!await breezSDK.isInitialized()) {
-      breezSDK.initialize();
+      breezSDK.initialize(filterLevel: LevelFilter.Debug);
       breezLogger.registerBreezSdkLog(breezSDK);
     }
 


### PR DESCRIPTION
![Build iOS](https://github.com/breez/c-breez/actions/workflows/build-ios.yml/badge.svg?branch=logger_flutter)![Build Android](https://github.com/breez/c-breez/actions/workflows/build-android.yml/badge.svg?branch=logger_flutter)![Run CI](https://github.com/breez/c-breez/actions/workflows/CI.yml/badge.svg?branch=logger_flutter)
--- 
This PR applies filter level customization changes on logger from Breez SDK PR:
- https://github.com/breez/breez-sdk/pull/874

which addresses the issue raised on: 
- https://github.com/breez/c-breez/pull/817

where we were receiving unwanted SDK module logs as the filtering mechanism previously did not apply to them on binding loggers.

---

Reducing default log level from `CONFIG` to `INFO` had unwanted side effects such as missing out on node logs as they were all emitted on `Debug` level on the SDK, corresponds to `CONFIG` level on app layer, which got addressed by increasing their level to `Info` but this is a temporary fix that did not address the underlying issue.

The logs that are coming from modules were still not filtered and we were missing out on helpful logs on `Debug` level across the SDK, notification extensions and app. Also, since notification extensions & SDK uses the same log stream, there was no way to differentiate between their filter levels. Which are all addressed by this & SDK PR.

Currently, we don't miss information from `Debug` level logs & unwanted SDK module logs are filtered out.

---

#### Changelist:
- Filter out node logs below Debug level on extensions 872c81d76fb0126520fea799312a5ac5992f0c8f
- Filter out node logs below Debug level on app bb979cabbae747efaa3ae7012c160074def5050e
  - Increase default log level back to `CONFIG` from `INFO`