### PR TITLE
Display a generic error message on Deposit to BTC Address page

### DIFF
--- a/lib/routes/subswap/swap/swap_page.dart
+++ b/lib/routes/subswap/swap/swap_page.dart
@@ -6,7 +6,6 @@ import 'package:c_breez/routes/subswap/swap/widgets/address_widget_placeholder.d
 import 'package:c_breez/routes/subswap/swap/widgets/deposit_widget.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/inprogress_swap.dart';
 import 'package:c_breez/routes/subswap/swap/widgets/swap_error_message.dart';
-import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
 import 'package:c_breez/widgets/single_button_bottom_bar.dart';
 import 'package:flutter/material.dart';
@@ -52,7 +51,7 @@ class SwapPageState extends State<SwapPage> {
                           DepositWidget(swapState.unused!)
                       ],
                       if (swapState.error != null) ...[
-                        DepositErrorMessage(errorMessage: extractExceptionMessage(swapState.error!, texts)),
+                        DepositErrorMessage(errorMessage: texts.invoice_btc_address_network_error),
                       ]
                     ],
                   ),

--- a/lib/routes/subswap/swap/widgets/swap_error_message.dart
+++ b/lib/routes/subswap/swap/widgets/swap_error_message.dart
@@ -1,6 +1,4 @@
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:breez_translations/breez_translations_locales.dart';
-import 'package:c_breez/utils/exceptions.dart';
 import 'package:c_breez/utils/min_font_size.dart';
 import 'package:flutter/material.dart';
 
@@ -14,7 +12,6 @@ class DepositErrorMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final texts = context.texts();
     return Padding(
       padding: const EdgeInsets.all(16.0),
       child: SizedBox(
@@ -23,7 +20,7 @@ class DepositErrorMessage extends StatelessWidget {
           child: Padding(
             padding: const EdgeInsets.all(8),
             child: AutoSizeText(
-              extractExceptionMessage(errorMessage, texts),
+              errorMessage,
               textAlign: TextAlign.justify,
               minFontSize: MinFontSize(context).minFontSize,
             ),

--- a/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
+++ b/lib/routes/withdraw/reverse_swap/in_progress/reverse_swap_in_progress.dart
@@ -1,4 +1,3 @@
-import 'package:breez_sdk/bridge_generated.dart' as sdk;
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/network/network_settings_bloc.dart';
 import 'package:c_breez/services/injector.dart';

--- a/lib/utils/exceptions.dart
+++ b/lib/utils/exceptions.dart
@@ -17,20 +17,25 @@ String extractExceptionMessage(
       message = _localizedExceptionMessage(texts, message);
       return message;
     }
+  } else if (exception is FrbAnyhowException) {
+    if (exception.anyhow.isNotEmpty) {
+      var message = exception.anyhow.replaceAll("\n", " ").trim();
+      message = _extractInnerErrorMessage(message)?.trim() ?? message;
+      message = _localizedExceptionMessage(texts, message);
+      return message;
+    }
   }
   return _extractInnerErrorMessage(exception.toString()) ?? defaultErrorMsg ?? exception.toString();
 }
 
 String? _extractInnerErrorMessage(String content) {
   _log.info("extractInnerErrorMessage: $content");
-  final anyhowRegex = RegExp(r'((?<=FrbAnyhowException.*: )(.*)(?=.*\)))');
   final innerMessageRegex = RegExp(r'((?<=message: \\")(.*)(?=.*\\"))');
   final messageRegex = RegExp(r'((?<=message: ")(.*)(?=.*"))');
   final causedByRegex = RegExp(r'((?<=Caused by: )(.*)(?=.*))');
   final reasonRegex = RegExp(r'((?<=FAILURE_REASON_)(.*)(?=.*))');
 
-  return anyhowRegex.stringMatch(content) ??
-      innerMessageRegex.stringMatch(content) ??
+  return innerMessageRegex.stringMatch(content) ??
       messageRegex.stringMatch(content) ??
       causedByRegex.stringMatch(content) ??
       reasonRegex.stringMatch(content);
@@ -42,11 +47,11 @@ String _localizedExceptionMessage(
 ) {
   _log.info("localizedExceptionMessage: $originalMessage");
   final messageToLower = originalMessage.toLowerCase();
-  if (messageToLower == "transport error") {
+  if (messageToLower.contains("transport error")) {
     return texts.generic_network_error;
-  } else if (messageToLower == "insufficient_balance") {
+  } else if (messageToLower.contains("insufficient_balance")) {
     return texts.payment_error_insufficient_balance;
-  } else if (messageToLower == "incorrect_payment_details") {
+  } else if (messageToLower.contains("incorrect_payment_details")) {
     return texts.payment_error_incorrect_payment_details;
   } else if (messageToLower == "error") {
     return texts.payment_error_unexpected_error;


### PR DESCRIPTION
Fixes #852 

### Changelist:
- `FrbAnyhowException` messages are retrieved by exception type instead of relying on regex 
- `transport error` messages are converted to generic network messages for nested exceptions. 
  - All `transport error`'s across the app should be beautified now.
- We now display a generic network error message on "Deposit to BTC Address" page.