### PR TITLE
Refactor Reverse Swap In Progress

### DIFF
--- a/lib/bloc/refund/refund_bloc.dart
+++ b/lib/bloc/refund/refund_bloc.dart
@@ -4,8 +4,10 @@ import 'package:breez_sdk/breez_sdk.dart';
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/refund/refund_state.dart';
+import 'package:c_breez/logger.dart';
 import 'package:c_breez/models/fee_options/fee_option.dart';
 import 'package:c_breez/utils/exceptions.dart';
+import 'package:c_breez/utils/sdk_fields/serializer_helper.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
 
@@ -46,7 +48,7 @@ class RefundBloc extends Cubit<RefundState> {
 
   _listenSwapEvents() {
     _breezSDK.swapEventsStream.listen((event) {
-      _log.info('Got SwapUpdate event: $event');
+      printWrapped(_log, 'Got SwapUpdate event: ${swapInfoToString(event.details)}');
       listRefundables();
     }, onError: (e) {
       _log.severe('Failed to listen swapEventsStream: $e');

--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -111,7 +111,7 @@ class ReverseSwapBloc extends Cubit<ReverseSwapState> {
   }) async {
     try {
       _log.info(
-        "Estimate reverse swap fees for $amountSat sats to be ${amountType == SwapAmountType.Receive ? "received on the" : "sent to the"} destination address",
+        "Estimate reverse swap fees for $amountSat sats to be ${amountType == SwapAmountType.Receive ? "received on the" : "sent to the"} destination address w/ $claimTxFeerate sat/Vbyte fee rate.",
       );
       final req = PrepareOnchainPaymentRequest(
         amountSat: amountSat,
@@ -119,7 +119,9 @@ class ReverseSwapBloc extends Cubit<ReverseSwapState> {
         claimTxFeerate: claimTxFeerate,
       );
       PrepareOnchainPaymentResponse revSwapPairInfo = await _breezSDK.prepareOnchainPayment(req: req);
-      _log.info("Total estimated fees for reverse swap: ${revSwapPairInfo.totalFees}");
+      _log.info(
+        "Total estimated fees for reverse swap: ${revSwapPairInfo.totalFees} w/ $claimTxFeerate sat/Vbyte fee rate.",
+      );
       return revSwapPairInfo;
     } catch (e) {
       _log.severe("prepareOnchainPayment error", e);

--- a/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
+++ b/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
@@ -9,40 +9,10 @@ import 'package:c_breez/widgets/loader.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
-class ReverseSwapInprogress extends StatelessWidget {
-  final sdk.ReverseSwapInfo reverseSwap;
+class ReverseSwapInProgress extends StatelessWidget {
+  final String lockupTxid;
 
-  const ReverseSwapInprogress({
-    required this.reverseSwap,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final texts = context.texts();
-    final lockTxID = context.watch<sdk.ReverseSwapInfo>().lockupTxid;
-
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      crossAxisAlignment: CrossAxisAlignment.stretch,
-      children: [
-        _ContentWrapper(
-          content: Text(texts.swap_in_progress_message_waiting_confirmation, textAlign: TextAlign.center),
-          top: 50.0,
-        ),
-        if (lockTxID != null) ...[
-          _ContentWrapper(
-            content: _TxLink(txid: lockTxID),
-          ),
-        ]
-      ],
-    );
-  }
-}
-
-class _TxLink extends StatelessWidget {
-  final String txid;
-
-  const _TxLink({required this.txid});
+  const ReverseSwapInProgress({required this.lockupTxid});
 
   @override
   Widget build(BuildContext context) {
@@ -62,10 +32,10 @@ class _TxLink extends StatelessWidget {
         );
 
         return LinkLauncher(
-          linkName: txid,
+          linkName: lockupTxid,
           linkAddress: transactionUrl,
           onCopy: () {
-            ServiceInjector().device.setClipboardText(txid);
+            ServiceInjector().device.setClipboardText(lockupTxid);
             showFlushbar(
               context,
               message: text.add_funds_transaction_id_copied,
@@ -74,25 +44,6 @@ class _TxLink extends StatelessWidget {
           },
         );
       },
-    );
-  }
-}
-
-class _ContentWrapper extends StatelessWidget {
-  final Widget content;
-  final double top;
-
-  const _ContentWrapper({required this.content, this.top = 30.0});
-
-  @override
-  Widget build(BuildContext context) {
-    return Padding(
-      padding: EdgeInsets.only(
-        top: top,
-        left: 30.0,
-        right: 30.0,
-      ),
-      child: content,
     );
   }
 }

--- a/lib/routes/withdraw/reverse_swap/in_progress/reverse_swaps_in_progress_page.dart
+++ b/lib/routes/withdraw/reverse_swap/in_progress/reverse_swaps_in_progress_page.dart
@@ -1,4 +1,5 @@
 import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart';
 import 'package:flutter/material.dart';
 
@@ -13,14 +14,28 @@ class ReverseSwapsInProgressPage extends StatefulWidget {
 class _ReverseSwapsInProgressPageState extends State<ReverseSwapsInProgressPage> {
   @override
   Widget build(BuildContext context) {
-    return ListView.builder(
-      shrinkWrap: true,
-      itemCount: widget.reverseSwaps.length,
-      itemBuilder: (context, index) {
-        ReverseSwapInfo reverseSwap = widget.reverseSwaps[index];
+    final texts = context.texts();
 
-        return ReverseSwapInprogress(reverseSwap: reverseSwap);
-      },
+    return Padding(
+      padding: const EdgeInsets.only(top: 50.0, left: 30.0, right: 30.0),
+      child: Column(
+        children: [
+          Text(texts.swap_in_progress_message_waiting_confirmation, textAlign: TextAlign.center),
+          ListView.builder(
+            shrinkWrap: true,
+            itemCount: widget.reverseSwaps.length,
+            itemBuilder: (context, index) {
+              ReverseSwapInfo reverseSwap = widget.reverseSwaps[index];
+              // Lockup tx id is always available at this stage, added null-handling for safety
+              final lockupTxid = reverseSwap.lockupTxid;
+              return Padding(
+                padding: const EdgeInsets.only(top: 30.0),
+                child: ReverseSwapInProgress(lockupTxid: (lockupTxid != null) ? lockupTxid : ""),
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
#### Changelist:
- Refactor reverse swap in progress bloc 
  - Increased timer interval to 30 seconds
  - Ensure the bloc isn't closed when emitting states
- Log fee rate for prepared onchain payment
- Refactor `ReverseSwapInProgress` widget (fixes #855)

  - > `ReverseSwapInProgressBloc` is not accessible from `ReverseSwapInprogress` and it caused UI to crash when we tried fetching lockupTxid via:
    >
    > `final lockTxID = context.watch<sdk.ReverseSwapInfo>().lockupTxid;`
    >
    > `lockupTxid` is now passed to child widgets from `ReverseSwapPage` and not looked up from provider using `context.watch()`

- If there was a race condition and there were multiple swaps in progress, the UI repeated the waiting confirmation message for each TX. The waiting confirmation message is now displayed as header on `ReverseSwapsInProgressPage`.
- Log `SwapInfo` of `SwapUpdated` event properly on `RefundBloc`
