### PR TITLE
fix the swap-in refund sender amount

### DIFF
--- a/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_breakdown.dart
+++ b/lib/routes/withdraw/widgets/fee_chooser/widgets/fee_breakdown.dart
@@ -35,9 +35,7 @@ class FeeBreakdown extends StatelessWidget {
       child: Column(
         children: [
           SenderAmount(
-            amountSat: (feeOption is ReverseSwapFeeOption)
-                ? feeOption.pairInfo.senderAmountSat
-                : amountSat + feeOption.txFeeSat,
+            amountSat: (feeOption is ReverseSwapFeeOption) ? feeOption.pairInfo.senderAmountSat : amountSat,
           ),
           if (boltzServiceFeeSat != null) ...[
             BoltzServiceFee(boltzServiceFeeSat: boltzServiceFeeSat),


### PR DESCRIPTION
The tx fee for a swap-in should be deducted from the amount. The sender amount is `amountSat` here.