### PR TITLE
Flutter 3.22  - Dependencies breaking build

### DIFF
--- a/lib/routes/fiat_currencies/fiat_currency_settings.dart
+++ b/lib/routes/fiat_currencies/fiat_currency_settings.dart
@@ -27,6 +27,8 @@ class FiatCurrencySettings extends StatefulWidget {
 class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
   final _scrollController = ScrollController();
 
+  bool isInit = false;
+
   @override
   Widget build(BuildContext context) {
     final texts = context.texts();
@@ -49,7 +51,7 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
             return FutureBuilder(
               future: artificialWait(),
               builder: (context, snapshot) {
-                if (snapshot.connectionState != ConnectionState.done) {
+                if (isInit == false && snapshot.connectionState != ConnectionState.done) {
                   return const Center(
                     child: Loader(
                       color: Colors.white,
@@ -207,9 +209,12 @@ class FiatCurrencySettingsState extends State<FiatCurrencySettings> {
   /// and blocks the UI thread. Since data retrieval is not the bottleneck, it
   /// blocks the UI thread almost immediately on the screen navigating to this page.
   /// Before the underlying performance issues are fixed on the library.
-  /// We've added an artificial wait to display the page route animation and spinnig
+  /// We've added an artificial wait to display the page route animation and spinning
   /// loader before UI thread is blocked to convey a better UX as a workaround.
   Future artificialWait() async {
+    setState(() {
+      isInit = true;
+    });
     return await Future.delayed(const Duration(milliseconds: 800));
   }
 }

--- a/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/widgets/restore_form.dart
@@ -49,10 +49,13 @@ class RestoreFormPageState extends State<RestoreForm> {
             final itemIndex = index + (6 * (widget.currentPage - 1));
             return TypeAheadFormField(
               textFieldConfiguration: TextFieldConfiguration(
+                autocorrect: false,
                 controller: widget.textEditingControllers[itemIndex],
                 textInputAction: TextInputAction.next,
-                onSubmitted: (text) {
-                  widget.textEditingControllers[itemIndex].text = text;
+                onSubmitted: (text) async {
+                  final suggestions = await _getSuggestions(text);
+                  widget.textEditingControllers[itemIndex].text =
+                      suggestions.length == 1 ? suggestions.first : text;
                   if (itemIndex + 1 < focusNodes.length) {
                     focusNodes[itemIndex + 1].requestFocus();
                   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -324,10 +324,11 @@ packages:
   drag_and_drop_lists:
     dependency: "direct main"
     description:
-      name: drag_and_drop_lists
-      sha256: "9a14595f9880be7953f23578aef88c15cc9b367eeb39dbc1f1bd6af52f70872b"
-      url: "https://pub.dev"
-    source: hosted
+      path: "."
+      ref: "38cc3155a6161730b4ec476d781873afb7ec4846"
+      resolved-ref: "38cc3155a6161730b4ec476d781873afb7ec4846"
+      url: "https://github.com/breez/DragAndDropLists"
+    source: git
     version: "0.3.3"
   duration:
     dependency: "direct main"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -715,8 +715,8 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: a16aa4deeff1c5e96c6da46da31cb0533f838d8d
-      resolved-ref: a16aa4deeff1c5e96c6da46da31cb0533f838d8d
+      ref: "4a494322762af9f30820f3c63aba784d46b86b69"
+      resolved-ref: "4a494322762af9f30820f3c63aba784d46b86b69"
       url: "https://github.com/breez/flutter_typeahead.git"
     source: git
     version: "4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,10 @@ dependencies:
   csv: ^6.0.0
   connectivity_plus: ^6.0.3
   device_info_plus: ^10.1.0
-  drag_and_drop_lists: ^0.3.3
+  drag_and_drop_lists:
+    git:
+      url: https://github.com/breez/DragAndDropLists
+      ref: 38cc3155a6161730b4ec476d781873afb7ec4846
   duration: ^3.0.13
   email_validator: ^2.1.17
   extended_image: ^8.2.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -57,7 +57,7 @@ dependencies:
   flutter_typeahead:
     git:
       url: https://github.com/breez/flutter_typeahead.git
-      ref: a16aa4deeff1c5e96c6da46da31cb0533f838d8d
+      ref: 4a494322762af9f30820f3c63aba784d46b86b69
   git_info: ^1.1.2
   hex: ^0.2.0
   http: ^1.2.1


### PR DESCRIPTION
Updated dependencies that are not compatible with Flutter 3.22.

- Forked `drag_and_drop_list` and addressed issues [here](https://github.com/breez/DragAndDropLists/commit/38cc3155a6161730b4ec476d781873afb7ec4846).
  - Note: This plugin is no longer maintained.
- Addressed breaking changes on our fork of `flutter_typeahead` [here](https://github.com/breez/flutter_typeahead/commit/4a494322762af9f30820f3c63aba784d46b86b69).