### PR TITLE
Compare payment amount against `maxPayableSat` instead of `balanceSat`

### DIFF
--- a/lib/bloc/reverse_swap/reverse_swap_bloc.dart
+++ b/lib/bloc/reverse_swap/reverse_swap_bloc.dart
@@ -133,12 +133,13 @@ class ReverseSwapBloc extends Cubit<ReverseSwapState> {
     try {
       OnchainPaymentLimitsResponse paymentLimits = await _breezSDK.onchainPaymentLimits();
       _log.info(
-        "Current maximum ${paymentLimits.maxSat} and "
-        "minimum ${paymentLimits.minSat} payment limits for onchain payments",
+        "Current minimum ${paymentLimits.minSat} and "
+        "maximum ${paymentLimits.maxSat} payment limits, in sats, for onchain payments."
+        "\nMaximum amount this node can send with the current channels and the current local balance: ${paymentLimits.maxPayableSat} (sats).",
       );
       return paymentLimits;
     } catch (e) {
-      _log.severe("fetchOnchainPaymentLimits error", e);
+      _log.severe("onchainPaymentLimits error", e);
       rethrow;
     }
   }

--- a/lib/routes/withdraw/redeem_onchain_funds/redeem_onchain_funds_page.dart
+++ b/lib/routes/withdraw/redeem_onchain_funds/redeem_onchain_funds_page.dart
@@ -88,7 +88,7 @@ class _RedeemFundsPageState extends State<RedeemFundsPage> {
                           widget.walletBalanceSat,
                           widget.walletBalanceSat,
                         ),
-                        balanceSat: widget.walletBalanceSat,
+                        maxPayableSat: widget.walletBalanceSat,
                       );
                     },
                   ),

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_form.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_form.dart
@@ -84,7 +84,7 @@ class _ReverseSwapFormState extends State<ReverseSwapForm> {
               bitcoinCurrency: widget.bitcoinCurrency,
               controller: widget.amountController,
               withdrawMaxValue: widget.withdrawMaxValue,
-              balanceSat: widget.paymentLimits.maxSat,
+              maxPayableSat: widget.paymentLimits.maxPayableSat,
               policy: WithdrawFundsPolicy(
                 WithdrawKind.withdraw_funds,
                 widget.paymentLimits.minSat,
@@ -105,7 +105,7 @@ class _ReverseSwapFormState extends State<ReverseSwapForm> {
                   setState(() {
                     widget.onChanged(value);
                     if (widget.withdrawMaxValue) {
-                      _setAmount(widget.paymentLimits.maxSat);
+                      _setAmount(widget.paymentLimits.maxPayableSat);
                     } else {
                       widget.amountController.text = "";
                     }

--- a/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
+++ b/lib/routes/withdraw/reverse_swap/reverse_swap_page.dart
@@ -14,6 +14,7 @@ final _log = Logger("ReverseSwapPage");
 
 class ReverseSwapPage extends StatefulWidget {
   final BitcoinAddressData? btcAddressData;
+
   const ReverseSwapPage({super.key, required this.btcAddressData});
 
   @override
@@ -21,25 +22,25 @@ class ReverseSwapPage extends StatefulWidget {
 }
 
 class _ReverseSwapPageState extends State<ReverseSwapPage> {
-  Future<OnchainPaymentLimitsResponse>? _revSwapOptionsFuture;
+  Future<OnchainPaymentLimitsResponse>? _onchainPaymentLimitsFuture;
 
   @override
   void initState() {
     super.initState();
-    _fetchReverseSwapPairInfo();
+    _fetchOnchainPaymentLimits();
   }
 
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _fetchReverseSwapPairInfo();
+      _fetchOnchainPaymentLimits();
     }
   }
 
-  Future _fetchReverseSwapPairInfo() async {
-    _log.info("Fetching reverse swap pair info");
+  Future _fetchOnchainPaymentLimits() async {
+    _log.info("Fetching onchain payment limits");
     final revSwapBloc = context.read<ReverseSwapBloc>();
     setState(() {
-      _revSwapOptionsFuture = revSwapBloc.onchainPaymentLimits();
+      _onchainPaymentLimitsFuture = revSwapBloc.onchainPaymentLimits();
     });
   }
 
@@ -54,7 +55,7 @@ class _ReverseSwapPageState extends State<ReverseSwapPage> {
         title: Text(texts.reverse_swap_title),
       ),
       body: FutureBuilder<OnchainPaymentLimitsResponse>(
-        future: _revSwapOptionsFuture,
+        future: _onchainPaymentLimitsFuture,
         builder: (BuildContext context, AsyncSnapshot<OnchainPaymentLimitsResponse> snapshot) {
           if (snapshot.hasError) {
             return Center(

--- a/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/withdraw_funds_amount_text_form_field.dart
@@ -18,7 +18,7 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
     required TextEditingController super.controller,
     required bool withdrawMaxValue,
     required WithdrawFundsPolicy policy,
-    required int balanceSat,
+    required int maxPayableSat,
   }) : super(
           texts: context.texts(),
           readOnly: policy.withdrawKind == WithdrawKind.unexpected_funds || withdrawMaxValue,
@@ -36,7 +36,7 @@ class WithdrawFundsAmountTextFormField extends AmountFormField {
                 if (amountSat > policy.maxValue) {
                   throw PaymentExceededLimitError(policy.maxValue);
                 }
-                if (amountSat > balanceSat) {
+                if (amountSat > maxPayableSat) {
                   throw const InsufficientLocalBalanceError();
                 }
               },


### PR DESCRIPTION
This PR applies the changes in
- https://github.com/breez/breez-sdk/issues/1037

`minSat` & `maxSat` are no longer returned as 0 when user has insufficient balance for the payment from `onchainPaymentLimits`, a new field `maxPayableSat` is added which denotes the maximum amount the node can send with it's current channels & local balance.

If the payment amount falls within min-max limits, it is then compared against `maxPayableSat` to validate if the payment can be made.