### PR TITLE
Add required `allowsNostr` field to `LnUrlPayRequestData`

### DIFF
--- a/test/mock/breez_bridge_mock.dart
+++ b/test/mock/breez_bridge_mock.dart
@@ -102,6 +102,7 @@ class BreezSDKMock extends Mock implements BreezSDK {
       metadataStr: "",
       commentAllowed: 0,
       domain: "",
+      allowsNostr: false,
     ),
   );
 


### PR DESCRIPTION
Addresses breaking changes from Breez SDK PR:
- https://github.com/breez/breez-sdk/pull/918

Adds required `allowNostr` field to mock `LnUrlPayRequestData` used on tests.