### PR TITLE
Address UI differences between Breez mobile

### DIFF
--- a/lib/routes/buy_bitcoin/moonpay/moonpay_page.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_page.dart
@@ -18,6 +18,8 @@ class MoonPayPage extends StatefulWidget {
 }
 
 class _MoonPayPageState extends State<MoonPayPage> {
+  bool isLoading = true;
+
   @override
   void initState() {
     super.initState();
@@ -34,17 +36,19 @@ class _MoonPayPageState extends State<MoonPayPage> {
     return Material(
       type: MaterialType.transparency,
       child: Scaffold(
-        backgroundColor: Colors.black.withOpacity(0.8),
+        backgroundColor: isLoading ? Colors.black.withOpacity(0.8) : Colors.transparent,
         appBar: AppBar(
           backgroundColor: Colors.transparent,
           automaticallyImplyLeading: false,
-          actions: [
-            IconButton(
-              icon: const Icon(Icons.close),
-              color: themeData.iconTheme.color,
-              onPressed: () => Navigator.of(context).pop(),
-            ),
-          ],
+          actions: isLoading
+              ? [
+                  IconButton(
+                    icon: const Icon(Icons.close),
+                    color: themeData.iconTheme.color,
+                    onPressed: () => Navigator.of(context).pop(),
+                  ),
+                ]
+              : [],
         ),
         body: BlocListener<MoonPayBloc, MoonPayState>(
           listener: (context, state) async {
@@ -54,6 +58,9 @@ class _MoonPayPageState extends State<MoonPayPage> {
               if (state.webViewStatus == WebViewStatus.error) {
                 _closeOnError();
               } else {
+                setState(() {
+                  isLoading = false;
+                });
                 await promptLSPFeeAndNavigate(context, state.buyBitcoinResponse.openingFeeParams!).then(
                   (isApproved) {
                     _launchMoonPayUrl(state.buyBitcoinResponse.url, isApproved);

--- a/lib/routes/dev/developers_view.dart
+++ b/lib/routes/dev/developers_view.dart
@@ -62,12 +62,16 @@ class _DevelopersViewState extends State<DevelopersView> {
   @override
   Widget build(BuildContext context) {
     final GlobalKey<ScaffoldState> scaffoldKey = GlobalKey<ScaffoldState>();
+
+    final texts = getSystemAppLocalizations();
     final themeData = Theme.of(context);
 
     return Scaffold(
       key: scaffoldKey,
       appBar: AppBar(
+        automaticallyImplyLeading: false,
         leading: const back_button.BackButton(),
+        title: Text(texts.home_drawer_item_title_developers),
         actions: [
           PopupMenuButton<Choice>(
             onSelected: (c) => c.function(context),
@@ -131,7 +135,6 @@ class _DevelopersViewState extends State<DevelopersView> {
                 .toList(),
           ),
         ],
-        title: const Text("Developers"),
       ),
       body: CommandLineInterface(scaffoldKey: scaffoldKey),
     );

--- a/lib/routes/home/account_page.dart
+++ b/lib/routes/home/account_page.dart
@@ -76,20 +76,20 @@ class AccountPage extends StatelessWidget {
 
     final bool showSliver =
         nonFilteredPayments.isNotEmpty || paymentFilters.filters != PaymentTypeFilter.values;
-
+    int? startDate = paymentFilters.fromTimestamp;
+    int? endDate = paymentFilters.toTimestamp;
+    bool hasDateFilter = startDate != null && endDate != null;
     if (showSliver) {
       slivers.add(
         PaymentsFilterSliver(
           maxSize: _kFilterMaxSize,
           scrollController: scrollController,
-          hasFilter: paymentFilters.filters != PaymentTypeFilter.values,
+          hasFilter: paymentFilters.filters != PaymentTypeFilter.values || hasDateFilter,
         ),
       );
     }
 
-    int? startDate = paymentFilters.fromTimestamp;
-    int? endDate = paymentFilters.toTimestamp;
-    if (startDate != null && endDate != null) {
+    if (hasDateFilter) {
       slivers.add(
         HeaderFilterChip(
           _kFilterMaxSize,

--- a/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
+++ b/lib/routes/home/widgets/payments_filter/calendar_dialog.dart
@@ -135,9 +135,12 @@ class CalendarDialogState extends State<CalendarDialog> {
       firstDate: widget.firstDate,
       lastDate: DateTime.now(),
       builder: (context, child) {
+        final themeData = Theme.of(context);
         return Theme(
-          data: Theme.of(context).calendarTheme,
-          child: child!,
+          data: themeData.isLightTheme
+              ? themeData.copyWith(colorScheme: themeData.colorScheme.copyWith(onSurface: Colors.black))
+              : themeData,
+          child: DatePickerTheme(data: Theme.of(context).calendarTheme, child: child!),
         );
       },
     );

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -102,23 +102,78 @@ final ThemeData breezDarkTheme = ThemeData(
     }),
   ),
   chipTheme: const ChipThemeData(backgroundColor: Color(0xFF0085fb)),
+  datePickerTheme: calendarDarkTheme,
 );
 
-final ThemeData calendarDarkTheme = ThemeData.dark().copyWith(
-  colorScheme: const ColorScheme.light(
-    primary: Color(0xFF0085fb), // header bg color
-    onPrimary: Colors.white, // header text color
-    onSurface: Colors.white, // body text color
+final DatePickerThemeData calendarDarkTheme = DatePickerThemeData(
+  yearBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color(0xFF0085fb);
+    }
+    return Colors.transparent;
+  }),
+  yearForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.white38;
+    }
+    return Colors.white;
+  }),
+  dayBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color(0xFF0085fb);
+    }
+    return Colors.transparent;
+  }),
+  dayForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.white38;
+    }
+    return Colors.white;
+  }),
+  todayBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color(0xFF0085fb);
+    }
+    return Colors.transparent;
+  }),
+  todayForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return Colors.white;
+    }
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.white38;
+    }
+    return const Color(0xFF0085fb);
+  }),
+  todayBorder: const BorderSide(color: Color(0xFF0085fb)),
+  headerBackgroundColor: const Color(0xFF0085fb),
+  headerForegroundColor: Colors.white,
+  backgroundColor: const Color(0xFF152a3d),
+  shape: const RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(
+      Radius.circular(12.0),
+    ),
   ),
-  textButtonTheme: TextButtonThemeData(
-    style: TextButton.styleFrom(foregroundColor: const Color(0xFF0085fb)),
+  cancelButtonStyle: ButtonStyle(
+    foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+      (states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white38;
+        }
+
+        return const Color(0xFF0085fb);
+      },
+    ),
   ),
-  dialogTheme: const DialogTheme(
-    backgroundColor: Color(0xFF152a3d),
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(
-        Radius.circular(12.0),
-      ),
+  confirmButtonStyle: ButtonStyle(
+    foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+      (states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.white38;
+        }
+
+        return const Color(0xFF0085fb);
+      },
     ),
   ),
 );

--- a/lib/theme/breez_dark_theme.dart
+++ b/lib/theme/breez_dark_theme.dart
@@ -24,6 +24,7 @@ final ThemeData breezDarkTheme = ThemeData(
   canvasColor: const Color(0xFF0c2031),
   bottomAppBarTheme: const BottomAppBarTheme(elevation: 0, color: Color(0xFF0085fb)),
   appBarTheme: AppBarTheme(
+    centerTitle: false,
     backgroundColor: const Color(0xFF0c2031),
     iconTheme: const IconThemeData(
       color: Colors.white,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -23,6 +23,7 @@ final ThemeData breezLightTheme = ThemeData(
   canvasColor: BreezColors.blue[500],
   bottomAppBarTheme: const BottomAppBarTheme(elevation: 0, color: Color(0xFF0085fb)),
   appBarTheme: AppBarTheme(
+    centerTitle: false,
     backgroundColor: BreezColors.blue[500],
     iconTheme: const IconThemeData(
       color: Colors.white,

--- a/lib/theme/breez_light_theme.dart
+++ b/lib/theme/breez_light_theme.dart
@@ -109,22 +109,85 @@ final ThemeData breezLightTheme = ThemeData(
     ),
   ),
   chipTheme: const ChipThemeData(backgroundColor: Color(0xFF0085fb)),
+  datePickerTheme: calendarLightTheme,
 );
 
-final ThemeData calendarLightTheme = ThemeData.light().copyWith(
-  colorScheme: const ColorScheme.light(
-    primary: Color.fromRGBO(5, 93, 235, 1.0),
-  ),
-  textButtonTheme: TextButtonThemeData(
-    style: TextButton.styleFrom(
-      foregroundColor: BreezColors.blue[500],
+final DatePickerThemeData calendarLightTheme = DatePickerThemeData(
+  weekdayStyle: TextStyle(color: Colors.black.withOpacity(0.6)),
+  yearBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color.fromRGBO(5, 93, 235, 1.0);
+    }
+    return Colors.transparent;
+  }),
+  yearForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return Colors.white;
+    }
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.black38;
+    }
+    return Colors.black;
+  }),
+  dayBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color.fromRGBO(5, 93, 235, 1.0);
+    }
+    return Colors.transparent;
+  }),
+  dayForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return Colors.white;
+    }
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.black38;
+    }
+    return Colors.black;
+  }),
+  todayBackgroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return const Color.fromRGBO(5, 93, 235, 1.0);
+    }
+    return Colors.transparent;
+  }),
+  todayForegroundColor: MaterialStateProperty.resolveWith<Color>((states) {
+    if (states.contains(MaterialState.selected)) {
+      return Colors.white;
+    }
+    if (states.contains(MaterialState.disabled)) {
+      return Colors.black38;
+    }
+    return const Color.fromRGBO(5, 93, 235, 1.0);
+  }),
+  todayBorder: const BorderSide(color: Color.fromRGBO(5, 93, 235, 1.0)),
+  headerBackgroundColor: const Color.fromRGBO(5, 93, 235, 1.0),
+  headerForegroundColor: Colors.white,
+  backgroundColor: Colors.white,
+  shape: const RoundedRectangleBorder(
+    borderRadius: BorderRadius.all(
+      Radius.circular(12.0),
     ),
   ),
-  dialogTheme: const DialogTheme(
-    shape: RoundedRectangleBorder(
-      borderRadius: BorderRadius.all(
-        Radius.circular(12.0),
-      ),
+  cancelButtonStyle: ButtonStyle(
+    foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+      (states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.black38;
+        }
+
+        return const Color.fromRGBO(5, 93, 235, 1.0);
+      },
+    ),
+  ),
+  confirmButtonStyle: ButtonStyle(
+    foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+      (states) {
+        if (states.contains(MaterialState.disabled)) {
+          return Colors.black38;
+        }
+
+        return const Color.fromRGBO(5, 93, 235, 1.0);
+      },
     ),
   ),
 );

--- a/lib/theme/theme_extensions.dart
+++ b/lib/theme/theme_extensions.dart
@@ -103,7 +103,7 @@ const TextStyle warningStyle = TextStyle(
 extension ThemeExtensions on ThemeData {
   bool get isLightTheme => primaryColor == breezLightTheme.primaryColor;
 
-  ThemeData get calendarTheme => isLightTheme ? calendarLightTheme : calendarDarkTheme;
+  DatePickerThemeData get calendarTheme => isLightTheme ? calendarLightTheme : calendarDarkTheme;
 
   CustomData get customData => isLightTheme ? blueThemeCustomData : darkThemeCustomData;
 


### PR DESCRIPTION
### Address regression on date picker
I'm not sure when did Flutter changed this but overriding ThemeData is no longer enough to override date picker theme. It now uses colorScheme & datePickerTheme of ThemeData.

- Added datePickerTheme to ThemeData

<img width="50%" alt="image" src="https://github.com/breez/c-breez/assets/4012752/6cef5733-3958-4cd7-83d4-c8acce6d2d51"><img width="50%" alt="image" src="https://github.com/breez/c-breez/assets/4012752/0a24f4ec-1c4d-4720-b95e-2b98eaaf3705">

<img width="50%" alt="image" src="https://github.com/breez/c-breez/assets/4012752/0e1d2286-469f-4d50-9e59-4eb2e2d0f87d"><img width="50%" alt="image" src="https://github.com/breez/c-breez/assets/4012752/7c2fe50c-5f06-4fc6-8462-5f4e54cef311">
