### PR TITLE
Set "https://mempool.space/" as default mempool url on app layer

### DIFF
--- a/lib/bloc/network/network_settings_bloc.dart
+++ b/lib/bloc/network/network_settings_bloc.dart
@@ -89,7 +89,7 @@ class NetworkSettingsBloc extends Cubit<NetworkSettingsState> with HydratedMixin
     ));
   }
 
-  Future<String> get mempoolInstance async {
+  Future<String?> get mempoolInstance async {
     String? mempoolInstance = await ServiceInjector().preferences.getMempoolSpaceUrl();
     if (mempoolInstance == null) {
       final config = await Config.instance();

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -15,12 +15,12 @@ class Config {
 
   final sdk.Config sdkConfig;
   final sdk.NodeConfig nodeConfig;
-  final String defaultMempoolUrl;
+  final String? defaultMempoolUrl;
 
   Config._({
     required this.sdkConfig,
     required this.nodeConfig,
-    required this.defaultMempoolUrl,
+    this.defaultMempoolUrl,
   });
 
   static Future<Config> instance({
@@ -33,7 +33,7 @@ class Config {
       final breezSDK = injector.breezSDK;
       final breezConfig = await _getBundledConfig();
       final defaultConf = await _getDefaultConf(breezSDK, breezConfig.apiKey, breezConfig.nodeConfig);
-      final defaultMempoolUrl = defaultConf.mempoolspaceUrl;
+      final defaultMempoolUrl = defaultConf.mempoolspaceUrl ?? "https://mempool.space/";
       final sdkConfig = await getSDKConfig(injector, defaultConf, breezConfig);
 
       _instance = Config._(
@@ -99,7 +99,7 @@ class Config {
     return configuredExemptFee;
   }
 
-  static Future<String> _mempoolSpaceUrl(
+  static Future<String?> _mempoolSpaceUrl(
     ServiceInjector serviceInjector,
     sdk.Config defaultConf,
   ) async {

--- a/lib/routes/get-refund/widgets/refund_item_action.dart
+++ b/lib/routes/get-refund/widgets/refund_item_action.dart
@@ -34,7 +34,7 @@ class _RefundItemActionState extends State<RefundItemAction> {
 
     return FutureBuilder(
       future: networkSettingsBloc.mempoolInstance,
-      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+      builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
           return const Loader();
         }

--- a/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
+++ b/lib/routes/home/widgets/payments_list/dialog/closed_channel_payment_details.dart
@@ -22,9 +22,9 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
     final texts = context.texts();
     final networkSettingsBloc = context.read<NetworkSettingsBloc>();
 
-    return FutureBuilder<String>(
+    return FutureBuilder<String?>(
       future: networkSettingsBloc.mempoolInstance,
-      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+      builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
         if (snapshot.connectionState != ConnectionState.done) {
           return const Loader();
         }
@@ -44,7 +44,9 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
                   paymentMinutiae.closingTxid != null) ...[
                 TxWidget(
                   txURL: BlockChainExplorerUtils().formatTransactionUrl(
-                      txid: paymentMinutiae.closingTxid!, mempoolInstance: mempoolInstance),
+                    txid: paymentMinutiae.closingTxid!,
+                    mempoolInstance: mempoolInstance,
+                  ),
                   txID: paymentMinutiae.closingTxid!,
                 ),
               ],
@@ -67,14 +69,18 @@ class ClosedChannelPaymentDetailsWidget extends StatelessWidget {
             if (paymentMinutiae.fundingTxid != null) ...[
               TxWidget(
                 txURL: BlockChainExplorerUtils().formatTransactionUrl(
-                    txid: paymentMinutiae.fundingTxid!, mempoolInstance: mempoolInstance),
+                  txid: paymentMinutiae.fundingTxid!,
+                  mempoolInstance: mempoolInstance,
+                ),
                 txID: paymentMinutiae.fundingTxid!,
               ),
             ],
             if (paymentMinutiae.closingTxid != null) ...[
               TxWidget(
                 txURL: BlockChainExplorerUtils().formatTransactionUrl(
-                    txid: paymentMinutiae.closingTxid!, mempoolInstance: mempoolInstance),
+                  txid: paymentMinutiae.closingTxid!,
+                  mempoolInstance: mempoolInstance,
+                ),
                 txID: paymentMinutiae.closingTxid!,
               ),
             ]

--- a/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
+++ b/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
@@ -56,8 +56,10 @@ class _TxLink extends StatelessWidget {
           return const Loader();
         }
 
-        final transactionUrl =
-            BlockChainExplorerUtils().formatTransactionUrl(mempoolInstance: snapshot.data!, txid: txid);
+        final transactionUrl = BlockChainExplorerUtils().formatTransactionUrl(
+          mempoolInstance: snapshot.data!,
+          txid: lockupTxid,
+        );
 
         return LinkLauncher(
           linkName: txid,


### PR DESCRIPTION
Applies minimum required changes for Breez SDK PR:
- https://github.com/breez/breez-sdk/pull/898

These changes do integrate the fallback behavior but we still rely on "https://mempool.space/" to display the transactions onchain on the UI.

That is until the user sets a Mempool API URL of their choice from **Preferences** -> **Network**.