### PR TITLE
Temporary solutions to log large strings & certain SDK classes

### DIFF
--- a/lib/bloc/input/input_bloc.dart
+++ b/lib/bloc/input/input_bloc.dart
@@ -18,7 +18,6 @@ class InputBloc extends Cubit<InputState> {
   final BreezSDK _breezSDK;
   final LightningLinksService _lightningLinks;
   final Device _device;
-  final InputPrinter _printer;
 
   final _decodeInvoiceController = StreamController<InputData>();
 
@@ -26,7 +25,6 @@ class InputBloc extends Cubit<InputState> {
     this._breezSDK,
     this._lightningLinks,
     this._device,
-    this._printer,
   ) : super(const InputState.empty()) {
     _initializeInputBloc();
   }
@@ -97,7 +95,7 @@ class InputBloc extends Cubit<InputState> {
   }
 
   Future<InputState> _handleParsedInput(InputType parsedInput, InputSource source) async {
-    _log.info("handleParsedInput: $source => ${_printer.inputTypeToString(parsedInput)}");
+    _log.info("handleParsedInput: $source => ${inputTypeToString(parsedInput)}");
     InputState result;
     if (parsedInput is InputType_Bolt11) {
       result = await handlePaymentRequest(parsedInput, source);

--- a/lib/bloc/input/input_printer.dart
+++ b/lib/bloc/input/input_printer.dart
@@ -1,75 +1,111 @@
 import 'package:breez_sdk/bridge_generated.dart';
 
-class InputPrinter {
-  const InputPrinter();
-
-  String inputTypeToString(InputType inputType) {
-    if (inputType is InputType_BitcoinAddress) {
-      return _bitcoinAddressToString(inputType);
-    } else if (inputType is InputType_Bolt11) {
-      return _bolt11ToString(inputType);
-    } else if (inputType is InputType_NodeId) {
-      return _nodeIdToString(inputType);
-    } else if (inputType is InputType_Url) {
-      return _urlToString(inputType);
-    } else if (inputType is InputType_LnUrlPay) {
-      return _lnUrlPayToString(inputType);
-    } else if (inputType is InputType_LnUrlWithdraw) {
-      return _lnUrlWithdrawToString(inputType);
-    } else if (inputType is InputType_LnUrlAuth) {
-      return _lnUrlAuthToString(inputType);
-    } else if (inputType is InputType_LnUrlError) {
-      return _lnUrlErrorToString(inputType);
-    } else {
-      return "Unknown InputType";
-    }
-  }
-
-  String _bitcoinAddressToString(InputType_BitcoinAddress inputType) {
-    final data = inputType.address;
-    return "BitcoinAddress(address: ${data.address}, network: ${data.network}, amountSat: ${data.amountSat}, "
-        "label: ${data.label}, message: ${data.message})";
-  }
-
-  String _bolt11ToString(InputType_Bolt11 inputType) {
-    final data = inputType.invoice;
-    return "Bolt11(invoice: ${data.bolt11}, paymentHash: ${data.paymentHash}, "
-        "description: ${data.description}, amountMsat: ${data.amountMsat}, expiry: ${data.expiry}, "
-        "payeePubkey: ${data.payeePubkey}, descriptionHash: ${data.descriptionHash}, "
-        "timestamp: ${data.timestamp}, routingHints: ${data.routingHints}, "
-        "paymentSecret: ${data.paymentSecret})";
-  }
-
-  String _nodeIdToString(InputType_NodeId inputType) {
-    return "NodeId(nodeId: ${inputType.nodeId})";
-  }
-
-  String _urlToString(InputType_Url inputType) {
-    return "Url(url: ${inputType.url})";
-  }
-
-  String _lnUrlPayToString(InputType_LnUrlPay inputType) {
-    final data = inputType.data;
-    return "LnUrlPayRequestData(callback: ${data.callback}, minSendable: ${data.minSendable}, "
-        "maxSendable: ${data.maxSendable}, metadata: ${data.metadataStr}, "
-        "commentAllowed: ${data.commentAllowed}, domain: ${data.domain}, lnAddr: ${data.lnAddress})";
-  }
-
-  String _lnUrlWithdrawToString(InputType_LnUrlWithdraw inputType) {
-    final data = inputType.data;
-    return "LnUrlWithdrawRequestData(callback: ${data.callback}, minWithdrawable: ${data.minWithdrawable}, "
-        "maxWithdrawable: ${data.maxWithdrawable}, defaultDescription: ${data.defaultDescription}, "
-        "k1: ${data.k1})";
-  }
-
-  String _lnUrlAuthToString(InputType_LnUrlAuth inputType) {
-    final data = inputType.data;
-    return "LnUrlAuthRequestData(k1: ${data.k1}, action: ${data.action}, domain: ${data.domain}, "
-        "url: ${data.url})";
-  }
-
-  String _lnUrlErrorToString(InputType_LnUrlError inputType) {
-    final data = inputType.data;
-    return "LnUrlError(reason: ${data.reason})";
+String inputTypeToString(InputType inputType) {
+  if (inputType is InputType_BitcoinAddress) {
+    return _bitcoinAddressToString(inputType);
+  } else if (inputType is InputType_Bolt11) {
+    return _bolt11ToString(inputType);
+  } else if (inputType is InputType_NodeId) {
+    return _nodeIdToString(inputType);
+  } else if (inputType is InputType_Url) {
+    return _urlToString(inputType);
+  } else if (inputType is InputType_LnUrlPay) {
+    return _lnUrlPayToString(inputType);
+  } else if (inputType is InputType_LnUrlWithdraw) {
+    return _lnUrlWithdrawToString(inputType);
+  } else if (inputType is InputType_LnUrlAuth) {
+    return _lnUrlAuthToString(inputType);
+  } else if (inputType is InputType_LnUrlError) {
+    return _lnUrlErrorToString(inputType);
+  } else {
+    return "Unknown InputType";
   }
 }
+
+String inputDataToString(dynamic data) {
+  if (data is BitcoinAddressData) {
+    return _bitcoinAddressDataToString(data);
+  } else if (data is LNInvoice) {
+    return _lnInvoiceToString(data);
+  } else if (data is LnUrlPayRequestData) {
+    return _lnUrlPayRequestDataToString(data);
+  } else if (data is LnUrlWithdrawRequestData) {
+    return _lnUrlWithdrawRequestDataToString(data);
+  } else if (data is LnUrlAuthRequestData) {
+    return _lnUrlAuthRequestDataToString(data);
+  } else if (data is LnUrlErrorData) {
+    return _lnUrlErrorDataToString(data);
+  } else {
+    return "Unknown InputType";
+  }
+}
+
+String _bitcoinAddressToString(InputType_BitcoinAddress inputType) {
+  final data = inputType.address;
+  return _bitcoinAddressDataToString(data);
+}
+
+String _bitcoinAddressDataToString(BitcoinAddressData data) {
+  return "BitcoinAddressData(address: ${data.address}, network: ${data.network}, amountSat: ${data.amountSat}, "
+      "label: ${data.label}, message: ${data.message})";
+}
+
+String _bolt11ToString(InputType_Bolt11 inputType) {
+  final data = inputType.invoice;
+  return _lnInvoiceToString(data);
+}
+
+String _lnInvoiceToString(LNInvoice data) {
+  return "LNInvoice(invoice: ${data.bolt11}, paymentHash: ${data.paymentHash}, "
+      "description: ${data.description}, amountMsat: ${data.amountMsat}, expiry: ${data.expiry}, "
+      "payeePubkey: ${data.payeePubkey}, descriptionHash: ${data.descriptionHash}, "
+      "timestamp: ${data.timestamp}, routingHints: ${data.routingHints}, "
+      "paymentSecret: ${data.paymentSecret})";
+}
+
+String _nodeIdToString(InputType_NodeId inputType) {
+  return "NodeId(nodeId: ${inputType.nodeId})";
+}
+
+String _urlToString(InputType_Url inputType) {
+  return "Url(url: ${inputType.url})";
+}
+
+String _lnUrlPayToString(InputType_LnUrlPay inputType) {
+  final data = inputType.data;
+  return _lnUrlPayRequestDataToString(data);
+}
+
+String _lnUrlPayRequestDataToString(LnUrlPayRequestData data) {
+  return "LnUrlPayRequestData(callback: ${data.callback}, minSendable: ${data.minSendable}, "
+      "maxSendable: ${data.maxSendable}, metadata: ${data.metadataStr}, "
+      "commentAllowed: ${data.commentAllowed}, domain: ${data.domain}, lnAddr: ${data.lnAddress})";
+}
+
+String _lnUrlWithdrawToString(InputType_LnUrlWithdraw inputType) {
+  final data = inputType.data;
+  return _lnUrlWithdrawRequestDataToString(data);
+}
+
+String _lnUrlWithdrawRequestDataToString(LnUrlWithdrawRequestData data) {
+  return "LnUrlWithdrawRequestData(callback: ${data.callback}, minWithdrawable: ${data.minWithdrawable}, "
+      "maxWithdrawable: ${data.maxWithdrawable}, defaultDescription: ${data.defaultDescription}, "
+      "k1: ${data.k1})";
+}
+
+String _lnUrlAuthToString(InputType_LnUrlAuth inputType) {
+  final data = inputType.data;
+  return _lnUrlAuthRequestDataToString(data);
+}
+
+String _lnUrlAuthRequestDataToString(LnUrlAuthRequestData data) {
+  return "LnUrlAuthRequestData(k1: ${data.k1}, action: ${data.action}, domain: ${data.domain}, "
+      "url: ${data.url})";
+}
+
+String _lnUrlErrorToString(InputType_LnUrlError inputType) {
+  final data = inputType.data;
+  return _lnUrlErrorDataToString(data);
+}
+
+String _lnUrlErrorDataToString(LnUrlErrorData data) => "LnUrlErrorData(reason: ${data.reason})";

--- a/lib/bloc/input/input_state.dart
+++ b/lib/bloc/input/input_state.dart
@@ -1,4 +1,5 @@
 import 'package:breez_sdk/bridge_generated.dart';
+import 'package:c_breez/bloc/input/input_printer.dart';
 import 'package:c_breez/bloc/input/input_source.dart';
 import 'package:c_breez/models/invoice.dart';
 
@@ -119,7 +120,7 @@ class LnUrlPayInputState extends InputState {
 
   @override
   String toString() {
-    return 'LnUrlPayInputState{data: $data, source: $source}';
+    return 'LnUrlPayInputState{data: ${inputDataToString(data)}, source: $source}';
   }
 
   @override
@@ -145,7 +146,7 @@ class LnUrlWithdrawInputState extends InputState {
 
   @override
   String toString() {
-    return 'LnUrlWithdrawInputState{data: $data, source: $source}';
+    return 'LnUrlWithdrawInputState{data: ${inputDataToString(data)}, source: $source}';
   }
 
   @override
@@ -171,7 +172,7 @@ class LnUrlAuthInputState extends InputState {
 
   @override
   String toString() {
-    return 'LnUrlAuthInputState{data: $data, source: $source}';
+    return 'LnUrlAuthInputState{data: ${inputDataToString(data)}, source: $source}';
   }
 
   @override
@@ -197,7 +198,7 @@ class LnUrlErrorInputState extends InputState {
 
   @override
   String toString() {
-    return 'LnUrlErrorInputState{data: $data, source: $source}';
+    return 'LnUrlErrorInputState{data: ${inputDataToString(data)}, source: $source}';
   }
 
   @override
@@ -249,7 +250,7 @@ class BitcoinAddressInputState extends InputState {
 
   @override
   String toString() {
-    return 'BitcoinAddressInputState{data: $data, source: $source}';
+    return 'BitcoinAddressInputState{data: ${inputDataToString(data)}, source: $source}';
   }
 
   @override

--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -26,6 +26,11 @@ void shareLog() async {
   Share.shareXFiles([zipFile]);
 }
 
+void printWrapped(Logger log, String text) {
+  final pattern = RegExp('.{1,800}'); // 800 is the size of each chunk
+  pattern.allMatches(text).forEach((match) => log.info(match.group(0)));
+}
+
 class BreezLogger {
   BreezLogger() {
     Logger.root.level = Level.INFO;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -12,7 +12,6 @@ import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/error_report_bloc/error_report_bloc.dart';
 import 'package:c_breez/bloc/health_check/health_check_bloc.dart';
 import 'package:c_breez/bloc/input/input_bloc.dart';
-import 'package:c_breez/bloc/input/input_printer.dart';
 import 'package:c_breez/bloc/lsp/lsp_bloc.dart';
 import 'package:c_breez/bloc/network/network_settings_bloc.dart';
 import 'package:c_breez/bloc/payment_options/payment_options_bloc.dart';
@@ -88,7 +87,6 @@ void main() async {
               breezSDK,
               injector.lightningLinks,
               injector.device,
-              const InputPrinter(),
             ),
           ),
           BlocProvider<UserProfileBloc>(

--- a/lib/routes/qr_scan/widgets/qr_scan.dart
+++ b/lib/routes/qr_scan/widgets/qr_scan.dart
@@ -45,7 +45,7 @@ class QRScanState extends State<QRScan> {
                     onDetect: (capture) {
                       final List<Barcode> barcodes = capture.barcodes;
                       for (final barcode in barcodes) {
-                        _log.info("Barcode detected: $barcode");
+                        _log.info("Barcode detected. ${barcode.displayValue}");
                         if (popped) {
                           _log.info("Skipping, already popped");
                           return;
@@ -59,7 +59,7 @@ class QRScanState extends State<QRScan> {
                           _log.warning("Failed to scan QR code.");
                         } else {
                           popped = true;
-                          _log.info("Popping read QR code $code");
+                          _log.info("Popping read QR code: $code");
                           Navigator.of(context).pop(code);
                         }
                       }

--- a/lib/utils/sdk_fields/serializer_helper.dart
+++ b/lib/utils/sdk_fields/serializer_helper.dart
@@ -1,0 +1,23 @@
+import 'package:breez_sdk/bridge_generated.dart';
+
+/// Temporary toString implementations for SDK fields
+String swapInfoToString(SwapInfo? swapInfo) {
+  return (swapInfo == null)
+      ? ""
+      : "SwapInfo { bitcoinAddress: ${swapInfo.bitcoinAddress}, createdAt: ${swapInfo.createdAt}, lockHeight:"
+          " ${swapInfo.lockHeight}, paymentHash: ${swapInfo.paymentHash}, preimage: ${swapInfo.preimage}, "
+          "privateKey: ${swapInfo.privateKey}, publicKey: ${swapInfo.publicKey}, swapperPublicKey: ${swapInfo.swapperPublicKey}, "
+          "script: ${swapInfo.script}, bolt11: ${swapInfo.bolt11}, paidMsat: ${swapInfo.paidMsat}, totalIncomingTxs: ${swapInfo.totalIncomingTxs}, "
+          "confirmedSats: ${swapInfo.confirmedSats}, unconfirmedSats: ${swapInfo.unconfirmedSats}, status: ${swapInfo.status}, "
+          "refundTxIds: ${swapInfo.refundTxIds}, unconfirmedTxIds: ${swapInfo.unconfirmedTxIds}, minAllowedDeposit: ${swapInfo.minAllowedDeposit}, "
+          "maxAllowedDeposit: ${swapInfo.maxAllowedDeposit}, lastRedeemError: ${swapInfo.lastRedeemError}, channelOpeningFees: ${ofpToString(swapInfo.channelOpeningFees)}, "
+          "confirmedAt: ${swapInfo.confirmedAt} }";
+}
+
+String ofpToString(OpeningFeeParams? ofp) {
+  return (ofp == null)
+      ? ""
+      : "OpeningFeeParams { minMsat: ${ofp.minMsat}, minMsat: ${ofp.minMsat}, "
+          "proportional: ${ofp.proportional}, validUntil: ${ofp.validUntil}, maxIdleTime: ${ofp.maxIdleTime}, "
+          "maxIdleTime: ${ofp.maxIdleTime}, maxClientToSelfDelay: ${ofp.maxClientToSelfDelay}, promise: ${ofp.promise} }";
+}

--- a/test/bloc/input/input_bloc_test.dart
+++ b/test/bloc/input/input_bloc_test.dart
@@ -1,6 +1,5 @@
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:c_breez/bloc/input/input_bloc.dart';
-import 'package:c_breez/bloc/input/input_printer.dart';
 import 'package:c_breez/bloc/input/input_source.dart';
 import 'package:c_breez/bloc/input/input_state.dart';
 import 'package:c_breez/services/injector.dart';
@@ -41,7 +40,7 @@ void main() {
           "VCEKGEFCVG6KXDFJV9JRYFN5V9NN6MR0VA5KUZPFUCA";
       final parsedInput = await breezSDK.parseInput(input: input) as InputType_LnUrlPay;
 
-      final bloc = InputBloc(breezSDK, injector.lightningLinks, injector.device, const InputPrinter());
+      final bloc = InputBloc(breezSDK, injector.lightningLinks, injector.device);
       breezSDK.nodeInfo();
 
       expectLater(


### PR DESCRIPTION
This PR addresses the issue where large logs that are truncated. They are now printed in chunks.

- Add helper method `printWrapped` to log large strings,
- Add helper methods to print certain SDK classes
  - `SwapInfo` & `OpeningFeeParams`. These will be used on in progress reverse swap/swap bloc revision PR.
- Get rid of `InputPrinter` and make it's methods globally accessible
  - Add `inputDataToString` helper method
  
  
  