### PR TITLE
Address Flutter 3.24 breaking changes & requirements

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -22,7 +22,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "7.4.2" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.20" apply false
+    id "org.jetbrains.kotlin.android" version "2.0.10" apply false
     id "com.google.gms.google-services" version "4.4.0" apply false
     id "org.jetbrains.kotlin.plugin.serialization" version "1.8.20" apply false
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - app_group_directory (1.0.0):
     - Flutter
-  - breez_sdk (0.5.1-rc3):
+  - breez_sdk (0.5.2):
     - Flutter
   - clipboard_watcher (0.0.1):
     - Flutter
@@ -10,39 +10,39 @@ PODS:
     - FlutterMacOS
   - device_info_plus (0.0.1):
     - Flutter
-  - Firebase/CoreOnly (10.28.0):
-    - FirebaseCore (= 10.28.0)
-  - Firebase/DynamicLinks (10.28.0):
+  - Firebase/CoreOnly (10.29.0):
+    - FirebaseCore (= 10.29.0)
+  - Firebase/DynamicLinks (10.29.0):
     - Firebase/CoreOnly
-    - FirebaseDynamicLinks (~> 10.28.0)
-  - Firebase/Messaging (10.28.0):
+    - FirebaseDynamicLinks (~> 10.29.0)
+  - Firebase/Messaging (10.29.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 10.28.0)
-  - firebase_core (3.2.0):
-    - Firebase/CoreOnly (= 10.28.0)
+    - FirebaseMessaging (~> 10.29.0)
+  - firebase_core (3.3.0):
+    - Firebase/CoreOnly (= 10.29.0)
     - Flutter
-  - firebase_dynamic_links (6.0.3):
-    - Firebase/DynamicLinks (= 10.28.0)
+  - firebase_dynamic_links (6.0.4):
+    - Firebase/DynamicLinks (= 10.29.0)
     - firebase_core
     - Flutter
-  - firebase_messaging (15.0.3):
-    - Firebase/Messaging (= 10.28.0)
+  - firebase_messaging (15.0.4):
+    - Firebase/Messaging (= 10.29.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (10.28.0):
+  - FirebaseCore (10.29.0):
     - FirebaseCoreInternal (~> 10.0)
     - GoogleUtilities/Environment (~> 7.12)
     - GoogleUtilities/Logger (~> 7.12)
   - FirebaseCoreInternal (10.29.0):
     - "GoogleUtilities/NSData+zlib (~> 7.8)"
-  - FirebaseDynamicLinks (10.28.0):
+  - FirebaseDynamicLinks (10.29.0):
     - FirebaseCore (~> 10.0)
   - FirebaseInstallations (10.29.0):
     - FirebaseCore (~> 10.0)
     - GoogleUtilities/Environment (~> 7.8)
     - GoogleUtilities/UserDefaults (~> 7.8)
     - PromisesObjC (~> 2.1)
-  - FirebaseMessaging (10.28.0):
+  - FirebaseMessaging (10.29.0):
     - FirebaseCore (~> 10.0)
     - FirebaseInstallations (~> 10.0)
     - GoogleDataTransport (~> 9.3)
@@ -117,6 +117,7 @@ PODS:
   - KeychainAccess (4.2.2)
   - local_auth_darwin (0.0.1):
     - Flutter
+    - FlutterMacOS
   - MLImage (1.0.0-beta5)
   - MLKitBarcodeScanning (5.0.0):
     - MLKitCommon (~> 11.0)
@@ -300,19 +301,19 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_group_directory: 7bf9f8f9819ead554de29da7c25fb7a680d6a9a0
-  breez_sdk: c27f6e5a5ffb918ab57cff57cad4dd00e611f159
+  breez_sdk: 786b7c9260708ae0845dfa510c5a3cd64fdd1beb
   clipboard_watcher: 86fb70421aca6f4944e0591a8292605da7784666
   connectivity_plus: ddd7f30999e1faaef5967c23d5b6d503d10434db
   device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
-  Firebase: 5121c624121af81cbc81df3bda414b3c28c4f3c3
-  firebase_core: a9d0180d5285527884d07a41eb4a9ec9ed12cdb6
-  firebase_dynamic_links: ef37ec989592ed84f0bbcf2d2f938d4407bee1c2
-  firebase_messaging: ccc82a143a74de75f440a4e413dbbb37ec3fddbc
-  FirebaseCore: 857dc1c6dd1255675047404d8466f7dfaac5d779
+  Firebase: cec914dab6fd7b1bd8ab56ea07ce4e03dd251c2d
+  firebase_core: 57aeb91680e5d5e6df6b888064be7c785f146efb
+  firebase_dynamic_links: 550e8cefbdee7b6e74adfebb3cc4d340fa72f6c8
+  firebase_messaging: c862b3d2b973ecc769194dc8de09bd22c77ae757
+  FirebaseCore: 30e9c1cbe3d38f5f5e75f48bfcea87d7c358ec16
   FirebaseCoreInternal: df84dd300b561c27d5571684f389bf60b0a5c934
-  FirebaseDynamicLinks: f6a65ece086df7d8366400b8bb99e50dd2659ad4
+  FirebaseDynamicLinks: 83c278fcae48ac2cf8c3fb10f64f3d469dadcf9b
   FirebaseInstallations: 913cf60d0400ebd5d6b63a28b290372ab44590dd
-  FirebaseMessaging: 087a7c7cadef7b9239f005bc4db823894844f323
+  FirebaseMessaging: 7b5d8033e183ab59eb5b852a53201559e976d366
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_fgbg: 31c0d1140a131daea2d342121808f6aa0dcd879d
   flutter_inappwebview_ios: 97215cf7d4677db55df76782dbd2930c5e1c1ea0
@@ -326,9 +327,9 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
   image_cropper: a3291c624a953049bc6a02e1f8c8ceb162a24b25
   image_picker_ios: c560581cceedb403a6ff17f2f816d7fea1421fc1
-  integration_test: ce0a3ffa1de96d1a89ca0ac26fca7ea18a749ef4
+  integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
-  local_auth_darwin: 4d56c90c2683319835a61274b57620df9c4520ab
+  local_auth_darwin: 66e40372f1c29f383a314c738c7446e2f7fdadc3
   MLImage: 1824212150da33ef225fbd3dc49f184cf611046c
   MLKitBarcodeScanning: 10ca0845a6d15f2f6e911f682a1998b68b973e8b
   MLKitCommon: afec63980417d29ffbb4790529a1b0a2291699e1

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/lib/handlers/check_version_handler.dart
+++ b/lib/handlers/check_version_handler.dart
@@ -14,7 +14,7 @@ void checkVersionDialog(
   final texts = context.texts();
 
   userProfileBloc.checkVersion().catchError((err) {
-    if (err.toString().contains('bad version')) {
+    if (err.toString().contains('bad version') && context.mounted) {
       showFlushbar(
         context,
         buttonText: texts.handler_check_version_action_update,

--- a/lib/handlers/connectivity_handler.dart
+++ b/lib/handlers/connectivity_handler.dart
@@ -109,14 +109,20 @@ class ConnectivityHandler extends Handler {
                 context.read<ConnectivityBloc>().setIsConnecting(true);
                 Future.delayed(
                   const Duration(seconds: 1),
-                  () => context
-                      .read<ConnectivityBloc>()
-                      .checkConnectivity()
-                      .whenComplete(() => context.read<ConnectivityBloc>().setIsConnecting(false))
-                      .onError((error, stackTrace) {
-                    context.read<ConnectivityBloc>().setIsConnecting(false);
-                    throw error.toString();
-                  }),
+                  () {
+                    if (context.mounted) {
+                      context.read<ConnectivityBloc>().checkConnectivity().whenComplete(() {
+                        if (context.mounted) {
+                          context.read<ConnectivityBloc>().setIsConnecting(false);
+                        }
+                      }).onError((error, stackTrace) {
+                        if (context.mounted) {
+                          context.read<ConnectivityBloc>().setIsConnecting(false);
+                        }
+                        throw error.toString();
+                      });
+                    }
+                  },
                 );
               },
               child: Text(

--- a/lib/handlers/health_check_handler.dart
+++ b/lib/handlers/health_check_handler.dart
@@ -39,30 +39,32 @@ class HealthCheckHandler extends Handler {
           _log.info("Flushbar already shown");
           return;
         }
-        _log.info("Showing flushbar for: $event");
-        _flushbar = showFlushbar(
-          context,
-          isDismissible: false,
-          showMainButton: true,
-          position: FlushbarPosition.TOP,
-          duration: Duration.zero,
-          message: event == HealthCheckStatus.Maintenance
-              ? texts.handler_check_version_error_upgrading_servers
-              : texts.handler_health_check_service_disruption,
-          buttonText: texts.handler_health_check_action_retry,
-          onDismiss: () {
-            _flushbar = null;
-            bloc.checkStatus();
-            return true;
-          },
-          icon: SvgPicture.asset(
-            "src/icon/warning.svg",
-            colorFilter: ColorFilter.mode(
-              themeData.colorScheme.error,
-              BlendMode.srcATop,
+        if (context.mounted) {
+          _log.info("Showing flushbar for: $event");
+          _flushbar = showFlushbar(
+            context,
+            isDismissible: false,
+            showMainButton: true,
+            position: FlushbarPosition.TOP,
+            duration: Duration.zero,
+            message: event == HealthCheckStatus.Maintenance
+                ? texts.handler_check_version_error_upgrading_servers
+                : texts.handler_health_check_service_disruption,
+            buttonText: texts.handler_health_check_action_retry,
+            onDismiss: () {
+              _flushbar = null;
+              bloc.checkStatus();
+              return true;
+            },
+            icon: SvgPicture.asset(
+              "src/icon/warning.svg",
+              colorFilter: ColorFilter.mode(
+                themeData.colorScheme.error,
+                BlendMode.srcATop,
+              ),
             ),
-          ),
-        );
+          );
+        }
       } else {
         _flushbar?.dismiss();
         _flushbar = null;

--- a/lib/handlers/input_handler.dart
+++ b/lib/handlers/input_handler.dart
@@ -78,7 +78,7 @@ class InputHandler extends Handler {
           _setLoading(false);
           if (error != null) {
             final context = contextProvider?.getBuildContext();
-            if (context != null) {
+            if (context != null && context.mounted) {
               showFlushbar(context, message: extractExceptionMessage(error, context.texts()));
             } else {
               _log.info("Skipping handling of error: $error because context is null");

--- a/lib/routes/buy_bitcoin/moonpay/moonpay_swap_in_progress.dart
+++ b/lib/routes/buy_bitcoin/moonpay/moonpay_swap_in_progress.dart
@@ -41,7 +41,9 @@ class MoonpaySwapInProgress extends StatelessWidget {
                 Navigator.of(context).pop();
               } else {
                 context.read<MoonPayBloc>().makeExplorerUrl(state.address).then((url) {
-                  launchLinkOnExternalBrowser(context, linkAddress: url);
+                  if (context.mounted) {
+                    launchLinkOnExternalBrowser(context, linkAddress: url);
+                  }
                 });
               }
             },

--- a/lib/routes/create_invoice/qr_code_dialog.dart
+++ b/lib/routes/create_invoice/qr_code_dialog.dart
@@ -70,7 +70,9 @@ class QrCodeDialogState extends State<QrCodeDialog> with SingleTickerProviderSta
         });
       }).catchError((e) {
         _log.warning("Failed to track payment", e);
-        showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        if (mounted) {
+          showFlushbar(context, message: extractExceptionMessage(e, context.texts()));
+        }
         onFinish(false);
       });
     }

--- a/lib/routes/create_invoice/widgets/successful_payment.dart
+++ b/lib/routes/create_invoice/widgets/successful_payment.dart
@@ -30,7 +30,11 @@ class SuccessfulPaymentRouteState extends State<SuccessfulPaymentRoute> with Wid
           builder: (context) => SuccessfulPaymentDialog(
             onPrint: widget.onPrint,
           ),
-        ).whenComplete(() => Navigator.of(context).pop());
+        ).whenComplete(() {
+          if (mounted) {
+            Navigator.of(context).pop();
+          }
+        });
       });
     }
   }

--- a/lib/routes/home/home_page.dart
+++ b/lib/routes/home/home_page.dart
@@ -77,7 +77,7 @@ class HomeState extends State<Home> with AutoLockMixin, HandlerContextProvider {
 
     return PopScope(
       canPop: false,
-      onPopInvoked: (bool didPop) async {
+      onPopInvokedWithResult: (bool didPop, _) async {
         if (didPop) {
           return;
         }

--- a/lib/routes/home/widgets/app_bar/account_required_actions.dart
+++ b/lib/routes/home/widgets/app_bar/account_required_actions.dart
@@ -61,12 +61,16 @@ class AccountRequiredActionsIndicator extends StatelessWidget {
             WarningAction(
               () async {
                 await ServiceInjector().keychain.read(CredentialsManager.accountMnemonic).then(
-                      (accountMnemonic) => Navigator.pushNamed(
+                  (accountMnemonic) {
+                    if (context.mounted) {
+                      return Navigator.pushNamed(
                         context,
                         '/mnemonics',
                         arguments: accountMnemonic,
-                      ),
-                    );
+                      );
+                    }
+                  },
+                );
               },
             ),
           );

--- a/lib/routes/home/widgets/drawer/home_drawer.dart
+++ b/lib/routes/home/widgets/drawer/home_drawer.dart
@@ -94,7 +94,7 @@ class HomeDrawerState extends State<HomeDrawer> {
           });
         } else {
           Navigator.of(context).pushNamed(screenName).then((message) {
-            if (message != null && message is String) {
+            if (message != null && message is String && context.mounted) {
               showFlushbar(context, message: message);
             }
           });

--- a/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
+++ b/lib/routes/home/widgets/payments_filter/payments_filter_calendar.dart
@@ -47,13 +47,15 @@ class PaymentsFilterCalendar extends StatelessWidget {
                     context: context,
                     builder: (_) => CalendarDialog(firstDate!),
                   ).then((result) {
-                    final accountBloc = context.read<AccountBloc>();
-                    if (result != null) {
-                      accountBloc.changePaymentFilter(
-                        filters: filter,
-                        fromTimestamp: result[0].millisecondsSinceEpoch,
-                        toTimestamp: result[1].millisecondsSinceEpoch,
-                      );
+                    if (context.mounted) {
+                      final accountBloc = context.read<AccountBloc>();
+                      if (result != null) {
+                        accountBloc.changePaymentFilter(
+                          filters: filter,
+                          fromTimestamp: result[0].millisecondsSinceEpoch,
+                          toTimestamp: result[1].millisecondsSinceEpoch,
+                        );
+                      }
                     }
                   })
                 : ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/routes/home/widgets/qr_action_button.dart
+++ b/lib/routes/home/widgets/qr_action_button.dart
@@ -53,7 +53,7 @@ class QrActionButton extends StatelessWidget {
       (barcode) {
         _log.info("Scanned string: '$barcode'");
         if (barcode == null) return;
-        if (barcode.isEmpty) {
+        if (barcode.isEmpty && context.mounted) {
           showFlushbar(
             context,
             message: texts.qr_action_button_error_code_not_detected,

--- a/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
+++ b/lib/routes/initial_walkthrough/mnemonics/enter_mnemonics_page.dart
@@ -26,7 +26,7 @@ class EnterMnemonicsPageState extends State<EnterMnemonicsPage> {
 
     return PopScope(
       canPop: _currentPage == 1,
-      onPopInvoked: (_) async {
+      onPopInvokedWithResult: (_, __) async {
         if (_currentPage > 1) {
           FocusScope.of(context).requestFocus(FocusNode());
           setState(() {

--- a/lib/routes/lnurl/auth/lnurl_auth_handler.dart
+++ b/lib/routes/lnurl/auth/lnurl_auth_handler.dart
@@ -17,7 +17,7 @@ Future<LNURLPageResult?> handleAuthRequest(
 ) async {
   return promptAreYouSure(context, null, LoginText(domain: reqData.domain)).then(
     (permitted) async {
-      if (permitted == true) {
+      if (permitted == true && context.mounted) {
         final texts = context.texts();
         final navigator = Navigator.of(context);
         final loaderRoute = createLoaderRoute(context);

--- a/lib/routes/security/auto_lock_mixin.dart
+++ b/lib/routes/security/auto_lock_mixin.dart
@@ -10,12 +10,18 @@ mixin AutoLockMixin<T extends StatefulWidget> on State<T> {
   void initState() {
     super.initState();
     final securityBloc = context.read<SecurityBloc>();
-    securityBloc.stream.distinct().where((state) => state.lockState == security.LockState.locked).listen((_) {
-      Navigator.of(context, rootNavigator: true).push(FadeInRoute(
-        builder: (_) => const LockScreen(
-          authorizedAction: AuthorizedAction.popPage,
-        ),
-      ));
-    });
+    securityBloc.stream.distinct().where((state) => state.lockState == security.LockState.locked).listen(
+      (_) {
+        if (mounted) {
+          Navigator.of(context, rootNavigator: true).push(
+            FadeInRoute(
+              builder: (_) => const LockScreen(
+                authorizedAction: AuthorizedAction.popPage,
+              ),
+            ),
+          );
+        }
+      },
+    );
   }
 }

--- a/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
+++ b/lib/routes/security/widget/mnemonics/security_mnemonics_management.dart
@@ -40,22 +40,24 @@ class SecurityMnemonicsManagement extends StatelessWidget {
           onTap: () async {
             await ServiceInjector().keychain.read(CredentialsManager.accountMnemonic).then(
               (accountMnemonic) {
-                if (account.verificationStatus == VerificationStatus.UNVERIFIED) {
-                  Navigator.pushNamed(
-                    context,
-                    '/mnemonics',
-                    arguments: accountMnemonic,
-                  );
-                } else {
-                  Navigator.push(
-                    context,
-                    FadeInRoute(
-                      builder: (context) => MnemonicsPage(
-                        mnemonics: accountMnemonic!,
-                        viewMode: true,
+                if (context.mounted) {
+                  if (account.verificationStatus == VerificationStatus.UNVERIFIED) {
+                    Navigator.pushNamed(
+                      context,
+                      '/mnemonics',
+                      arguments: accountMnemonic,
+                    );
+                  } else {
+                    Navigator.push(
+                      context,
+                      FadeInRoute(
+                        builder: (context) => MnemonicsPage(
+                          mnemonics: accountMnemonic!,
+                          viewMode: true,
+                        ),
                       ),
-                    ),
-                  );
+                    );
+                  }
                 }
               },
             );

--- a/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
+++ b/lib/routes/spontaneous_payment/spontaneous_payment_page.dart
@@ -54,7 +54,11 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
     _doneAction = KeyboardDoneAction(focusNodes: <FocusNode>[_amountFocusNode]);
     Future.delayed(
       const Duration(milliseconds: 200),
-      () => FocusScope.of(context).requestFocus(_amountFocusNode),
+      () {
+        if (mounted) {
+          FocusScope.of(context).requestFocus(_amountFocusNode);
+        }
+      },
     );
     super.initState();
   }
@@ -198,7 +202,7 @@ class SpontaneousPaymentPageState extends State<SpontaneousPaymentPage> {
       cancelText: texts.spontaneous_payment_action_cancel,
     ).then(
       (ok) async {
-        if (ok == true) {
+        if (ok == true && mounted) {
           Future sendFuture = Future.value(null);
           showDialog(
             useRootNavigator: false,

--- a/lib/routes/withdraw/redeem_onchain_funds/confirmation_page/redeem_onchain_funds_confirmation.dart
+++ b/lib/routes/withdraw/redeem_onchain_funds/confirmation_page/redeem_onchain_funds_confirmation.dart
@@ -87,16 +87,20 @@ class _RedeemOnchainConfirmationPageState extends State<RedeemOnchainConfirmatio
   void _fetchRedeemOnchainFeeOptions() {
     final redeemOnchainFundsBloc = context.read<RedeemOnchainFundsBloc>();
     _fetchFeeOptionsFuture = redeemOnchainFundsBloc.fetchRedeemOnchainFeeOptions(toAddress: widget.toAddress);
-    _fetchFeeOptionsFuture.then((feeOptions) {
-      final account = context.read<AccountBloc>().state;
-      setState(() {
-        affordableFees = feeOptions
-            .where((f) =>
-                f.isAffordable(walletBalanceSat: account.walletBalanceSat, amountSat: widget.amountSat))
-            .toList();
-        selectedFeeIndex = (affordableFees.length / 2).floor();
-      });
-    });
+    _fetchFeeOptionsFuture.then(
+      (feeOptions) {
+        if (mounted) {
+          final account = context.read<AccountBloc>().state;
+          setState(() {
+            affordableFees = feeOptions
+                .where((f) =>
+                    f.isAffordable(walletBalanceSat: account.walletBalanceSat, amountSat: widget.amountSat))
+                .toList();
+            selectedFeeIndex = (affordableFees.length / 2).floor();
+          });
+        }
+      },
+    );
   }
 }
 

--- a/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
+++ b/lib/routes/withdraw/reverse_swap/confirmation_page/reverse_swap_confirmation_page.dart
@@ -89,15 +89,19 @@ class _ReverseSwapConfirmationPageState extends State<ReverseSwapConfirmationPag
       amountSat: widget.amountSat,
       amountType: widget.isMaxValue ? SwapAmountType.Send : SwapAmountType.Receive,
     );
-    _fetchFeeOptionsFuture.then((feeOptions) {
-      final account = context.read<AccountBloc>().state;
-      setState(() {
-        affordableFees = feeOptions
-            .where((f) => f.isAffordable(balanceSat: account.balanceSat, amountSat: widget.amountSat))
-            .toList();
-        selectedFeeIndex = (affordableFees.length / 2).floor();
-      });
-    });
+    _fetchFeeOptionsFuture.then(
+      (feeOptions) {
+        if (mounted) {
+          final account = context.read<AccountBloc>().state;
+          setState(() {
+            affordableFees = feeOptions
+                .where((f) => f.isAffordable(balanceSat: account.balanceSat, amountSat: widget.amountSat))
+                .toList();
+            selectedFeeIndex = (affordableFees.length / 2).floor();
+          });
+        }
+      },
+    );
   }
 }
 

--- a/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
+++ b/lib/routes/withdraw/widgets/bitcoin_address_text_form_field.dart
@@ -36,7 +36,7 @@ class BitcoinAddressTextFormField extends TextFormField {
                     final address = BitcoinAddressInfo.fromScannedString(barcode).address;
                     _log.info("BitcoinAddressInfoFromScannedString: '$address'");
                     if (address == null) return;
-                    if (address.isEmpty) {
+                    if (address.isEmpty && context.mounted) {
                       showFlushbar(
                         context,
                         message: context.texts().withdraw_funds_error_qr_code_not_detected,
@@ -44,7 +44,9 @@ class BitcoinAddressTextFormField extends TextFormField {
                       return;
                     }
                     controller.text = address;
-                    _onAddressChanged(context, validatorHolder, address);
+                    if (context.mounted) {
+                      _onAddressChanged(context, validatorHolder, address);
+                    }
                   },
                 );
               },

--- a/lib/widgets/amount_form_field/currency_converter_dialog.dart
+++ b/lib/widgets/amount_form_field/currency_converter_dialog.dart
@@ -58,19 +58,21 @@ class CurrencyConverterDialogState extends State<CurrencyConverterDialog>
       }
     });
 
-    widget._currencyBloc.fetchExchangeRates().catchError((value) {
-      final texts = context.texts();
-      if (mounted) {
-        setState(() {
-          Navigator.pop(context);
-          showFlushbar(
-            context,
-            message: texts.currency_converter_dialog_error_exchange_rate,
-          );
-        });
-      }
-      return <String, Rate>{};
-    });
+    widget._currencyBloc.fetchExchangeRates().catchError(
+      (value) {
+        if (mounted) {
+          final texts = context.texts();
+          setState(() {
+            Navigator.pop(context);
+            showFlushbar(
+              context,
+              message: texts.currency_converter_dialog_error_exchange_rate,
+            );
+          });
+        }
+        return <String, Rate>{};
+      },
+    );
   }
 
   @override

--- a/lib/widgets/payment_dialogs/payment_request_dialog.dart
+++ b/lib/widgets/payment_dialogs/payment_request_dialog.dart
@@ -55,7 +55,7 @@ class PaymentRequestDialogState extends State<PaymentRequestDialog> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: false,
-      onPopInvoked: (_) async {
+      onPopInvokedWithResult: (_, __) async {
         if (_state == PaymentRequestState.PROCESSING_PAYMENT) {
           return;
         } else {

--- a/lib/widgets/payment_dialogs/processing_payment_dialog.dart
+++ b/lib/widgets/payment_dialogs/processing_payment_dialog.dart
@@ -109,7 +109,9 @@ class ProcessingPaymentDialogState extends State<ProcessingPaymentDialog>
         if (_currentRoute != null && _currentRoute!.isActive) {
           navigator.removeRoute(_currentRoute!);
         }
-        showFlushbar(context, message: extractExceptionMessage(err, texts));
+        if (mounted) {
+          showFlushbar(context, message: extractExceptionMessage(err, texts));
+        }
       }
     });
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,26 +5,31 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.dev"
     source: hosted
-    version: "67.0.0"
+    version: "72.0.0"
   _flutterfire_internals:
     dependency: transitive
     description:
       name: _flutterfire_internals
-      sha256: b46f62516902afb04befa4b30eb6a12ac1f58ca8cb25fb9d632407259555dd3d
+      sha256: b1595874fbc8f7a50da90f5d8f327bb0bfd6a95dc906c390efe991540c3b54aa
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.39"
+    version: "1.3.40"
+  _macros:
+    dependency: transitive
+    description: dart
+    source: sdk
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.dev"
     source: hosted
-    version: "6.4.1"
+    version: "6.7.0"
   another_flushbar:
     dependency: "direct main"
     description:
@@ -103,7 +108,7 @@ packages:
       path: "../breez-sdk/libs/sdk-flutter"
       relative: true
     source: path
-    version: "0.5.1-rc3"
+    version: "0.5.2"
   breez_translations:
     dependency: "direct main"
     description:
@@ -157,18 +162,18 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "644dc98a0f179b872f612d3eb627924b578897c629788e858157fa5e704ca0c7"
+      sha256: dd09dd4e2b078992f42aac7f1a622f01882a8492fef08486b27ddde929c19f04
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.11"
+    version: "2.4.12"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      sha256: e3c79f69a64bdfcd8a776a3c28db4eb6e3fb5356d013ae5eb2e52007706d5dbe
+      sha256: f8126682b87a7282a339b871298cc12009cb67109cfa1614d6436fb0289193e0
       url: "https://pub.dev"
     source: hosted
-    version: "7.3.1"
+    version: "7.3.2"
   built_collection:
     dependency: transitive
     description:
@@ -237,18 +242,18 @@ packages:
     dependency: "direct main"
     description:
       name: connectivity_plus
-      sha256: db7a4e143dc72cc3cb2044ef9b052a7ebfe729513e6a82943bc3526f784365b8
+      sha256: "3e7d1d9dbae40ae82cbe6c23c518f0c4ffe32764ee9749b9a99d32cbac8734f6"
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.4"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
       name: connectivity_plus_platform_interface
-      sha256: b6a56efe1e6675be240de39107281d4034b64ac23438026355b4234042a35adb
+      sha256: "42657c1715d48b167930d5f34d00222ac100475f73d10162ddf43e714932f204"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   convert:
     dependency: transitive
     description:
@@ -261,18 +266,18 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "3945034e86ea203af7a056d98e98e42a5518fff200d6e8e6647e1886b07e936e"
+      sha256: "576aaab8b1abdd452e0f656c3e73da9ead9d7880e15bdc494189d9c1a1baf0db"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.0"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
-      sha256: "55d7b444feb71301ef6b8838dbc1ae02e63dd48c8773f3810ff53bb1e2945b32"
+      sha256: "7caf6a750a0c04effbb52a676dce9a4a592e10ad35c34d6d2d0e4811160d5670"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.4+1"
+    version: "0.3.4+2"
   crypto:
     dependency: transitive
     description:
@@ -309,18 +314,18 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: eead12d1a1ed83d8283ab4c2f3fca23ac4082f29f25f29dff0f758f57d06ec91
+      sha256: "93429694c9253d2871b3af80cf11b3cbb5c65660d402ed7bf69854ce4a089f82"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "10.1.1"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
       name: device_info_plus_platform_interface
-      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      sha256: "282d3cf731045a2feb66abfe61bbc40870ae50a3ed10a4d3d217556c35c8c2ba"
       url: "https://pub.dev"
     source: hosted
-    version: "7.0.0"
+    version: "7.0.1"
   drag_and_drop_lists:
     dependency: "direct main"
     description:
@@ -406,74 +411,74 @@ packages:
     dependency: transitive
     description:
       name: file_selector_windows
-      sha256: d3547240c20cabf205c7c7f01a50ecdbc413755814d6677f3cb366f04abcead0
+      sha256: "2ad726953f6e8affbc4df8dc78b77c3b4a060967a291e528ef72ae846c60fb69"
       url: "https://pub.dev"
     source: hosted
-    version: "0.9.3+1"
+    version: "0.9.3+2"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
-      sha256: "5159984ce9b70727473eb388394650677c02c925aaa6c9439905e1f30966a4d5"
+      sha256: "3187f4f8e49968573fd7403011dca67ba95aae419bc0d8131500fae160d94f92"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.0"
+    version: "3.3.0"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: "1003a5a03a61fc9a22ef49f37cbcb9e46c86313a7b2e7029b9390cf8c6fc32cb"
+      sha256: "3c3a1e92d6f4916c32deea79c4a7587aa0e9dbbe5889c7a16afcf005a485ee02"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.0"
+    version: "5.2.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
-      sha256: "23509cb3cddfb3c910c143279ac3f07f06d3120f7d835e4a5d4b42558e978712"
+      sha256: e8d1e22de72cb21cdcfc5eed7acddab3e99cd83f3b317f54f7a96c32f25fd11e
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.3"
+    version: "2.17.4"
   firebase_dynamic_links:
     dependency: "direct main"
     description:
       name: firebase_dynamic_links
-      sha256: beed25d57e0240728952c0ff540dde214b11b323ca09cb1ae5f71f30e5efc3b3
+      sha256: f094b1f90951981328abdb39c4140c0b0590c8d56fe23a9ad987b654a33000d0
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.3"
+    version: "6.0.4"
   firebase_dynamic_links_platform_interface:
     dependency: transitive
     description:
       name: firebase_dynamic_links_platform_interface
-      sha256: bb949552fcf65e8ed810b69327eb0dcb174b7d69e2b71f8856d27af50c89ddc7
+      sha256: a9af616ec8e33c739b12153c420d16d6987532e13c8d764a0f20a64031bb93f1
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.6+39"
+    version: "0.2.6+40"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
-      sha256: "156c4292aa63a6a7d508c68ded984cb38730d2823c3265e573cb1e94983e2025"
+      sha256: "1b0a4f9ecbaf9007771bac152afad738ddfacc4b8431a7591c00829480d99553"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.3"
+    version: "15.0.4"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
-      sha256: "10408c5ca242b7fc632dd5eab4caf8fdf18ebe88db6052980fa71a18d88bd200"
+      sha256: c5a6443e66ae064fe186901d740ee7ce648ca2a6fd0484b8c5e963849ac0fc28
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.41"
+    version: "4.5.42"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
-      sha256: c7a756e3750679407948de665735e69a368cb902940466e5d68a00ea7aba1aaa
+      sha256: "232ef63b986467ae5b5577a09c2502b26e2e2aebab5b85e6c966a5ca9b038b89"
       url: "https://pub.dev"
     source: hosted
-    version: "3.8.11"
+    version: "3.8.12"
   fixnum:
     dependency: transitive
     description:
@@ -630,10 +635,10 @@ packages:
     dependency: transitive
     description:
       name: flutter_plugin_android_lifecycle
-      sha256: c6b0b4c05c458e1c01ad9bcc14041dd7b1f6783d487be4386f793f47a8a4d03e
+      sha256: "9d98bd47ef9d34e803d438f17fd32b116d31009f534a6fa5ce3a1167f189a6de"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.20"
+    version: "2.0.21"
   flutter_rust_bridge:
     dependency: "direct main"
     description:
@@ -766,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   hex:
     dependency: "direct main"
     description:
@@ -870,18 +875,18 @@ packages:
     dependency: transitive
     description:
       name: image_picker_android
-      sha256: ff39a10ab4f48f4ac70776d0494a97bf073cd2570892cd46bc8a5cac162c25db
+      sha256: c0e72ecd170b00a5590bb71238d57dc8ad22ee14c60c6b0d1a4e05cafbc5db4b
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.12+4"
+    version: "0.8.12+11"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
-      sha256: "5d6eb13048cd47b60dbf1a5495424dea226c5faf3950e20bf8120a58efb5b5f3"
+      sha256: "65d94623e15372c5c51bebbcb820848d7bcb323836e12dfdba60b5d3a8b39e50"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.4"
+    version: "3.0.5"
   image_picker_ios:
     dependency: transitive
     description:
@@ -971,18 +976,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -1003,26 +1008,26 @@ packages:
     dependency: "direct main"
     description:
       name: local_auth
-      sha256: "280421b416b32de31405b0a25c3bd42dfcef2538dfbb20c03019e02a5ed55ed0"
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   local_auth_android:
     dependency: "direct main"
     description:
       name: local_auth_android
-      sha256: "33fcebe9c3cf1bb0033bc85caed354c1e75ff7f7670918a571bd3152a2b65bf4"
+      sha256: e99c44ca0bce08f26f25e2a2e07d3b443d69986e1c3acf67c1449f7d847e3625
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.42"
+    version: "1.0.43"
   local_auth_darwin:
     dependency: "direct main"
     description:
       name: local_auth_darwin
-      sha256: e424ebf90d5233452be146d4a7da4bcd7a70278b67791592f3fde1bda8eef9e2
+      sha256: "7ba5738c874ca2b910d72385d00d2bebad9d4e807612936cf5e32bc01a048c71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   local_auth_platform_interface:
     dependency: transitive
     description:
@@ -1035,10 +1040,10 @@ packages:
     dependency: transitive
     description:
       name: local_auth_windows
-      sha256: "505ba3367ca781efb1c50d3132e44a2446bccc4163427bc203b9b4d8994d97ea"
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.10"
+    version: "1.0.11"
   logging:
     dependency: "direct main"
     description:
@@ -1047,6 +1052,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  macros:
+    dependency: transitive
+    description:
+      name: macros
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -1059,18 +1072,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -1131,18 +1144,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: b93d8b4d624b4ea19b0a5a208b2d6eff06004bc3ce74c06040b120eeadd00ce0
+      sha256: "4de6c36df77ffbcef0a5aefe04669d33f2d18397fea228277b852a2d4e58e860"
       url: "https://pub.dev"
     source: hosted
-    version: "8.0.0"
+    version: "8.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: f49918f3433a3146047372f9d4f1f847511f2acd5cd030e1f44fe5a50036b70e
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   path:
     dependency: "direct main"
     description:
@@ -1163,18 +1176,18 @@ packages:
     dependency: "direct main"
     description:
       name: path_provider
-      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      sha256: fec0d61223fba3154d87759e3cc27fe2c8dc498f6386c6d6fc80d1afdd1bf378
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: "30c5aa827a6ae95ce2853cdc5fe3971daaac00f6f081c419c013f7f57bff2f5e"
+      sha256: "490539678396d4c3c0b06efdaab75ae60675c3e0c66f72bc04c2e2c1e0e2abeb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.9"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -1315,18 +1328,18 @@ packages:
     dependency: "direct main"
     description:
       name: share_plus
-      sha256: ef3489a969683c4f3d0239010cc8b7a2a46543a8d139e111c06c558875083544
+      sha256: "59dfd53f497340a0c3a81909b220cfdb9b8973a91055c4e5ab9b9b9ad7c513c0"
       url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.0.0"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
-      sha256: "0f9e4418835d1b2c3ae78fdb918251959106cefdbc4dd43526e182f80e82f6d4"
+      sha256: "6ababf341050edff57da8b6990f11f4e99eaba837865e2e6defe16d039619db5"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.0.0"
   shared_preference_app_group:
     dependency: "direct main"
     description:
@@ -1339,58 +1352,58 @@ packages:
     dependency: "direct main"
     description:
       name: shared_preferences
-      sha256: d3bbe5553a986e83980916ded2f0b435ef2e1893dfaa29d5a7a790d0eca12180
+      sha256: c272f9cabca5a81adc9b0894381e9c1def363e980f960fa903c604c471b22f68
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.1"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
-      sha256: "93d0ec9dd902d85f326068e6a899487d1f65ffcd5798721a95330b26c8131577"
+      sha256: "041be4d9d2dc6079cf342bc8b761b03787e3b71192d658220a56cac9c04a0294"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.3"
+    version: "2.3.0"
   shared_preferences_foundation:
     dependency: transitive
     description:
       name: shared_preferences_foundation
-      sha256: "0a8a893bf4fd1152f93fec03a415d11c27c74454d96e2318a7ac38dd18683ab7"
+      sha256: "671e7a931f55a08aa45be2a13fe7247f2a41237897df434b30d2012388191833"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
-      sha256: "9f2cbcf46d4270ea8be39fa156d86379077c8a5228d9dfdb1164ae0bb93f1faa"
+      sha256: "2ba0510d3017f91655b7543e9ee46d48619de2a2af38e5c790423f7007c7ccc1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
       name: shared_preferences_platform_interface
-      sha256: "22e2ecac9419b4246d7c22bfbbda589e3acf5c0351137d87dd2939d984d37c3b"
+      sha256: "57cbf196c486bc2cf1f02b85784932c6094376284b3ad5779d1b1c6c6a816b80"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.1"
   shared_preferences_web:
     dependency: transitive
     description:
       name: shared_preferences_web
-      sha256: "9aee1089b36bd2aafe06582b7d7817fd317ef05fc30e6ba14bff247d0933042a"
+      sha256: "59dc807b94d29d52ddbb1b3c0d3b9d0a67fc535a64e62a5542c8db0513fcb6c2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.0"
+    version: "2.4.1"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
-      sha256: "841ad54f3c8381c480d0c9b508b89a34036f512482c407e6df7a9c4aa2ef8f59"
+      sha256: "398084b47b7f92110683cac45c6dc4aae853db47e470e5ddcd52cab7f7196ab2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.2"
+    version: "2.4.0"
   shelf:
     dependency: transitive
     description:
@@ -1496,10 +1509,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "6d17989c0b06a5870b2190d391925186f944cb943e5262d0d3f778fcfca3bc6e"
+      sha256: fde692580bee3379374af1f624eb3e113ab2865ecb161dbe2d8ac2de9735dbdb
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.5"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1576,10 +1589,10 @@ packages:
     dependency: "direct overridden"
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.3"
   test_core:
     dependency: transitive
     description:
@@ -1664,10 +1677,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: ceb2625f0c24ade6ef6778d1de0b2e44f2db71fded235eb52295247feba8c5cf
+      sha256: "94d8ad05f44c6d4e2ffe5567ab4d741b82d62e3c8e288cc1fcea45965edf47c9"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.3"
+    version: "6.3.8"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -1704,18 +1717,18 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "8d9e750d8c9338601e709cd0885f95825086bd8b642547f26bda435aade95d8a"
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.3"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
-      sha256: ecf9725510600aa2bb6d7ddabe16357691b6d2805f66216a97d1b881e21beff7
+      sha256: "49c10f879746271804767cb45551ec5592cdab00ee105c06dddde1a98f73b185"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.2"
   uuid:
     dependency: transitive
     description:
@@ -1808,18 +1821,18 @@ packages:
     dependency: transitive
     description:
       name: win32
-      sha256: a79dbe579cb51ecd6d30b17e0cae4e0ea15e2c0e66f69ad4198f22a6789e94f4
+      sha256: "015002c060f1ae9f41a818f2d5640389cc05283e368be19dc8d77cecb43c40c9"
       url: "https://pub.dev"
     source: hosted
-    version: "5.5.1"
+    version: "5.5.3"
   win32_registry:
     dependency: transitive
     description:
       name: win32_registry
-      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
+      sha256: "723b7f851e5724c55409bb3d5a32b203b3afe8587eaf5dafb93a5fed8ecda0d6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.3"
+    version: "1.1.4"
   xdg_directories:
     dependency: transitive
     description:
@@ -1845,5 +1858,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,8 @@ publish_to: "none"
 version: 1.1.0
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: ">=3.19.0"
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:
@@ -28,8 +28,8 @@ dependencies:
       ref: a564088448149e9c28b4a2eb82fa0a3536698d24
   clipboard_watcher: ^0.2.1
   csv: ^6.0.0
-  connectivity_plus: ^6.0.3
-  device_info_plus: ^10.1.0
+  connectivity_plus: ^6.0.4
+  device_info_plus: ^10.1.1
   drag_and_drop_lists:
     git:
       url: https://github.com/breez/DragAndDropLists
@@ -39,11 +39,11 @@ dependencies:
   extended_image: ^8.2.1
   ffi: ^2.1.2
   # Doesn't support: Linux Windows
-  firebase_core: ^3.2.0
+  firebase_core: ^3.3.0
   # Doesn't support: Linux Mac Windows
-  firebase_dynamic_links: ^6.0.3
+  firebase_dynamic_links: ^6.0.4
   # Doesn't support: Linux Windows
-  firebase_messaging: ^15.0.3
+  firebase_messaging: ^15.0.4
   flutter_bloc: ^8.1.6
   # Doesn't support: Linux Mac Windows
   flutter_fgbg:
@@ -70,22 +70,22 @@ dependencies:
   ini: ^2.1.0
   intl: ^0.19.0
   # Doesn't support: Linux Mac
-  local_auth: ^2.2.0
-  local_auth_android: ^1.0.42
-  local_auth_darwin: ^1.3.1
+  local_auth: ^2.3.0
+  local_auth_android: ^1.0.43
+  local_auth_darwin: ^1.4.0
   logging: ^1.2.0
   mockito: ^5.4.4
   # Doesn't support: Linux Windows
   mobile_scanner: ^5.1.1
-  package_info_plus: ^8.0.0
+  package_info_plus: ^8.0.1
   path: ^1.9.0
-  path_provider: ^2.1.3
+  path_provider: ^2.1.4
   path_provider_platform_interface: ^2.1.2
   plugin_platform_interface: ^2.1.8
   qr_flutter: ^4.1.0
   rxdart: ^0.28.0
-  share_plus: ^9.0.0
-  shared_preferences: ^2.2.3
+  share_plus: ^10.0.0
+  shared_preferences: ^2.3.1
   shared_preference_app_group: ^1.1.1 # iOS Notification Service extension requirement to access shared preferences
   simple_animations: ^5.0.2
   sqflite_common_ffi: ^2.3.3
@@ -103,12 +103,12 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  build_runner: ^2.4.11
+  build_runner: ^2.4.12
   flutter_lints: ^4.0.0
   test: ^1.25.8
 
 dependency_overrides:
-  test_api: <0.7.1 # test_api >=0.7.1 is incompatible with flutter_test from the flutter SDK
+  test_api: ^0.7.3
   # Comment-out to work with breez-sdk from git repository
   breez_sdk:
     path: ../breez-sdk/libs/sdk-flutter


### PR DESCRIPTION
This PR addresses [breaking changes](https://docs.flutter.dev/release/breaking-changes#released-in-flutter-3-24) introduced in Flutter 3.24 & not so well documented parts; re: resource linking failures on `android:lStar` which requires `Kotlin` upgrade.

More can be found here: [Flutter 3.24 release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.24.0).

### Changelist
- Update SDK ranges
  - Dart >= `3.5.0`
  - Flutter >= `3.24.0`
- Update dependencies to latest version
- Update Kotlin to latest, `2.0.10`
  - @@ Make flutter tool enforce >= kotlin 1.7.0, Gradle 7.0.2, and AGP 7.0.0, and Fix test failures blocking androidx upgrade
- Address linter warnings
  - Replace `onPopInvoked` with `onPopInvokedWithResult`
    - @@ add a new `PopScope.onPopWithResultInvoke` widget to replace `PopScope.onPopInvoke`
  - Addressed [use_build_context_synchronously](https://dart.dev/tools/linter-rules/use_build_context_synchronously) linter warnings
    - @@ Tweak to fix `context.mounted` in dialog_demo
- @@ [iOS] Migrate `@UIApplicationMain` attribute to `@main`