### PR TITLE
Display balance on "Send to BTC Address" page at all times

### DIFF
--- a/lib/routes/withdraw/reverse_swap/reverse_swap_form.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_form.dart
@@ -1,0 +1,121 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/models/currency.dart';
+import 'package:c_breez/routes/withdraw/model/withdraw_funds_model.dart';
+import 'package:c_breez/routes/withdraw/widgets/bitcoin_address_text_form_field.dart';
+import 'package:c_breez/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart';
+import 'package:c_breez/utils/validator_holder.dart';
+import 'package:c_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger("ReverseSwapForm");
+
+class ReverseSwapForm extends StatefulWidget {
+  final GlobalKey<FormState> formKey;
+  final TextEditingController amountController;
+  final TextEditingController addressController;
+  final bool withdrawMaxValue;
+  final ValueChanged<bool> onChanged;
+  final BitcoinAddressData? btcAddressData;
+  final BitcoinCurrency bitcoinCurrency;
+  final OnchainPaymentLimitsResponse paymentLimits;
+
+  const ReverseSwapForm({
+    super.key,
+    required this.formKey,
+    required this.amountController,
+    required this.addressController,
+    required this.onChanged,
+    required this.withdrawMaxValue,
+    this.btcAddressData,
+    required this.bitcoinCurrency,
+    required this.paymentLimits,
+  });
+
+  @override
+  State<ReverseSwapForm> createState() => _ReverseSwapFormState();
+}
+
+class _ReverseSwapFormState extends State<ReverseSwapForm> {
+  final _validatorHolder = ValidatorHolder();
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.btcAddressData != null) {
+      _fillBtcAddressData(widget.btcAddressData!);
+    }
+  }
+
+  void _fillBtcAddressData(BitcoinAddressData addressData) {
+    _log.info("Filling BTC Address data for ${addressData.address}");
+    widget.addressController.text = addressData.address;
+    if (addressData.amountSat != null) {
+      _setAmount(addressData.amountSat!);
+    }
+  }
+
+  void _setAmount(int amountSats) {
+    setState(() {
+      widget.amountController.text = widget.bitcoinCurrency
+          .format(amountSats, includeDisplayName: false, userInput: true)
+          .formatBySatAmountFormFieldFormatter();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Form(
+        key: widget.formKey,
+        child: Column(
+          children: [
+            BitcoinAddressTextFormField(
+              context: context,
+              controller: widget.addressController,
+              validatorHolder: _validatorHolder,
+            ),
+            WithdrawFundsAmountTextFormField(
+              context: context,
+              bitcoinCurrency: widget.bitcoinCurrency,
+              controller: widget.amountController,
+              withdrawMaxValue: widget.withdrawMaxValue,
+              balance: widget.paymentLimits.maxSat,
+              policy: WithdrawFundsPolicy(
+                WithdrawKind.withdraw_funds,
+                widget.paymentLimits.minSat,
+                widget.paymentLimits.maxSat,
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: Text(
+                texts.withdraw_funds_use_all_funds,
+                style: const TextStyle(color: Colors.white),
+                maxLines: 1,
+              ),
+              trailing: Switch(
+                value: widget.withdrawMaxValue,
+                activeColor: Colors.white,
+                onChanged: (bool value) async {
+                  setState(() {
+                    widget.onChanged(value);
+                    if (widget.withdrawMaxValue) {
+                      _setAmount(widget.paymentLimits.maxSat);
+                    } else {
+                      widget.amountController.text = "";
+                    }
+                  });
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_form_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_form_page.dart
@@ -1,0 +1,147 @@
+import 'package:breez_sdk/bridge_generated.dart';
+import 'package:breez_translations/breez_translations_locales.dart';
+import 'package:c_breez/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart';
+import 'package:c_breez/bloc/rev_swap_in_progress/rev_swap_in_progress_state.dart';
+import 'package:c_breez/models/currency.dart';
+import 'package:c_breez/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart';
+import 'package:c_breez/routes/withdraw/reverse_swap/in_progress/reverse_swaps_in_progress_page.dart';
+import 'package:c_breez/routes/withdraw/reverse_swap/reverse_swap_form.dart';
+import 'package:c_breez/routes/withdraw/widgets/withdraw_funds_available_btc.dart';
+import 'package:c_breez/utils/exceptions.dart';
+import 'package:c_breez/widgets/flushbar.dart';
+import 'package:c_breez/widgets/loader.dart';
+import 'package:c_breez/widgets/route.dart';
+import 'package:c_breez/widgets/single_button_bottom_bar.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:logging/logging.dart';
+
+final _log = Logger("ReverseSwapFormPage");
+
+class ReverseSwapFormPage extends StatefulWidget {
+  final BitcoinAddressData? btcAddressData;
+  final BitcoinCurrency bitcoinCurrency;
+  final OnchainPaymentLimitsResponse paymentLimits;
+
+  const ReverseSwapFormPage({
+    super.key,
+    this.btcAddressData,
+    required this.bitcoinCurrency,
+    required this.paymentLimits,
+  });
+
+  @override
+  State<ReverseSwapFormPage> createState() => _ReverseSwapFormPageState();
+}
+
+class _ReverseSwapFormPageState extends State<ReverseSwapFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _amountController = TextEditingController();
+  final _addressController = TextEditingController();
+  bool _withdrawMaxValue = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final texts = context.texts();
+    final themeData = Theme.of(context);
+
+    return SafeArea(
+      child: BlocBuilder<RevSwapsInProgressBloc, RevSwapsInProgressState>(
+        builder: (context, inProgressSwapState) {
+          if (inProgressSwapState.isLoading) {
+            return Center(
+              child: Loader(
+                color: themeData.primaryColor.withOpacity(0.5),
+              ),
+            );
+          }
+
+          if (inProgressSwapState.reverseSwapsInProgress.isNotEmpty) {
+            return ReverseSwapsInProgressPage(
+              reverseSwaps: inProgressSwapState.reverseSwapsInProgress,
+            );
+          }
+
+          return Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: Column(
+              children: [
+                ReverseSwapForm(
+                  formKey: _formKey,
+                  amountController: _amountController,
+                  addressController: _addressController,
+                  withdrawMaxValue: _withdrawMaxValue,
+                  btcAddressData: widget.btcAddressData,
+                  bitcoinCurrency: widget.bitcoinCurrency,
+                  paymentLimits: widget.paymentLimits,
+                  onChanged: (bool value) {
+                    setState(() {
+                      _withdrawMaxValue = value;
+                    });
+                  },
+                ),
+                const WithdrawFundsAvailableBtc(),
+                Expanded(child: Container()),
+                SingleButtonBottomBar(
+                  text: texts.withdraw_funds_action_next,
+                  onPressed: _prepareReverseSwap,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  int _getAmount() {
+    int amount = 0;
+    try {
+      amount = widget.bitcoinCurrency.parse(_amountController.text);
+    } catch (e) {
+      _log.warning("Failed to parse the input amount", e);
+    }
+    return amount;
+  }
+
+  void _prepareReverseSwap() async {
+    final texts = context.texts();
+    final navigator = Navigator.of(context);
+    if (_formKey.currentState?.validate() ?? false) {
+      var loaderRoute = createLoaderRoute(context);
+      navigator.push(loaderRoute);
+      try {
+        int amount = _getAmount();
+        if (loaderRoute.isActive) {
+          navigator.removeRoute(loaderRoute);
+        }
+        navigator.push(
+          FadeInRoute(
+            builder: (_) => ReverseSwapConfirmationPage(
+              amountSat: amount,
+              amountType: SwapAmountType.Receive,
+              onchainRecipientAddress: _addressController.text,
+              isMaxValue: _withdrawMaxValue,
+            ),
+          ),
+        );
+      } catch (error) {
+        if (loaderRoute.isActive) {
+          navigator.removeRoute(loaderRoute);
+        }
+        _log.severe("Received error: $error");
+        if (!context.mounted) return;
+        showFlushbar(
+          context,
+          message: texts.reverse_swap_upstream_generic_error_message(
+            extractExceptionMessage(error, texts),
+          ),
+        );
+      } finally {
+        if (loaderRoute.isActive) {
+          navigator.removeRoute(loaderRoute);
+        }
+      }
+    }
+  }
+}

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -1,23 +1,11 @@
 import 'package:breez_sdk/bridge_generated.dart';
 import 'package:breez_translations/breez_translations_locales.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
-import 'package:c_breez/bloc/rev_swap_in_progress/rev_swap_in_progress_bloc.dart';
-import 'package:c_breez/bloc/rev_swap_in_progress/rev_swap_in_progress_state.dart';
 import 'package:c_breez/bloc/reverse_swap/reverse_swap_bloc.dart';
-import 'package:c_breez/routes/withdraw/model/withdraw_funds_model.dart';
-import 'package:c_breez/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart';
-import 'package:c_breez/routes/withdraw/reverse_swap/in_progress/reverse_swaps_in_progress_page.dart';
-import 'package:c_breez/routes/withdraw/widgets/bitcoin_address_text_form_field.dart';
-import 'package:c_breez/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart';
-import 'package:c_breez/routes/withdraw/widgets/withdraw_funds_available_btc.dart';
+import 'package:c_breez/routes/withdraw/reverse_swap/reverse_swap_form_page.dart';
 import 'package:c_breez/utils/exceptions.dart';
-import 'package:c_breez/utils/validator_holder.dart';
-import 'package:c_breez/widgets/amount_form_field/sat_amount_form_field_formatter.dart';
 import 'package:c_breez/widgets/back_button.dart' as back_button;
-import 'package:c_breez/widgets/flushbar.dart';
 import 'package:c_breez/widgets/loader.dart';
-import 'package:c_breez/widgets/route.dart';
-import 'package:c_breez/widgets/single_button_bottom_bar.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:logging/logging.dart';
@@ -33,21 +21,12 @@ class ReverseSwapPage extends StatefulWidget {
 }
 
 class _ReverseSwapPageState extends State<ReverseSwapPage> {
-  final _addressController = TextEditingController();
-  final _amountController = TextEditingController();
-  final _formKey = GlobalKey<FormState>();
-  final _validatorHolder = ValidatorHolder();
-
-  bool _withdrawMaxValue = false;
   Future<OnchainPaymentLimitsResponse>? _revSwapOptionsFuture;
 
   @override
   void initState() {
     super.initState();
     _fetchReverseSwapPairInfo();
-    if (widget.btcAddressData != null) {
-      _fillBtcAddressData(widget.btcAddressData!);
-    }
   }
 
   void didChangeAppLifecycleState(AppLifecycleState state) {
@@ -57,23 +36,15 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
   }
 
   Future _fetchReverseSwapPairInfo() async {
+    _log.info("Fetching reverse swap pair info");
     final revSwapBloc = context.read<ReverseSwapBloc>();
     setState(() {
       _revSwapOptionsFuture = revSwapBloc.onchainPaymentLimits();
     });
   }
 
-  void _fillBtcAddressData(BitcoinAddressData addressData) {
-    _addressController.text = addressData.address;
-    if (addressData.amountSat != null) {
-      _setAmount(addressData.amountSat!);
-    }
-  }
-
   @override
   Widget build(BuildContext context) {
-    final bitcoinCurrency = context.read<CurrencyBloc>().state.bitcoinCurrency;
-
     final texts = context.texts();
     final themeData = Theme.of(context);
 
@@ -83,177 +54,36 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
         title: Text(texts.reverse_swap_title),
       ),
       body: FutureBuilder<OnchainPaymentLimitsResponse>(
-          future: _revSwapOptionsFuture,
-          builder: (BuildContext context, AsyncSnapshot<OnchainPaymentLimitsResponse> snapshot) {
-            switch (snapshot.connectionState) {
-              case ConnectionState.none:
-              case ConnectionState.waiting:
-                return Center(
-                  child: Loader(
-                    color: themeData.primaryColor.withOpacity(0.5),
+        future: _revSwapOptionsFuture,
+        builder: (BuildContext context, AsyncSnapshot<OnchainPaymentLimitsResponse> snapshot) {
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
+                child: Text(
+                  texts.reverse_swap_upstream_generic_error_message(
+                    extractExceptionMessage(snapshot.error!, texts),
                   ),
-                );
-              case ConnectionState.active:
-              case ConnectionState.done:
-                if (snapshot.hasError) {
-                  return Center(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(32, 0, 32, 0),
-                      child: Text(
-                        texts.reverse_swap_upstream_generic_error_message(
-                          extractExceptionMessage(snapshot.error!, texts),
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  );
-                } else {
-                  return SafeArea(
-                    child: BlocBuilder<RevSwapsInProgressBloc, RevSwapsInProgressState>(
-                      builder: (context, inProgressSwapState) {
-                        if (inProgressSwapState.isLoading) {
-                          return Center(
-                            child: Loader(
-                              color: themeData.primaryColor.withOpacity(0.5),
-                            ),
-                          );
-                        }
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            );
+          }
+          if (snapshot.connectionState != ConnectionState.done && !snapshot.hasData) {
+            return Center(
+              child: Loader(
+                color: themeData.primaryColor.withOpacity(0.5),
+              ),
+            );
+          }
 
-                        if (inProgressSwapState.reverseSwapsInProgress.isNotEmpty) {
-                          return ReverseSwapsInProgressPage(
-                            reverseSwaps: inProgressSwapState.reverseSwapsInProgress,
-                          );
-                        }
-
-                        final maxSendableAmount = snapshot.data!.maxSat;
-                        return Column(
-                          children: [
-                            Padding(
-                              padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                              child: Form(
-                                key: _formKey,
-                                child: Column(
-                                  children: [
-                                    BitcoinAddressTextFormField(
-                                      context: context,
-                                      controller: _addressController,
-                                      validatorHolder: _validatorHolder,
-                                    ),
-                                    WithdrawFundsAmountTextFormField(
-                                      context: context,
-                                      bitcoinCurrency: bitcoinCurrency,
-                                      controller: _amountController,
-                                      withdrawMaxValue: _withdrawMaxValue,
-                                      balance: maxSendableAmount,
-                                      policy: WithdrawFundsPolicy(
-                                        WithdrawKind.withdraw_funds,
-                                        snapshot.data!.minSat,
-                                        maxSendableAmount,
-                                      ),
-                                    ),
-                                    ListTile(
-                                      contentPadding: EdgeInsets.zero,
-                                      title: Text(
-                                        texts.withdraw_funds_use_all_funds,
-                                        style: const TextStyle(color: Colors.white),
-                                        maxLines: 1,
-                                      ),
-                                      trailing: Switch(
-                                        value: _withdrawMaxValue,
-                                        activeColor: Colors.white,
-                                        onChanged: (bool value) async {
-                                          setState(() {
-                                            _withdrawMaxValue = value;
-                                            if (_withdrawMaxValue) {
-                                              _setAmount(maxSendableAmount);
-                                            } else {
-                                              _amountController.text = "";
-                                            }
-                                          });
-                                        },
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ),
-                            WithdrawFundsAvailableBtc(maxSendableAmount: maxSendableAmount),
-                            Expanded(child: Container()),
-                            Padding(
-                              padding: const EdgeInsets.fromLTRB(16, 4, 16, 16),
-                              child: SubmitButton(
-                                texts.withdraw_funds_action_next,
-                                () async {
-                                  final navigator = Navigator.of(context);
-                                  if (_formKey.currentState?.validate() ?? false) {
-                                    var loaderRoute = createLoaderRoute(context);
-                                    navigator.push(loaderRoute);
-                                    try {
-                                      int amount = _getAmount();
-                                      if (loaderRoute.isActive) {
-                                        navigator.removeRoute(loaderRoute);
-                                      }
-                                      navigator.push(
-                                        FadeInRoute(
-                                          builder: (_) => ReverseSwapConfirmationPage(
-                                            amountSat: amount,
-                                            amountType: SwapAmountType.Receive,
-                                            onchainRecipientAddress: _addressController.text,
-                                            isMaxValue: _withdrawMaxValue,
-                                          ),
-                                        ),
-                                      );
-                                    } catch (error) {
-                                      if (loaderRoute.isActive) {
-                                        navigator.removeRoute(loaderRoute);
-                                      }
-                                      _log.severe("Received error: $error");
-                                      if (!context.mounted) return;
-                                      showFlushbar(
-                                        context,
-                                        message: texts.reverse_swap_upstream_generic_error_message(
-                                          extractExceptionMessage(error, texts),
-                                        ),
-                                      );
-                                    } finally {
-                                      if (loaderRoute.isActive) {
-                                        navigator.removeRoute(loaderRoute);
-                                      }
-                                    }
-                                  }
-                                },
-                              ),
-                            )
-                          ],
-                        );
-                      },
-                    ),
-                  );
-                }
-            }
-          }),
+          return ReverseSwapFormPage(
+            bitcoinCurrency: context.read<CurrencyBloc>().state.bitcoinCurrency,
+            btcAddressData: widget.btcAddressData,
+            paymentLimits: snapshot.data!,
+          );
+        },
+      ),
     );
-  }
-
-  int _getAmount() {
-    final bitcoinCurrency = context.read<CurrencyBloc>().state.bitcoinCurrency;
-
-    int amount = 0;
-    try {
-      amount = bitcoinCurrency.parse(_amountController.text);
-    } catch (e) {
-      _log.warning("Failed to parse the input amount", e);
-    }
-    return amount;
-  }
-
-  void _setAmount(int amountSats) {
-    final bitcoinCurrency = context.read<CurrencyBloc>().state.bitcoinCurrency;
-
-    setState(() {
-      _amountController.text = bitcoinCurrency
-          .format(amountSats, includeDisplayName: false, userInput: true)
-          .formatBySatAmountFormFieldFormatter();
-    });
   }
 }

--- a/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_available_btc.dart
@@ -3,51 +3,40 @@ import 'package:c_breez/bloc/account/account_bloc.dart';
 import 'package:c_breez/bloc/account/account_state.dart';
 import 'package:c_breez/bloc/currency/currency_bloc.dart';
 import 'package:c_breez/bloc/currency/currency_state.dart';
-import 'package:c_breez/theme/theme_provider.dart';
+import 'package:c_breez/theme/theme_provider.dart' as theme;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:logging/logging.dart';
-
-final _log = Logger("WithdrawFundsAvailableBtc");
 
 class WithdrawFundsAvailableBtc extends StatelessWidget {
-  final int? maxSendableAmount;
-
-  const WithdrawFundsAvailableBtc({this.maxSendableAmount});
+  const WithdrawFundsAvailableBtc();
 
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
-    final themeData = Theme.of(context);
-    final textStyle = themeData.primaryTextTheme.displaySmall!.copyWith(
-      color: BreezColors.white[500],
-    );
 
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-      child: Row(
-        children: [
-          Text(texts.withdraw_funds_balance, style: textStyle),
-          Padding(
-            padding: const EdgeInsets.only(left: 3.0),
-            child: BlocBuilder<AccountBloc, AccountState>(
-              builder: (context, account) {
-                _log.info(
-                  "Building with wallet balance: ${account.walletBalance} balance: ${account.balance} maxSendableAmount: $maxSendableAmount",
-                );
-                return BlocBuilder<CurrencyBloc, CurrencyState>(
-                  builder: (context, currencyState) {
-                    return Text(
-                      currencyState.bitcoinCurrency.format(maxSendableAmount ?? account.balance),
-                      style: textStyle,
-                    );
-                  },
-                );
-              },
+      padding: const EdgeInsets.only(top: 36.0),
+      child: BlocBuilder<AccountBloc, AccountState>(builder: (context, account) {
+        return Row(
+          children: [
+            Text(
+              texts.withdraw_funds_balance,
+              style: theme.textStyle,
             ),
-          ),
-        ],
-      ),
+            Padding(
+              padding: const EdgeInsets.only(left: 3.0),
+              child: BlocBuilder<CurrencyBloc, CurrencyState>(
+                builder: (context, currencyState) {
+                  return Text(
+                    currencyState.bitcoinCurrency.format(account.balance),
+                    style: theme.textStyle,
+                  );
+                },
+              ),
+            ),
+          ],
+        );
+      }),
     );
   }
 }


### PR DESCRIPTION
fixes #866

- Do not display max swap amount as **Balance** and let UI form validation fail. Only use max swap amount for "Use All Funds" feature
- Padding and text style now matches Breez mobile
- Reduce clutter on `ReverseSwapPage` by moving parts of it logic to `ReverseSwapFormPage` & `ReverseSwapForm`